### PR TITLE
Support remote and error frames in ASCWriter.

### DIFF
--- a/can/CAN.py
+++ b/can/CAN.py
@@ -304,7 +304,6 @@ class ASCWriter(Listener):
         arb_id = "{:X}".format(msg.arbitration_id)
         if msg.id_type:
             arb_id = arb_id + "x"
-        dtype = "r" if msg.is_remote_frame else "d {}".format(msg.dlc)
         timestamp = msg.timestamp
         if timestamp >= self.started:
             timestamp -= self.started

--- a/can/CAN.py
+++ b/can/CAN.py
@@ -262,7 +262,7 @@ class SqliteWriter(BufferedReader):
 class ASCWriter(Listener):
     """Logs CAN data to an ASCII log file (.asc)"""
 
-    LOG_STRING = "{time: 9.4f} {channel}  {id:<15} Rx   d {dlc} {data}\n"
+    LOG_STRING = "{time: 9.4f} {channel}  {id:<15} Rx   {dtype} {data}\n"
     EVENT_STRING = "{time: 9.4f} {message}\n"
 
     def __init__(self, filename, channel=1):
@@ -283,18 +283,28 @@ class ASCWriter(Listener):
             self.log_file.close()
             self.log_file = None
 
-    def log_event(self, message):
+    def log_event(self, message, timestamp=None):
         """Add an arbitrary message to the log file."""
-        timestamp = time.time() - self.started
+        timestamp = (timestamp or time.time()) - self.started
         line = self.EVENT_STRING.format(time=timestamp, message=message)
         if self.log_file is not None:
             self.log_file.write(line)
 
     def on_message_received(self, msg):
-        data = ["{:02X}".format(byte) for byte in msg.data]
+        if msg.is_error_frame:
+            self.log_event("ErrorFrame", msg.timestamp)
+            return
+
+        if msg.is_remote_frame:
+            dtype = "r"
+            data = []
+        else:
+            dtype = "d {}".format(msg.dlc)
+            data = ["{:02X}".format(byte) for byte in msg.data]
         arb_id = "{:X}".format(msg.arbitration_id)
         if msg.id_type:
             arb_id = arb_id + "x"
+        dtype = "r" if msg.is_remote_frame else "d {}".format(msg.dlc)
         timestamp = msg.timestamp
         if timestamp >= self.started:
             timestamp -= self.started
@@ -302,7 +312,7 @@ class ASCWriter(Listener):
         line = self.LOG_STRING.format(time=timestamp,
                                       channel=self.channel,
                                       id=arb_id,
-                                      dlc=msg.dlc,
+                                      dtype=dtype,
                                       data=" ".join(data))
         if self.log_file is not None:
             self.log_file.write(line)

--- a/test/listener_test.py
+++ b/test/listener_test.py
@@ -119,8 +119,18 @@ class ListenerTest(unittest.TestCase):
                           arbitration_id=0x123,
                           data=[0xff, 0xff])
         a_listener(msg)
+        msg = can.Message(extended_id=True,
+                          timestamp=a_listener.started + 1.5,
+                          is_remote_frame=True,
+                          dlc=8,
+                          arbitration_id=0xabcdef)
+        a_listener(msg)
+        msg = can.Message(is_error_frame=True,
+                          timestamp=a_listener.started + 1.6,
+                          arbitration_id=0xabcdef)
+        a_listener(msg)
         a_listener.stop()
-        with open("test.asc") as f:
+        with open("test.asc", "r") as f:
             print("Output from ASCWriter:")
             print(f.read())
 


### PR DESCRIPTION
These weren't logged correctly before.

Looked at can-utils [log2asc.c](https://github.com/linux-can/can-utils/blob/master/log2asc.c) implementation.