### PR TITLE
Feature canplayer

### DIFF
--- a/bin/can_player.py
+++ b/bin/can_player.py
@@ -8,10 +8,9 @@ Similar to canplayer in the can-utils package.
 from __future__ import print_function
 import datetime
 import argparse
-import time
-import socket
 
 import can
+from CAN import LogReader, MessageSync
 
 if __name__ == "__main__":
 
@@ -35,7 +34,6 @@ if __name__ == "__main__":
                         fall back to reading from configuration files.''',
                         choices=can.interface.VALID_INTERFACES)
 
-
     parser.add_argument('--ignore-timestamps', dest='timestamps',
                         help='''Ignore timestamps (send all frames immediately with minimum gap between
     frames)''', action='store_false')
@@ -57,42 +55,18 @@ if __name__ == "__main__":
 
     bus = can.interface.Bus(results.channel, bustype=results.interface)
 
-    # TODO refactor all sqlite specifics out
-    def create_frame_from_db_tuple(frame_data):
-        ts, id, is_extended, is_remote, is_error, dlc, data = frame_data
-        return can.Message(
-            ts, is_remote, is_extended, is_error, id, dlc, data
-        )
+    player = LogReader(results.infile)
 
-    def iterate_all_messages(c):
-        for frame_data in c.execute("SELECT * FROM messages"):
-            yield create_frame_from_db_tuple(frame_data)
+    in_sync = MessageSync(player, timestamps=True, skip=results.skip)
 
 
-    import sqlite3
-    conn = sqlite3.connect(results.infile)
-    c = conn.cursor()
-    c.execute("SELECT ts FROM messages LIMIT 1")
-    recorded_start_time = c.fetchone()[0]
-
-    print('Can Player (Started on {})'.format(datetime.datetime.now()))
-    print('Replaying data from {}'.format(datetime.datetime.fromtimestamp(recorded_start_time)))
+    print('Can LogReader (Started on {})'.format(
+        datetime.datetime.now()))
+    print('Replaying data from {}'.format(
+        player.recorded_start_datetime))
 
     try:
-        playback_start_time = time.time()
-        for m in iterate_all_messages(c):
-            if results.timestamps:
-                # Work out the correct wait time
-                now = time.time()
-                current_offset = now - playback_start_time
-                recorded_offset_from_start = m.timestamp - recorded_start_time
-                remaining_gap = recorded_offset_from_start - current_offset
-
-                sleep_period = max(gap, min(results.skip, remaining_gap))
-            else:
-                sleep_period = gap
-                time.sleep(sleep_period)
-
+        for m in in_sync:
             bus.send(m)
 
     except KeyboardInterrupt:

--- a/bin/can_player.py
+++ b/bin/can_player.py
@@ -59,16 +59,14 @@ if __name__ == "__main__":
 
     in_sync = MessageSync(player, timestamps=True, skip=results.skip)
 
-
     print('Can LogReader (Started on {})'.format(
         datetime.datetime.now()))
-    print('Replaying data from {}'.format(
-        player.recorded_start_datetime))
 
     try:
         for m in in_sync:
             bus.send(m)
-
     except KeyboardInterrupt:
+        pass
+    finally:
         bus.shutdown()
 

--- a/bin/can_player.py
+++ b/bin/can_player.py
@@ -10,7 +10,7 @@ import datetime
 import argparse
 
 import can
-from CAN import LogReader, MessageSync
+from can.util import MessageSync
 
 if __name__ == "__main__":
 
@@ -55,7 +55,7 @@ if __name__ == "__main__":
 
     bus = can.interface.Bus(results.channel, bustype=results.interface)
 
-    player = LogReader(results.infile)
+    player = can.LogReader(results.infile)
 
     in_sync = MessageSync(player, timestamps=True, skip=results.skip)
 

--- a/bin/can_player.py
+++ b/bin/can_player.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+"""
+can_player.py replays CAN traffic saved with can_logger.py back
+to a CAN bus.
+
+Similar to canplayer in the can-utils package.
+"""
+from __future__ import print_function
+import datetime
+import argparse
+import time
+import socket
+
+import can
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="Replay CAN traffic")
+
+    parser.add_argument("-f", "--file_name", dest="log_file",
+                        help="""Path and base log filename, extension can be .txt, .asc, .csv, .db, .npz""",
+                        default=None)
+
+    parser.add_argument("-v", action="count", dest="verbosity",
+                        help='''Also print can frames to stdout.
+                        You can add several of these to enable debugging''', default=2)
+
+    parser.add_argument('-c', '--channel',
+                        help='''Most backend interfaces require some sort of channel.
+    For example with the serial interface the channel might be a rfcomm device: "/dev/rfcomm0"
+    With the socketcan interfaces valid channel examples include: "can0", "vcan0"''')
+
+    parser.add_argument('-i', '--interface', dest="interface",
+                        help='''Specify the backend CAN interface to use. If left blank,
+                        fall back to reading from configuration files.''',
+                        choices=can.interface.VALID_INTERFACES)
+
+
+    parser.add_argument('--ignore-timestamps', dest='timestamps',
+                        help='''Ignore timestamps (send all frames immediately with minimum gap between
+    frames)''', action='store_false')
+
+    parser.add_argument('-g', '--gap', type=float, help='''<ms> minimum time between replayed frames''')
+    parser.add_argument('-s', '--skip', type=float, default=60*60*24,
+                        help='''<s> skip gaps greater than 's' seconds''')
+
+    parser.add_argument('infile', metavar='input-file', type=str,
+                        help='The file to replay. Supported types: .db')
+
+    results = parser.parse_args()
+
+    verbosity = results.verbosity
+    gap = 0.0001 if results.gap is None else results.gap
+
+    logging_level_name = ['critical', 'error', 'warning', 'info', 'debug', 'subdebug'][min(5, verbosity)]
+    can.set_logging_level(logging_level_name)
+
+    bus = can.interface.Bus(results.channel, bustype=results.interface)
+
+    # TODO refactor all sqlite specifics out
+    def create_frame_from_db_tuple(frame_data):
+        ts, id, is_extended, is_remote, is_error, dlc, data = frame_data
+        return can.Message(
+            ts, is_remote, is_extended, is_error, id, dlc, data
+        )
+
+    def iterate_all_messages(c):
+        for frame_data in c.execute("SELECT * FROM messages"):
+            yield create_frame_from_db_tuple(frame_data)
+
+
+    import sqlite3
+    conn = sqlite3.connect(results.infile)
+    c = conn.cursor()
+    c.execute("SELECT ts FROM messages LIMIT 1")
+    recorded_start_time = c.fetchone()[0]
+
+    print('Can Player (Started on {})'.format(datetime.datetime.now()))
+    print('Replaying data from {}'.format(datetime.datetime.fromtimestamp(recorded_start_time)))
+
+    try:
+        playback_start_time = time.time()
+        for m in iterate_all_messages(c):
+            if results.timestamps:
+                # Work out the correct wait time
+                now = time.time()
+                current_offset = now - playback_start_time
+                recorded_offset_from_start = m.timestamp - recorded_start_time
+                remaining_gap = recorded_offset_from_start - current_offset
+
+                sleep_period = max(gap, min(results.skip, remaining_gap))
+            else:
+                sleep_period = gap
+                time.sleep(sleep_period)
+
+            bus.send(m)
+
+    except KeyboardInterrupt:
+        bus.shutdown()
+

--- a/can/CAN.py
+++ b/can/CAN.py
@@ -132,16 +132,18 @@ class LogReader(object):
     Replay logged CAN messages from a file.
 
     The format is determined from the file format which can be one of:
-      * .asc: :class:`can.ASCWriter`
-      * .csv: :class:`can.CSVWriter`
-      * .db: :class:`can.SqliteWriter`
+      * .asc
+      * .csv
+      * .db
 
-    Options:
+    Exposes a simple iterator interface, to use simply:
 
-    - Ignore timestamps
-    - Minimum time between messages
-    - Skip periods of inactivity greater than X
+        >>> for m in LogReader(my_file):
+        ...     print(m)
 
+    Note there are no time delays, if you want to reproduce
+    the measured delays between messages look at the
+    :class:`can.util.MessageSync` class.
     """
 
     @classmethod
@@ -153,51 +155,12 @@ class LogReader(object):
             raise NotImplemented
         #     return CSVReader(filename)
         if filename.endswith(".db"):
-            return SqliteReader(filename)
+            return SqlReader(filename)
 
 
-class MessageSync:
-
-    def __init__(self, messages, timestamps=True, gap=0.0001, skip=60):
-        """
-
-        :param messages: An iterable of :class:`can.Message` instances.
-        :param timestamps: Use the messages' timestamps.
-        :param gap: Minimum time between sent messages
-        :param skip: Skip periods of inactivity greater than this.
-        """
-        self.raw_messages = messages
-        self.timestamps = timestamps
-        self.gap = gap
-        self.skip = skip
-
-    def __iter__(self):
-        log.debug("Iterating over messages at real speed")
-        playback_start_time = time.time()
-        recorded_start_time = None
-
-        for m in self.raw_messages:
-            if recorded_start_time is None:
-                recorded_start_time = m.timestamp
-
-            if self.timestamps:
-                # Work out the correct wait time
-                now = time.time()
-                current_offset = now - playback_start_time
-                recorded_offset_from_start = m.timestamp - recorded_start_time
-                remaining_gap = recorded_offset_from_start - current_offset
-
-                sleep_period = max(self.gap, min(self.skip, remaining_gap))
-            else:
-                sleep_period = self.gap
-
-            time.sleep(sleep_period)
-            yield m
-
-
-class SqliteReader:
+class SqlReader:
     def __init__(self, filename):
-        log.debug("Starting sqlitereader with {}".format(filename))
+        log.debug("Starting sqlreader with {}".format(filename))
         conn = sqlite3.connect(filename)
 
         self.c = conn.cursor()
@@ -217,7 +180,7 @@ class SqliteReader:
     def __iter__(self):
         log.debug("Iterating through messages from sql db")
         for frame_data in self.c.execute("SELECT * FROM messages"):
-            yield SqliteReader.create_frame_from_db_tuple(frame_data)
+            yield SqlReader.create_frame_from_db_tuple(frame_data)
 
 
 class Printer(Listener):

--- a/can/CAN.py
+++ b/can/CAN.py
@@ -59,6 +59,7 @@ class Listener(object):
         Override to cleanup any open resources.
         """
 
+
 class RedirectReader(Listener):
     """
     A RedirectReader sends all received messages
@@ -164,11 +165,7 @@ class SqlReader:
         conn = sqlite3.connect(filename)
 
         self.c = conn.cursor()
-        self.c.execute("SELECT ts FROM messages LIMIT 1")
 
-        self.recorded_start_time = self.c.fetchone()[0]
-
-        self.recorded_start_datetime = datetime.fromtimestamp(self.recorded_start_time)
 
     @staticmethod
     def create_frame_from_db_tuple(frame_data):

--- a/can/__init__.py
+++ b/can/__init__.py
@@ -10,7 +10,7 @@ rc = dict(channel=0)
 class CanError(IOError):
     pass
 
-from can.CAN import BufferedReader, Listener, Logger, Printer, CSVWriter, SqliteWriter, ASCWriter, set_logging_level
+from can.CAN import BufferedReader, Listener, Logger, Printer, CSVWriter, SqliteWriter, ASCWriter, LogReader, SqlReader, set_logging_level
 from can.message import Message
 from can.bus import BusABC
 from can.notifier import Notifier

--- a/can/util.py
+++ b/can/util.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 """
-Configuration file parsing.
+Utilities and configuration file parsing.
 """
+
+import time
 try:
     from configparser import ConfigParser
 except ImportError:
@@ -11,7 +13,9 @@ import os.path
 import sys
 import platform
 import re
+import logging
 
+log = logging.getLogger('can.util')
 
 REQUIRED_KEYS = [
     'interface',
@@ -143,6 +147,45 @@ def choose_socketcan_implementation():
             msg = 'SocketCAN not available under Linux {}'.format(
                     rel_string)
             raise Exception(msg)
+
+
+class MessageSync:
+
+    def __init__(self, messages, timestamps=True, gap=0.0001, skip=60):
+        """
+
+        :param messages: An iterable of :class:`can.Message` instances.
+        :param timestamps: Use the messages' timestamps.
+        :param gap: Minimum time between sent messages
+        :param skip: Skip periods of inactivity greater than this.
+        """
+        self.raw_messages = messages
+        self.timestamps = timestamps
+        self.gap = gap
+        self.skip = skip
+
+    def __iter__(self):
+        log.debug("Iterating over messages at real speed")
+        playback_start_time = time.time()
+        recorded_start_time = None
+
+        for m in self.raw_messages:
+            if recorded_start_time is None:
+                recorded_start_time = m.timestamp
+
+            if self.timestamps:
+                # Work out the correct wait time
+                now = time.time()
+                current_offset = now - playback_start_time
+                recorded_offset_from_start = m.timestamp - recorded_start_time
+                remaining_gap = recorded_offset_from_start - current_offset
+
+                sleep_period = max(self.gap, min(self.skip, remaining_gap))
+            else:
+                sleep_period = self.gap
+
+            time.sleep(sleep_period)
+            yield m
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,10 @@ setup(
         "doc": ["*.*"]
     },
 
-    scripts=["./bin/can_logger.py"],
+    scripts=[
+        "./bin/can_logger.py",
+        "./bin/can_player.py"
+    ],
 
     # Tests can be run using `python setup.py test`
     test_suite="nose.collector",

--- a/test/listener_test.py
+++ b/test/listener_test.py
@@ -5,7 +5,6 @@ import logging
 import tempfile
 
 import can
-from CAN import SqliteReader
 
 channel = 'vcan0'
 can.rc['interface'] = 'virtual'
@@ -26,6 +25,7 @@ class ListenerImportTest(unittest.TestCase):
         assert hasattr(can, 'BufferedReader')
         assert hasattr(can, 'Notifier')
         assert hasattr(can, 'ASCWriter')
+        assert hasattr(can, 'SqlReader')
 
 
 class BusTest(unittest.TestCase):
@@ -139,7 +139,7 @@ class FileReaderTest(BusTest):
         sleep(0.5)
         a_listener.stop()
 
-        reader = SqliteReader(f.name)
+        reader = can.SqlReader(f.name)
 
         ms = []
         for m in reader:


### PR DESCRIPTION
Add framework support for replaying messages from the files we create using `can_logger.py`.
I implemented the sql db reader, and added a new script to replay with correct delays to another bus.