### PR TITLE
Better diagnostic messages

### DIFF
--- a/can/interfaces/ixxat/__init__.py
+++ b/can/interfaces/ixxat/__init__.py
@@ -4,4 +4,4 @@ Ctypes wrapper module for IXXAT Virtual CAN Interface V3 on win32 systems
 Copyright (C) 2016 Giuseppe Corbelli <giuseppe.corbelli@weightpack.com>
 """
 
-from can.interfaces.ixxat.canlib import IXXATBus as Bus
+from can.interfaces.ixxat.canlib import IXXATBus

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -22,10 +22,10 @@ __all__ = ["VCITimeout", "VCIError", "VCIDeviceNotFoundError", "IXXATBus"]
 
 log = logging.getLogger('can.ixxat')
 
-if (sys.version_info.major == 2):
-    _timer_function = time.clock
-elif (sys.version_info.major == 3):
+if ((sys.version_info.major == 3) and (sys.version_info.minor >= 3)):
     _timer_function = time.perf_counter
+else:
+    _timer_function = time.clock
 
 # main ctypes instance
 if sys.platform == "win32":

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -22,10 +22,10 @@ __all__ = ["VCITimeout", "VCIError", "VCIDeviceNotFoundError", "IXXATBus"]
 
 log = logging.getLogger('can.ixxat')
 
-if sys.version_info > (3, 3):
-    _timer_function = time.perf_counter
-else:
+if (sys.version_info.major == 2):
     _timer_function = time.clock
+elif (sys.version_info.major == 3):
+    _timer_function = time.perf_counter
 
 # main ctypes instance
 if sys.platform == "win32":
@@ -210,14 +210,19 @@ class IXXATBus(BusABC):
         self._payload = (ctypes.c_byte * 8)()
 
         # Search for supplied device
-        log.info("Searching for unique HW ID %s", UniqueHardwareId)
+        if (UniqueHardwareId is None):
+            log.info("Searching for first available device")
+        else:
+            log.info("Searching for unique HW ID %s", UniqueHardwareId)
         _canlib.vciEnumDeviceOpen(ctypes.byref(self._device_handle))
         while True:
             try:
                 _canlib.vciEnumDeviceNext(self._device_handle, ctypes.byref(self._device_info))
             except StopIteration:
-                # TODO: better error message
-                raise VCIDeviceNotFoundError("Unique HW ID {} not found".format(UniqueHardwareId))
+                if (UniqueHardwareId is None):
+                    raise VCIDeviceNotFoundError("No IXXAT device(s) connected or device(s) in use by other process(es).")
+                else:
+                    raise VCIDeviceNotFoundError("Unique HW ID {} not connected or not available.".format(UniqueHardwareId))
             else:
                 if (UniqueHardwareId is None) or (self._device_info.UniqueHardwareId.AsChar == bytes(UniqueHardwareId, 'ascii')):
                     break
@@ -240,7 +245,7 @@ class IXXATBus(BusABC):
             self.CHANNEL_BITRATES[1][bitrate]
         )
         _canlib.canControlGetCaps(self._control_handle, ctypes.byref(self._channel_capabilities))
-        
+
         # With receive messages, this field contains the relative reception time of
         # the message in ticks. The resolution of a tick can be calculated from the fields
         # dwClockFreq and dwTscDivisor of the structure  CANCAPABILITIES in accordance with the following formula:

--- a/doc/interfaces/ixxat.rst
+++ b/doc/interfaces/ixxat.rst
@@ -20,6 +20,25 @@ Bus
 .. autoclass:: can.interfaces.ixxat.canlib.IXXATBus
 
 
+Configuration file
+------------------
+The simplest configuration file would be::
+
+    [default]
+    interface = ixxat
+    channel = 0
+
+Python-can will search for the first IXXAT device available and open the first channel.
+``interface`` and ``channel`` parameters are interpreted by frontend ``can.interfaces.interface``
+module, while the following parameters are optional and are interpreted by IXXAT implementation.
+
+* ``bitrate`` (default 500000) Channel bitrate
+* ``UniqueHardwareId`` (default first device) Unique hardware ID of the IXXAT device
+* ``rxFifoSize`` (default 16) Number of RX mailboxes
+* ``txFifoSize`` (default 16) Number of TX mailboxes
+* ``extended`` (default False) Allow usage of extended IDs
+
+
 Internals
 ---------
 


### PR DESCRIPTION
In case the IXXAT device cannot be initialized spit out better diagnostic messages.
time.perf_counter only available in cpython >= 3.3 (don't know in other implementations).
Apply to the develop branch.