### PR TITLE
Remote TCP/IP interface

### DIFF
--- a/bin/can_server.py
+++ b/bin/can_server.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+import logging
+FORMAT = '%(asctime)-15s %(message)s'
+logging.basicConfig(format=FORMAT)
+import argparse
+import can
+from can.interfaces import remote
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Remote CAN server")
+
+    parser.add_argument('-v', action='count', dest="verbosity",
+                        help='''How much information do you want to see at the command line?
+                        You can add several of these e.g., -vv is DEBUG''', default=2)
+
+    parser.add_argument('-c', '--channel', help='''Most backend interfaces require some sort of channel.
+    For example with the serial interface the channel might be a rfcomm device: "/dev/rfcomm0"
+    With the socketcan interfaces valid channel examples include: "can0", "vcan0"''')
+
+    parser.add_argument('-i', '--interface',
+                        help='''Specify the backend CAN interface to use. If left blank,
+                        fall back to reading from configuration files.''',
+                        choices=can.interface.VALID_INTERFACES)
+
+    parser.add_argument('-p', '--port', type=int,
+                        help='''TCP port to listen on (default %d).''' % remote.DEFAULT_PORT,
+                        default=remote.DEFAULT_PORT)
+
+    results = parser.parse_args()
+
+    verbosity = results.verbosity
+    logging_level_name = ['critical', 'error', 'warning', 'info', 'debug', 'subdebug'][min(5, verbosity)]
+    can.set_logging_level(logging_level_name)
+
+    server = remote.RemoteServer(results.port,
+                                 channel=results.channel,
+                                 bustype=results.interface)
+    server.start()

--- a/bin/can_server.py
+++ b/bin/can_server.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 import logging
-FORMAT = '%(asctime)-15s %(message)s'
-logging.basicConfig(format=FORMAT)
+logging.basicConfig(format='%(asctime)-15s %(message)s')
 import argparse
 import can
 from can.interfaces import remote
 
-if __name__ == "__main__":
+
+def main():
     parser = argparse.ArgumentParser(description="Remote CAN server")
 
     parser.add_argument('-v', action='count', dest="verbosity",
@@ -22,6 +22,10 @@ if __name__ == "__main__":
                         fall back to reading from configuration files.''',
                         choices=can.interface.VALID_INTERFACES)
 
+    parser.add_argument('-H', '--host',
+                        help='''Host to listen to (default 0.0.0.0).''',
+                        default='0.0.0.0')
+
     parser.add_argument('-p', '--port', type=int,
                         help='''TCP port to listen on (default %d).''' % remote.DEFAULT_PORT,
                         default=remote.DEFAULT_PORT)
@@ -32,7 +36,12 @@ if __name__ == "__main__":
     logging_level_name = ['critical', 'error', 'warning', 'info', 'debug', 'subdebug'][min(5, verbosity)]
     can.set_logging_level(logging_level_name)
 
-    server = remote.RemoteServer(results.port,
+    server = remote.RemoteServer(results.host,
+                                 results.port,
                                  channel=results.channel,
                                  bustype=results.interface)
-    server.start()
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/can_server.py
+++ b/bin/can_server.py
@@ -11,16 +11,22 @@ def main():
 
     parser.add_argument('-v', action='count', dest="verbosity",
                         help='''How much information do you want to see at the command line?
-                        You can add several of these e.g., -vv is DEBUG''', default=2)
+                        You can add several of these e.g., -vv is DEBUG''', default=3)
 
     parser.add_argument('-c', '--channel', help='''Most backend interfaces require some sort of channel.
     For example with the serial interface the channel might be a rfcomm device: "/dev/rfcomm0"
-    With the socketcan interfaces valid channel examples include: "can0", "vcan0"''')
+    With the socketcan interfaces valid channel examples include: "can0", "vcan0".
+    The server will only serve this channel. Start additional servers at different
+    ports to share more channels.''')
 
     parser.add_argument('-i', '--interface',
                         help='''Specify the backend CAN interface to use. If left blank,
                         fall back to reading from configuration files.''',
                         choices=can.interface.VALID_INTERFACES)
+
+    parser.add_argument('-b', '--bitrate', type=int,
+                        help='''Force to use a specific bitrate.
+                        This will override any requested bitrate by the clients.''')
 
     parser.add_argument('-H', '--host',
                         help='''Host to listen to (default 0.0.0.0).''',
@@ -36,11 +42,21 @@ def main():
     logging_level_name = ['critical', 'error', 'warning', 'info', 'debug', 'subdebug'][min(5, verbosity)]
     can.set_logging_level(logging_level_name)
 
-    server = remote.RemoteServer(results.host,
-                                 results.port,
-                                 channel=results.channel,
-                                 bustype=results.interface)
-    server.serve_forever()
+    config = {}
+    if results.channel:
+        config["channel"] = results.channel
+    if results.interface:
+        config["bustype"] = results.interface
+    if results.bitrate:
+        config["bitrate"] = results.bitrate
+
+    server = remote.RemoteServer(results.host, results.port, **config)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    logging.info("Closing server")
+    server.shutdown()
 
 
 if __name__ == "__main__":

--- a/can/interfaces/interface.py
+++ b/can/interfaces/interface.py
@@ -4,7 +4,7 @@ from can.util import load_config, choose_socketcan_implementation
 
 VALID_INTERFACES = set(['kvaser', 'serial', 'pcan', 'socketcan_native',
                         'socketcan_ctypes', 'socketcan', 'usb2can', 'ixxat',
-                        'nican', 'virtual'])
+                        'nican', 'remote', 'virtual'])
 
 
 class Bus(object):
@@ -64,6 +64,9 @@ class Bus(object):
         elif interface == 'nican':
             from can.interfaces.nican import NicanBus
             cls = NicanBus
+        elif interface == 'remote':
+            from can.interfaces.remote import RemoteBus
+            cls = RemoteBus
         elif interface == 'virtual':
             from can.interfaces.virtual import VirtualBus
             cls = VirtualBus
@@ -96,6 +99,9 @@ class CyclicSendTask(CyclicSendTaskABC):
         elif can.rc['interface'] == 'socketcan_native':
             from can.interfaces.socketcan_native import CyclicSendTask as _nativeCyclicSendTask
             cls = _nativeCyclicSendTask
+        elif can.rc['interface'] == 'remote':
+            from can.interfaces.remote import CyclicSendTask as _remoteCyclicSendTask
+            cls = _remoteCyclicSendTask
         else:
             can.log.info("Current CAN interface doesn't support CyclicSendTask")
 

--- a/can/interfaces/interface.py
+++ b/can/interfaces/interface.py
@@ -99,9 +99,9 @@ class CyclicSendTask(CyclicSendTaskABC):
         elif can.rc['interface'] == 'socketcan_native':
             from can.interfaces.socketcan_native import CyclicSendTask as _nativeCyclicSendTask
             cls = _nativeCyclicSendTask
-        elif can.rc['interface'] == 'remote':
-            from can.interfaces.remote import CyclicSendTask as _remoteCyclicSendTask
-            cls = _remoteCyclicSendTask
+        #elif can.rc['interface'] == 'remote':
+        #    from can.interfaces.remote import CyclicSendTask as _remoteCyclicSendTask
+        #    cls = _remoteCyclicSendTask
         else:
             can.log.info("Current CAN interface doesn't support CyclicSendTask")
 

--- a/can/interfaces/interface.py
+++ b/can/interfaces/interface.py
@@ -99,6 +99,9 @@ class CyclicSendTask(CyclicSendTaskABC):
         elif can.rc['interface'] == 'socketcan_native':
             from can.interfaces.socketcan_native import CyclicSendTask as _nativeCyclicSendTask
             cls = _nativeCyclicSendTask
+        # CyclicSendTask has not been fully implemented on remote interface yet.
+        # Waiting for issue #80 which will change the API to make it easier for
+        # interfaces other than socketcan to implement it
         #elif can.rc['interface'] == 'remote':
         #    from can.interfaces.remote import CyclicSendTask as _remoteCyclicSendTask
         #    cls = _remoteCyclicSendTask

--- a/can/interfaces/remote/__init__.py
+++ b/can/interfaces/remote/__init__.py
@@ -1,4 +1,4 @@
-from .client import RemoteBus, CyclicSendTask
+from .client import RemoteBus, CyclicSendTask, CanRemoteError
 from .server import RemoteServer
 
 

--- a/can/interfaces/remote/__init__.py
+++ b/can/interfaces/remote/__init__.py
@@ -1,0 +1,8 @@
+from .client import RemoteBus, CyclicSendTask
+from .server import RemoteServer
+
+
+# If the protocol changes, increase this number
+PROTOCOL_VERSION = 4
+
+DEFAULT_PORT = 54701

--- a/can/interfaces/remote/client.py
+++ b/can/interfaces/remote/client.py
@@ -1,0 +1,207 @@
+import logging
+import socket
+import threading
+try:
+    import queue as queue
+except ImportError:
+    import Queue as queue
+import can
+from can.interfaces.remote import events
+from can.interfaces.remote import connection
+
+
+logger = logging.getLogger(__name__)
+
+
+#: Max number of messages that can be buffered if `recv()` is not called
+MAX_BUFFER_LENGTH = 16384
+
+
+def create_connection(address):
+    address = address.split(':')
+    if len(address) >= 2:
+        address = (address[0], int(address[1]))
+    else:
+        address = (address[0], can.interfaces.remote.DEFAULT_PORT)
+    return socket.create_connection(address)
+
+
+class RemoteBus(can.bus.BusABC):
+    """CAN bus over a network connection bridge.
+
+    A background thread is started to handle all incoming traffic from the
+    server. Messages are placed in a queue which `recv()` reads from.
+    Up to 16384 messages can be buffered until old messages are discarded.
+
+    When `send()` is called, the message is transmitted directly to the server
+    and then blocks until a confirmation has been received that the message
+    was transmitted to the CAN bus successfully.
+    """
+
+    def __init__(self, channel, can_filters=None, **config):
+        """
+        :param str channel:
+            Address of server as host:port (port may be omitted).
+
+        :param list can_filters:
+            A list of dictionaries each containing a "can_id" and a "can_mask".
+
+            >>> [{"can_id": 0x11, "can_mask": 0x21}]
+
+            The filters are handed to the actual CAN interface on the server.
+
+        :param int bitrate:
+            Bitrate in bits/s to use on CAN bus. May be ignored by the interface.
+
+        Any other backend specific configuration will be silently ignored.
+        """
+        # Event to stop background thread
+        self.stop_event = threading.Event()
+        # Condition for when a message has been sent or failed
+        self.send_condition = threading.Condition()
+        self.send_successful = False
+
+        self.conn = connection.Connection()
+        #: Socket connection to the server
+        self.socket = create_connection(channel)
+
+        # Send handshake with protocol version and requested bitrate
+        bitrate = config.get('bitrate', 500000)
+        bus_req = events.BusRequest(can.interfaces.remote.PROTOCOL_VERSION,
+                                    bitrate)
+        filter_conf = events.FilterConfig(can_filters)
+        self.conn.send_event(bus_req)
+        self.conn.send_event(filter_conf)
+        self.socket.sendall(self.conn.next_data())
+
+        event = self._next_event()
+        if not isinstance(event, events.BusResponse):
+            raise CanRemoteError('Handshake error')
+        self.channel_info = '%s on %s' % (event.channel_info, channel)
+
+        self.queue = queue.Queue(MAX_BUFFER_LENGTH)
+        self._reader = threading.Thread(target=self._receive_from_server)
+        self._reader.daemon = True
+        self._reader.start()
+
+        self.channel = channel
+
+    def _next_event(self):
+        """Block until a new event has been received.
+
+        :return: Next event in queue
+        """
+        event = self.conn.next_event()
+        while event is None:
+            data = self.socket.recv(256)
+            self.conn.receive_data(data)
+            event = self.conn.next_event()
+        return event
+
+    def _receive_from_server(self):
+        """Continuously receive data from server."""
+        while not self.stop_event.is_set():
+            event = self._next_event()
+            if isinstance(event, events.CanMessage):
+                self._put(event.msg)
+            elif isinstance(event, events.RemoteException):
+                self._put(event.exc)
+            elif isinstance(event, events.TransmitSuccess):
+                with self.send_condition:
+                    self.send_successful = True
+                    self.send_condition.notify_all()
+            elif isinstance(event, events.TransmitFail):
+                with self.send_condition:
+                    self.send_successful = False
+                    self.send_condition.notify_all()
+            elif isinstance(event, events.ConnectionClosed):
+                break
+
+    def _put(self, item):
+        """Add message or exception to receive queue.
+
+        If queue is full, remove the oldest item.
+        """
+        while True:
+            try:
+                self.queue.put(item, block=False)
+            except queue.Full:
+                # Remove the oldest item and try again
+                self.queue.get()
+            else:
+                break
+
+    def recv(self, timeout=None):
+        try:
+            item = self.queue.get(block=True, timeout=timeout)
+        except queue.Empty:
+            return None
+
+        if isinstance(item, Exception):
+            raise item
+
+        return item
+
+    def send(self, msg):
+        with self.send_condition:
+            self.conn.send_event(events.CanMessage(msg))
+            self.socket.sendall(self.conn.next_data())
+            self.send_successful = False
+            self.send_condition.wait(2)
+
+        if not self.send_successful:
+            raise CanRemoteError('Transmission to CAN failed')
+
+    def shutdown(self):
+        """Close socket connection."""
+        # Give threads a chance to finish up
+        self.socket.shutdown(socket.SHUT_WR)
+        self.stop_event.set()
+        self._reader.join(0.5)
+        self.socket.close()
+        logger.debug('Network connection closed')
+
+    def __del__(self):
+        self.stop_event.set()
+
+
+class CyclicSendTask(can.broadcastmanager.CyclicSendTaskABC):
+
+    def __init__(self, channel, message, period):
+        """
+        :param channel: The name of the CAN channel to connect to.
+        :param message: The message to be sent periodically.
+        :param period: The rate in seconds at which to send the message.
+        """
+        super(CyclicSendTask, self).__init__(channel, message, period)
+        self.message = message
+        self.period = period
+        self.socket = create_connection(channel)
+        self.conn = connection.Connection()
+        self.start()
+
+    def __del__(self):
+        self.stop()
+        self.socket.close()
+
+    def start(self):
+        self._send_event(
+            events.PeriodicMessageStart(self.message, self.period))
+
+    def stop(self):
+        self._send_event(
+            events.PeriodicMessageStop(self.message.arbitration_id))
+
+    def modify_data(self, message):
+        assert message.arbitration_id == self.message.arbitration_id
+        self._send_event(
+            events.PeriodicMessageUpdate(
+                self.message.arbitration_id, message.data))
+
+    def _send_event(self, event):
+        self.conn.send_event(event)
+        self.socket.sendall(self.conn.next_data())
+
+
+class CanRemoteError(can.CanError):
+    pass

--- a/can/interfaces/remote/client.py
+++ b/can/interfaces/remote/client.py
@@ -1,10 +1,6 @@
 import logging
 import socket
 import select
-try:
-    import queue as queue
-except ImportError:
-    import Queue as queue
 import can
 from can.interfaces.remote import events
 from can.interfaces.remote import connection

--- a/can/interfaces/remote/client.py
+++ b/can/interfaces/remote/client.py
@@ -111,6 +111,8 @@ class RemoteBus(can.bus.BusABC):
         """Close socket connection."""
         # Give threads a chance to finish up
         self.socket.shutdown(socket.SHUT_WR)
+        while not isinstance(self._next_event(1), events.ConnectionClosed):
+            pass
         self.socket.close()
         logger.debug('Network connection closed')
 

--- a/can/interfaces/remote/connection.py
+++ b/can/interfaces/remote/connection.py
@@ -86,6 +86,13 @@ class Connection(object):
         del self._recv_buf[:1+len(event)]
         return event
 
+    def data_ready(self):
+        """Check if there is data to transmit.
+
+        :rtype: bool
+        """
+        return len(self._send_buf) > 0
+
     def __iter__(self):
         """Allow iteration on events in the buffer.
 

--- a/can/interfaces/remote/connection.py
+++ b/can/interfaces/remote/connection.py
@@ -1,0 +1,119 @@
+import struct
+from can.interfaces.remote import events
+
+
+class EventTypes(object):
+    """Keeps track of event classes that are supported."""
+
+    def __init__(self):
+        self._event_classes = {}
+
+    def register(self, event_cls):
+        if event_cls.EVENT_ID in self._event_classes:
+            raise ProtocolError('Duplicate event type registered')
+        self._event_classes[event_cls.EVENT_ID] = event_cls
+
+    def __getitem__(self, event_id):
+        return self._event_classes[event_id]
+
+
+class Connection(object):
+    """A connection handles buffering of raw data received from e.g. a socket
+    and converts the data stream to a stream of events.
+
+    Received events can be iterated over using this class.
+    """
+
+    def __init__(self):
+        self._send_buf = bytearray()
+        self._recv_buf = bytearray()
+        #: Indicates if the sender has closed the connection
+        self.closed = False
+
+    def receive_data(self, buf):
+        """Feed data received from source.
+
+        :param buf:
+            A bytes-like object. If empty, the connection is considered closed.
+        """
+        if not buf:
+            self.closed = True
+        self._recv_buf += buf
+
+    def send_event(self, event):
+        """Convert event to data that can be transmitted as bytes.
+
+        :param event:
+            Event to be sent
+        """
+        data = struct.pack('B', event.EVENT_ID) + event.encode()
+        self._send_buf += data
+
+    def next_data(self):
+        """Get next set of data to be transmitted.
+
+        The internal send buffer will be cleared.
+
+        :return:
+            A bytes-like object.
+        """
+        data = self._send_buf
+        self._send_buf = bytearray()
+        return data
+
+    def next_event(self):
+        """Get next event, if any.
+
+        :return:
+            An event object or None if not enough data exists.
+        """
+        if not self._recv_buf:
+            if self.closed:
+                return events.ConnectionClosed()
+            return None
+
+        event_id = self._recv_buf[0]
+        try:
+            Event = event_types[event_id]
+        except KeyError:
+            raise ProtocolError('%d is not a valid event ID' % event_id)
+        try:
+            event = Event.from_buffer(self._recv_buf[1:])
+        except events.NeedMoreDataError:
+            return None
+
+        # Remove processed data from buffer
+        del self._recv_buf[:1+len(event)]
+        return event
+
+    def __iter__(self):
+        """Allow iteration on events in the buffer.
+
+            >>> for event in conn:
+            ...     print(event)
+
+        :yields: Event objects.
+        """
+        while True:
+            event = self.next_event()
+            if event is None:
+                break
+            yield event
+
+
+class ProtocolError(Exception):
+    pass
+
+
+event_types = EventTypes()
+event_types.register(events.BusRequest)
+event_types.register(events.BusResponse)
+event_types.register(events.CanMessage)
+event_types.register(events.TransmitSuccess)
+event_types.register(events.TransmitFail)
+event_types.register(events.RemoteException)
+event_types.register(events.PeriodicMessageStart)
+event_types.register(events.PeriodicMessageStop)
+event_types.register(events.PeriodicMessageUpdate)
+event_types.register(events.FilterConfig)
+event_types.register(events.ConnectionClosed)

--- a/can/interfaces/remote/events.py
+++ b/can/interfaces/remote/events.py
@@ -1,0 +1,451 @@
+"""
+Different events can be sent and transmitted over the network connection.
+
+Examples:
+  * Messages
+  * Exceptions
+  * Transmit success
+  * Transmit failure
+  * ...
+"""
+
+import struct
+import logging
+import can
+
+logger = logging.getLogger(__name__)
+
+
+class BaseEvent(object):
+    """Events should inherit this class."""
+
+    def encode(self):
+        """Convert event data to bytes.
+
+        :return:
+            Bytestring representing the event data.
+        """
+        return b''
+
+    @classmethod
+    def from_buffer(cls, buf):
+        """Parse the data and return a new event.
+
+        :param buf:
+            Bytestring representing the event data.
+
+        :return:
+            Number of bytes actually processed.
+
+        :raise: :class:`can.interfaces.remote.events.NeedMoreDataError`
+            if not enough data exists.
+        """
+        return cls()
+
+    def __len__(self):
+        return len(self.encode())
+
+    # Useful for tests
+    def __eq__(self, other):
+        return (self.__class__ == other.__class__ and
+                self.__dict__ == other.__dict__)
+
+
+class BusRequest(BaseEvent):
+    """Request for connecting to CAN bus.
+
+    +--------+-------+--------------------------------------------------------+
+    | Byte   | Type  | Contents                                               |
+    +========+=======+========================================================+
+    | 0      | U8    | Protocol version used by client                        |
+    +--------+-------+--------------------------------------------------------+
+    | 1 - 4  | S32   | Bitrate in bits/s requested                            |
+    +--------+-------+--------------------------------------------------------+
+    """
+
+    #: Event ID
+    EVENT_ID = 1
+
+    _STRUCT = struct.Struct('>Bl')
+
+    def __init__(self, version, bitrate):
+        """
+        :param int version:
+            Network protocol version
+        :param int bitrate:
+            Bitrate to use on CAN
+        """
+        #: Network protocol version
+        self.version = version
+        #: Bitrate in bits/s
+        self.bitrate = bitrate
+
+    def encode(self):
+        return self._STRUCT.pack(self.version, self.bitrate)
+
+    @classmethod
+    def from_buffer(cls, buf):
+        try:
+            version, bitrate = cls._STRUCT.unpack_from(buf)
+        except struct.error:
+            raise NeedMoreDataError()
+
+        return cls(version, bitrate)
+
+    def __len__(self):
+        return self._STRUCT.size
+
+
+class BusResponse(BaseEvent):
+    """Response after connected to CAN bus.
+
+    +--------+-------+--------------------------------------------------------+
+    | Byte   | Type  | Contents                                               |
+    +========+=======+========================================================+
+    | 0      | U8    | Length of channel info string                          |
+    +--------+-------+--------------------------------------------------------+
+    | 1 - x  | STR   | Channel info (UTF-8)                                   |
+    +--------+-------+--------------------------------------------------------+
+    """
+
+    #: Event ID
+    EVENT_ID = 2
+
+    def __init__(self, channel_info):
+        """
+        :param str channel_info:
+            Text describing the channel
+        """
+        #: Text describing the channel
+        self.channel_info = channel_info
+
+    def encode(self):
+        data = self.channel_info.encode('utf-8')
+        length = struct.pack('B', len(data))
+        return length + data
+
+    @classmethod
+    def from_buffer(cls, buf):
+        try:
+            length, = struct.unpack_from('B', buf)
+        except struct.error:
+            raise NeedMoreDataError()
+
+        if len(buf) < 1 + length:
+            raise NeedMoreDataError()
+
+        channel_info = buf[1:1+length].decode('utf-8')
+        return cls(channel_info)
+
+
+class CanMessage(BaseEvent):
+    """CAN message being received or transmitted.
+
+    +--------+-------+--------------------------------------------------------+
+    | Byte   | Type  | Contents                                               |
+    +========+=======+========================================================+
+    | 0 - 7  | F64   | Timestamp                                              |
+    +--------+-------+--------------------------------------------------------+
+    | 8 - 11 | U32   | Arbitration ID                                         |
+    +--------+-------+--------------------------------------------------------+
+    | 12     | U8    | DLC                                                    |
+    +--------+-------+--------------------------------------------------------+
+    | 13     | U8    | Flags:                                                 |
+    |        |       |  - Bit 0: Extended ID                                  |
+    |        |       |  - Bit 1: Remote frame                                 |
+    |        |       |  - Bit 2: Error frame                                  |
+    +--------+-------+--------------------------------------------------------+
+    | 14 - 21| U8    | Data padded to an 8 byte array                         |
+    +--------+-------+--------------------------------------------------------+
+    """
+
+    #: Event ID
+    EVENT_ID = 3
+
+    _STRUCT = struct.Struct('>dlBB8s')
+    _EXT_FLAG = 0x1
+    _REMOTE_FRAME_FLAG = 0x2
+    _ERROR_FRAME_FLAG = 0x4
+
+    def __init__(self, msg):
+        """
+        :param msg:
+            A :class:`can.Message` instance.
+        """
+        #: A :class:`can.Message` instance.
+        self.msg = msg
+
+    def encode(self):
+        flags = 0
+        if self.msg.id_type:
+            flags |= self._EXT_FLAG
+        if self.msg.is_remote_frame:
+            flags |= self._REMOTE_FRAME_FLAG
+        if self.msg.is_error_frame:
+            flags |= self._ERROR_FRAME_FLAG
+        buf = self._STRUCT.pack(self.msg.timestamp,
+                                self.msg.arbitration_id,
+                                self.msg.dlc,
+                                flags,
+                                bytes(self.msg.data))
+        return buf
+
+    @classmethod
+    def from_buffer(cls, buf):
+        try:
+            timestamp, arb_id, dlc, flags, data = cls._STRUCT.unpack_from(buf)
+        except struct.error:
+            raise NeedMoreDataError()
+
+        msg = can.Message(timestamp=timestamp,
+                          arbitration_id=arb_id,
+                          extended_id=bool(flags & cls._EXT_FLAG),
+                          is_remote_frame=bool(flags & cls._REMOTE_FRAME_FLAG),
+                          is_error_frame=bool(flags & cls._ERROR_FRAME_FLAG),
+                          dlc=dlc,
+                          data=data[:dlc])
+        return cls(msg)
+
+    def __len__(self):
+        return self._STRUCT.size
+
+
+class TransmitSuccess(BaseEvent):
+    """A message has been successfully transmitted to CAN."""
+
+    #: Event ID
+    EVENT_ID = 4
+
+
+class TransmitFail(BaseEvent):
+    """A message failed to be transmitted to CAN."""
+
+    #: Event ID
+    EVENT_ID = 5
+
+
+class RemoteException(BaseEvent):
+    """An exception has occurred on the server.
+
+    +--------+-------+--------------------------------------------------------+
+    | Byte   | Type  | Contents                                               |
+    +========+=======+========================================================+
+    | 0      | U8    | Length of exception string                             |
+    +--------+-------+--------------------------------------------------------+
+    | 1 - x  | STR   | Exception description (UTF-8)                          |
+    +--------+-------+--------------------------------------------------------+
+    """
+
+    #: Event ID
+    EVENT_ID = 6
+
+    def __init__(self, exc):
+        #: The exception
+        self.exc = exc
+
+    def encode(self):
+        data = str(self.exc).encode('utf-8')
+        length = struct.pack('B', len(data))
+        return length + data
+
+    @classmethod
+    def from_buffer(cls, buf):
+        try:
+            length, = struct.unpack_from('B', buf)
+        except struct.error:
+            raise NeedMoreDataError()
+
+        if len(buf) - 1 < length:
+            raise NeedMoreDataError()
+
+        text = buf[1:1+length].decode('utf-8')
+        return cls(can.CanError(text))
+
+
+class PeriodicMessageStart(BaseEvent):
+    """Start periodic transmission of message.
+
+    +--------+-------+--------------------------------------------------------+
+    | Byte   | Type  | Contents                                               |
+    +========+=======+========================================================+
+    | 0 - 7  | F64   | Period (s)                                             |
+    +--------+-------+--------------------------------------------------------+
+    | 8 - 11 | U32   | Arbitration ID                                         |
+    +--------+-------+--------------------------------------------------------+
+    | 12     | U8    | DLC                                                    |
+    +--------+-------+--------------------------------------------------------+
+    | 13     | U8    | Extended ID                                            |
+    +--------+-------+--------------------------------------------------------+
+    | 14 - 21| U8    | Data padded to an 8 byte array                         |
+    +--------+-------+--------------------------------------------------------+
+    """
+
+    #: Event ID
+    EVENT_ID = 7
+
+    _STRUCT = struct.Struct('>dlBB8s')
+
+    def __init__(self, msg, period):
+        """
+        :param msg:
+            A :class:`can.Message` instance.
+        """
+        #: A :class:`can.Message` instance.
+        self.msg = msg
+        self.period = period
+
+    def encode(self):
+        buf = self._STRUCT.pack(self.period,
+                                self.msg.arbitration_id,
+                                self.msg.dlc,
+                                self.msg.id_type,
+                                bytes(self.msg.data))
+        return buf
+
+    @classmethod
+    def from_buffer(cls, buf):
+        try:
+            period, arb_id, dlc, extended, data = cls._STRUCT.unpack_from(buf)
+        except struct.error:
+            raise NeedMoreDataError()
+
+        msg = can.Message(arbitration_id=arb_id,
+                          extended_id=extended,
+                          dlc=dlc,
+                          data=data[:dlc])
+        return cls(msg, period)
+
+    def __len__(self):
+        return self._STRUCT.size
+
+
+class PeriodicMessageStop(BaseEvent):
+    """Stop periodic transmission of a message.
+
+    +--------+-------+--------------------------------------------------------+
+    | Byte   | Type  | Contents                                               |
+    +========+=======+========================================================+
+    | 0 - 4  | U32   | Arbitration ID                                         |
+    +--------+-------+--------------------------------------------------------+
+    """
+
+    #: Event ID
+    EVENT_ID = 8
+
+    _STRUCT = struct.Struct('>l')
+
+    def __init__(self, arbitration_id):
+        #: The arbitration ID of the message to stop transmitting
+        self.arbitration_id = arbitration_id
+
+    def encode(self):
+        return self._STRUCT.pack(self.arbitration_id)
+
+    @classmethod
+    def from_buffer(cls, buf):
+        try:
+            arbitration_id, = cls._STRUCT.unpack_from(buf)
+        except struct.error:
+            raise NeedMoreDataError()
+        return cls(arbitration_id)
+
+    def __len__(self):
+        return self._STRUCT.size
+
+
+class PeriodicMessageUpdate(CanMessage):
+    """Stop periodic transmission of a message.
+
+    +--------+-------+--------------------------------------------------------+
+    | Byte   | Type  | Contents                                               |
+    +========+=======+========================================================+
+    | 0 - 7  |       | Reserved                                               |
+    +--------+-------+--------------------------------------------------------+
+    | 8 - 11 | U32   | Arbitration ID                                         |
+    +--------+-------+--------------------------------------------------------+
+    | 12     | U8    | DLC                                                    |
+    +--------+-------+--------------------------------------------------------+
+    | 13     | U8    | Flags:                                                 |
+    |        |       |  - Bit 0: Extended ID                                  |
+    |        |       |  - Bit 1: Remote frame                                 |
+    |        |       |  - Bit 2: Error frame                                  |
+    +--------+-------+--------------------------------------------------------+
+    | 14 - 21| U8    | Data padded to an 8 byte array                         |
+    +--------+-------+--------------------------------------------------------+
+    """
+
+    #: Event ID
+    EVENT_ID = 9
+
+
+class FilterConfig(BaseEvent):
+    """CAN filter configuration.
+
+    +--------+-------+--------------------------------------------------------+
+    | Byte   | Type  | Contents                                               |
+    +========+=======+========================================================+
+    | 0      | U8    | Number of filters                                      |
+    +--------+-------+--------------------------------------------------------+
+    | 1 - 4  | U32   | CAN ID for filter 1                                    |
+    +--------+-------+--------------------------------------------------------+
+    | 5 - 8  | U32   | CAN mask for filter 1                                  |
+    +--------+-------+--------------------------------------------------------+
+    | 9 - 12 | U32   | CAN ID for filter 2                                    |
+    +--------+-------+--------------------------------------------------------+
+    | 13 - 16| U32   | CAN mask for filter 2                                  |
+    +--------+-------+--------------------------------------------------------+
+    | ...    | ...   | ...                                                    |
+    +--------+-------+--------------------------------------------------------+
+    """
+
+    #: Event ID
+    EVENT_ID = 10
+    _STRUCT = struct.Struct('>LL')
+
+    def __init__(self, can_filters=None):
+        """
+        :param list can_filters:
+            List of CAN filters
+        """
+        #: A list of CAN filter dictionaries as:
+        #: >>    {'can_id': 0x03, 'can_mask': 0xff}
+        self.can_filters = can_filters or []
+
+    def encode(self):
+        data = [struct.pack('B', len(self.can_filters))]
+        for can_filter in self.can_filters:
+            filter_data = self._STRUCT.pack(
+                can_filter['can_id'], can_filter['can_mask'])
+            data.append(filter_data)
+        return b''.join(data)
+
+    @classmethod
+    def from_buffer(cls, buf):
+        can_filters = []
+        try:
+            nof_filters, = struct.unpack_from('B', buf)
+            for i in range(nof_filters):
+                offset = 1 + i * cls._STRUCT.size
+                can_id, can_mask = cls._STRUCT.unpack_from(buf, offset)
+                can_filters.append({'can_id': can_id, 'can_mask': can_mask})
+        except struct.error:
+            raise NeedMoreDataError()
+
+        return cls(can_filters)
+
+    def __len__(self):
+        return 1 + self._STRUCT.size * len(self.can_filters)
+
+class ConnectionClosed(BaseEvent):
+    """Connection closed by peer.
+
+    Will be automatically emitted if the socket is closed.
+    """
+
+    #: Event ID
+    EVENT_ID = 255
+
+
+class NeedMoreDataError(Exception):
+    """There is not enough data yet."""
+    pass

--- a/can/interfaces/remote/events.py
+++ b/can/interfaces/remote/events.py
@@ -24,6 +24,7 @@ class BaseEvent(object):
 
         :return:
             Bytestring representing the event data.
+        :rtype: bytes
         """
         return b''
 
@@ -31,14 +32,14 @@ class BaseEvent(object):
     def from_buffer(cls, buf):
         """Parse the data and return a new event.
 
-        :param buf:
+        :param bytes buf:
             Bytestring representing the event data.
 
         :return:
-            Number of bytes actually processed.
+            Event decoded from buffer.
 
-        :raise: :class:`can.interfaces.remote.events.NeedMoreDataError`
-            if not enough data exists.
+        :raise can.interfaces.remote.events.NeedMoreDataError:
+            If not enough data exists.
         """
         return cls()
 
@@ -169,8 +170,8 @@ class CanMessage(BaseEvent):
 
     def __init__(self, msg):
         """
-        :param msg:
-            A :class:`can.Message` instance.
+        :param can.Message msg:
+            A Message object.
         """
         #: A :class:`can.Message` instance.
         self.msg = msg
@@ -240,6 +241,10 @@ class RemoteException(BaseEvent):
     EVENT_ID = 6
 
     def __init__(self, exc):
+        """
+        :param Exception exc:
+            The exception to send.
+        """
         #: The exception
         self.exc = exc
 
@@ -287,8 +292,10 @@ class PeriodicMessageStart(BaseEvent):
 
     def __init__(self, msg, period):
         """
-        :param msg:
-            A :class:`can.Message` instance.
+        :param can.Message msg:
+            A Message object.
+        :param float period:
+            Period of message in seconds.
         """
         #: A :class:`can.Message` instance.
         self.msg = msg
@@ -335,6 +342,10 @@ class PeriodicMessageStop(BaseEvent):
     _STRUCT = struct.Struct('>l')
 
     def __init__(self, arbitration_id):
+        """
+        :param int arbitration_id:
+            The CAN-ID of the message to stop sending.
+        """
         #: The arbitration ID of the message to stop transmitting
         self.arbitration_id = arbitration_id
 

--- a/can/interfaces/remote/server.py
+++ b/can/interfaces/remote/server.py
@@ -1,0 +1,203 @@
+import logging
+import socket
+import threading
+import can
+#from can.interfaces import remote
+from can.interfaces.remote import events
+from can.interfaces.remote import connection
+
+
+logger = logging.getLogger(__name__)
+
+
+class RemoteServer(object):
+    """Server for CAN communication."""
+
+    def __init__(self, port=None, **config):
+        """
+        :param int port:
+            Network port to listen to.
+        :param channel:
+            The can interface identifier. Expected type is backend dependent.
+        :param str bustype:
+            CAN interface to use.
+        """
+        self.port = port or can.interfaces.remote.DEFAULT_PORT
+        self.config = config
+
+        #: List of :class:`can.interfaces.remote.server.ClientBusConnection`
+        #: instances
+        self.clients = []
+
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    def start(self):
+        """Start listening for incoming clients."""
+        self.socket.bind(('', self.port))
+        self.socket.listen(5)
+        logger.info('Listening on port %d...', self.port)
+
+        while True:
+            try:
+                conn, address = self.socket.accept()
+            except KeyboardInterrupt:
+                break
+
+            logger.info('Got connection from %s', address)
+            try:
+                client = ClientBusConnection(conn, self)
+            except RemoteServerError as e:
+                logger.error(e)
+                conn.close()
+            else:
+                self.clients.append(client)
+
+        self.shutdown()
+
+    def shutdown(self):
+        self.socket.close()
+
+
+class ClientBusConnection(object):
+    """A client connection on the server."""
+
+    def __init__(self, conn, server):
+        """
+        :param conn:
+            A socket object to the client.
+        :param server:
+            The :class:`RemoteServer` object that received the connection.
+        """
+        #: Socket connection to client
+        self.socket = conn
+        self.server = server
+        self.conn = connection.Connection()
+        # Prevent threads to send data simultaneously
+        self.lock = threading.Lock()
+        self.stop_event = threading.Event()
+
+        event = self._next_event()
+        if not isinstance(event, events.BusRequest):
+            raise RemoteServerError('Handshake error')
+
+        #: Bitrate requested by client
+        self.bitrate = event.bitrate
+
+        if event.version != can.interfaces.remote.PROTOCOL_VERSION:
+            raise RemoteServerError('Protocol version mismatch (%d != %d)' % (
+                event.version, can.interfaces.remote.PROTOCOL_VERSION))
+
+        self._start_bus()
+
+        self.receive_thread = threading.Thread(target=self._receive_from_client)
+        self.receive_thread.daemon = True
+        self.receive_thread.start()
+
+    def _start_bus(self):
+        filter_event = self._next_event()
+        if not isinstance(filter_event, events.FilterConfig):
+            raise RemoteServerError('Handshake error')
+        #: CAN filters requested by client
+        self.can_filters = filter_event.can_filters
+
+        #: A :class:`can.interface.Bus` object
+        self.bus = can.interface.Bus(bitrate=self.bitrate,
+                                     can_filters=self.can_filters,
+                                     **self.server.config)
+        logger.info("Connected to bus '%s'", self.bus.channel_info)
+
+        # Send channel_info to client
+        self.send_event(events.BusResponse(self.bus.channel_info))
+
+        self.send_thread = threading.Thread(target=self._send_to_client)
+        self.send_thread.daemon = True
+        self.send_thread.start()
+
+    def _start_periodic_transmit(self):
+        start_event = self._next_event()
+        if not isinstance(start_event, events.PeriodicMessageStart):
+            raise RemoteServerError('Handshake error')
+
+        #: Cyclic send task
+        self.task = can.interface.CyclicSendTask(self.server.channel,
+                                                 start_event.msg,
+                                                 start_event.period)
+
+    def _next_event(self):
+        """Block until a new event has been received.
+
+        :return: Next event in queue
+        """
+        event = self.conn.next_event()
+        while event is None:
+            self.conn.receive_data(self.socket.recv(256))
+            event = self.conn.next_event()
+        return event
+
+    def _receive_from_client(self):
+        """Continuously read events from socket and send messages on CAN bus."""
+        while not self.stop_event.is_set():
+            event = self._next_event()
+            if isinstance(event, events.CanMessage):
+                self.send_msg(event.msg)
+            elif isinstance(event, events.ConnectionClosed):
+                break
+            elif isinstance(event, events.PeriodicMessageStart):
+                self.task.start()
+            elif isinstance(event, events.PeriodicMessageStop):
+                self.task.stop()
+            elif isinstance(event, events.PeriodicMessageUpdate):
+                self.task.modify_data(event.msg)
+
+        logger.info('Closing connection to %s', self.socket.getpeername())
+        # Remove itself from the server's list of clients
+        self.server.clients.remove(self)
+        self.stop_event.set()
+        with self.lock:
+            self.socket.close()
+            self.socket = None
+
+    def _send_to_client(self):
+        """Continuously read CAN messages and send to client."""
+        while not self.stop_event.is_set():
+            try:
+                msg = self.bus.recv(1.0)
+            except can.CanError as e:
+                logger.error(e)
+                self.send_event(events.RemoteException(e))
+                break
+
+            if msg is not None:
+                logger.log(9, 'Received from CAN:\n%s', msg)
+                self.send_event(events.CanMessage(msg))
+
+        # If there are no clients left, disconnect from CAN
+        # and stop thread
+        logger.info('Disconnecting from CAN bus')
+        self.bus.shutdown()
+        self.bus = None
+
+    def send_msg(self, msg):
+        """Send a CAN message to the bus."""
+        try:
+            self.bus.send(msg)
+        except can.CanError:
+            self.send_event(events.TransmitFail())
+        else:
+            self.send_event(events.TransmitSuccess())
+
+    def send_event(self, event):
+        """Send an event to the client."""
+        if self.socket:
+            with self.lock:
+                self.conn.send_event(event)
+                self.socket.sendall(self.conn.next_data())
+
+
+class RemoteServerError(Exception):
+    pass
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    RemoteServer(bustype='kvaser', channel=0).start()

--- a/doc/bin.rst
+++ b/doc/bin.rst
@@ -35,4 +35,29 @@ Command line help (``--help``)::
                             Which backend do you want to use?
 
 
+can_server.py
+-------------
+
+Command line help (``--help``)::
+
+      usage: can_server.py [-h] [-v] [-c CHANNEL]
+                          [-i {pcan,remote,ixxat,socketcan_ctypes,virtual,usb2can,nican,serial,kvaser,socketcan,socketcan_native}]
+                          [-p PORT]
+
+      Remote CAN server
+
+      optional arguments:
+        -h, --help            show this help message and exit
+        -v                    How much information do you want to see at the command
+                              line? You can add several of these e.g., -vv is DEBUG
+        -c CHANNEL, --channel CHANNEL
+                              Most backend interfaces require some sort of channel.
+                              For example with the serial interface the channel
+                              might be a rfcomm device: "/dev/rfcomm0" With the
+                              socketcan interfaces valid channel examples include:
+                              "can0", "vcan0"
+        -i {pcan,remote,ixxat,socketcan_ctypes,virtual,usb2can,nican,serial,kvaser,socketcan,socketcan_native}, --interface {pcan,remote,ixxat,socketcan_ctypes,virtual,usb2can,nican,serial,kvaser,socketcan,socketcan_native}
+                              Specify the backend CAN interface to use. If left
+                              blank, fall back to reading from configuration files.
+        -p PORT, --port PORT  TCP port to listen on (default 54701).
 

--- a/doc/interfaces.rst
+++ b/doc/interfaces.rst
@@ -18,6 +18,7 @@ The available interfaces are:
    interfaces/pcan
    interfaces/usb2can
    interfaces/nican
+   interfaces/remote
    interfaces/virtual
 
 

--- a/doc/interfaces/remote.rst
+++ b/doc/interfaces/remote.rst
@@ -1,0 +1,83 @@
+Remote
+======
+
+The remote interface works as a networked bridge between the computer running
+the application and the computer owning the physical CAN interface.
+
+Server
+------
+
+The computer which owns the CAN interface must start a server which accepts
+incoming connections. If more than one channel is to be shared, multiple
+servers must be started on different ports.
+
+Start a server using default interface and channel::
+
+    $ can_server.py
+
+Specify interface, channel and port number explicitly::
+
+    $ can_server.py --interface kvaser --channel 0 --port 54702
+
+Client
+------
+
+The application must specify ``remote`` as interface and ``host:port`` as
+channel. The port number can be omitted if default port is used. The bitrate
+to use on the CAN bus can also be specified.
+
+.. code-block:: python
+
+    bus = can.interface.Bus('192.168.0.10:54701',
+                            bustype='remote',
+                            bitrate=500000,
+                            can_filters=[
+                                {'can_id': 0x11},
+                                {'can_mask': 0xff}
+                            ])
+
+
+Alternatively in a .canrc file::
+
+    [default]
+    interface = remote
+    channel = myhostname
+
+Internals
+---------
+
+The client uses a standard Bus class to connect to the server.
+
+.. autoclass:: can.interfaces.remote.RemoteBus
+
+The server uses the following classes to implement the connections.
+
+.. autoclass:: can.interfaces.remote.RemoteServer
+.. autoclass:: can.interfaces.remote.server.ClientBusConnection
+
+Protocol
+~~~~~~~~
+
+The protocol is a stream of events over a network socket.
+Each event starts with one byte that represents the event id, followed by
+event specific data of arbitrary length in big-endian byte order.
+
+The client start with sending a :class:`can.interfaces.remote.events.BusRequest`
+followed by a :class:`can.interfaces.remote.events.FilterConfig`.
+The server will reply with a :class:`can.interfaces.remote.events.BusResponse`.
+
+Each event class inherits from the base event class:
+
+.. autoclass:: can.interfaces.remote.events.BaseEvent
+
+The available events that can occurr and their specification is listed below:
+
+.. autoclass:: can.interfaces.remote.events.BusRequest
+.. autoclass:: can.interfaces.remote.events.BusResponse
+.. autoclass:: can.interfaces.remote.events.CanMessage
+.. autoclass:: can.interfaces.remote.events.TransmitSuccess
+.. autoclass:: can.interfaces.remote.events.TransmitFail
+.. autoclass:: can.interfaces.remote.events.RemoteException
+.. autoclass:: can.interfaces.remote.events.PeriodicMessageStart
+.. autoclass:: can.interfaces.remote.events.FilterConfig
+.. autoclass:: can.interfaces.remote.events.ConnectionClosed

--- a/doc/interfaces/remote.rst
+++ b/doc/interfaces/remote.rst
@@ -49,6 +49,7 @@ Internals
 The client uses a standard Bus class to connect to the server.
 
 .. autoclass:: can.interfaces.remote.RemoteBus
+.. autoexception:: can.interfaces.remote.CanRemoteError
 
 The server uses the following classes to implement the connections.
 

--- a/doc/interfaces/remote.rst
+++ b/doc/interfaces/remote.rst
@@ -4,6 +4,10 @@ Remote
 The remote interface works as a networked bridge between the computer running
 the application and the computer owning the physical CAN interface.
 
+Multiple clients may connect to the same server simultaneously. Each client
+will create its own bus instance on the server, so this must be supported by the
+real interface.
+
 Server
 ------
 
@@ -41,7 +45,13 @@ Alternatively in a .canrc file::
 
     [default]
     interface = remote
-    channel = myhostname
+    channel = myhostname:54701
+
+
+The can_logger.py script could be started like this::
+
+    $ can_logger.py -i remote -c myhostname:54701
+
 
 Internals
 ---------
@@ -69,13 +79,13 @@ The server uses the following classes to implement the connections.
 Protocol
 ~~~~~~~~
 
-The protocol is a stream of events over a network socket.
+The protocol is a stream of events over a TCP socket.
 Each event starts with one byte that represents the event id, followed by
 event specific data of arbitrary length in big-endian byte order.
 
-The client start with sending a :class:`can.interfaces.remote.events.BusRequest`
-followed by a :class:`can.interfaces.remote.events.FilterConfig`.
-The server will reply with a :class:`can.interfaces.remote.events.BusResponse`.
+The client start with sending a :class:`~can.interfaces.remote.events.BusRequest`
+followed by a :class:`~can.interfaces.remote.events.FilterConfig`.
+The server will reply with a :class:`~can.interfaces.remote.events.BusResponse`.
 
 Each event class inherits from the base event class:
 
@@ -87,8 +97,6 @@ The available events that can occurr and their specification is listed below:
 .. autoclass:: can.interfaces.remote.events.BusResponse
 .. autoclass:: can.interfaces.remote.events.CanMessage
 .. autoclass:: can.interfaces.remote.events.TransmitSuccess
-.. autoclass:: can.interfaces.remote.events.TransmitFail
 .. autoclass:: can.interfaces.remote.events.RemoteException
-.. autoclass:: can.interfaces.remote.events.PeriodicMessageStart
 .. autoclass:: can.interfaces.remote.events.FilterConfig
 .. autoclass:: can.interfaces.remote.events.ConnectionClosed

--- a/doc/interfaces/remote.rst
+++ b/doc/interfaces/remote.rst
@@ -54,6 +54,16 @@ The client uses a standard Bus class to connect to the server.
 The server uses the following classes to implement the connections.
 
 .. autoclass:: can.interfaces.remote.RemoteServer
+
+   .. method:: serve_forever
+
+      Start listening for incoming connections.
+
+   .. method:: shutdown
+
+      Stop the server.
+
+
 .. autoclass:: can.interfaces.remote.server.ClientBusConnection
 
 Protocol

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "doc": ["*.*"]
     },
 
-    scripts=["./bin/can_logger.py"],
+    scripts=["./bin/can_logger.py", "./bin/can_server.py"],
 
     # Tests can be run using `python setup.py test`
     test_suite="nose.collector",

--- a/test/listener_test.py
+++ b/test/listener_test.py
@@ -63,7 +63,8 @@ class ListenerTest(BusTest):
         self.assertIsNotNone(m)
 
     def testSQLWriterReceives(self):
-        f = tempfile.NamedTemporaryFile('w')
+        f = tempfile.NamedTemporaryFile('w', delete=False)
+        f.close()
         a_listener = can.SqliteWriter(f.name)
         a_listener(generate_message(0xDADADA))
         # Small delay so we don't stop before we actually block trying to read
@@ -80,7 +81,8 @@ class ListenerTest(BusTest):
 
 
     def testSQLWriterWritesToSameFile(self):
-        f = tempfile.NamedTemporaryFile('w')
+        f = tempfile.NamedTemporaryFile('w', delete=False)
+        f.close()
 
         first_listener = can.SqliteWriter(f.name)
         first_listener(generate_message(0x01))
@@ -143,7 +145,8 @@ class ListenerTest(BusTest):
 class FileReaderTest(BusTest):
 
     def test_sql_reader(self):
-        f = tempfile.NamedTemporaryFile('w')
+        f = tempfile.NamedTemporaryFile('w', delete=False)
+        f.close()
         a_listener = can.SqliteWriter(f.name)
         a_listener(generate_message(0xDADADA))
         sleep(0.5)

--- a/test/remote_test.py
+++ b/test/remote_test.py
@@ -158,6 +158,8 @@ class RemoteBusTestCase(unittest.TestCase):
         server_thread.daemon = True
         server_thread.start()
         cls.server = server
+        # Wait for server to be properly started
+        time.sleep(0.1)
 
     def setUp(self):
         # Connect to remote bus on localhost

--- a/test/remote_test.py
+++ b/test/remote_test.py
@@ -153,13 +153,18 @@ class RemoteBusTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        server = can.interfaces.remote.RemoteServer(54700, channel='unittest', bustype='virtual')
-        server_thread = threading.Thread(target=server.start, name='Server thread')
+        server = can.interfaces.remote.RemoteServer(
+            '127.0.0.1', 54700, channel='unittest', bustype='virtual')
+        server_thread = threading.Thread(target=server.serve_forever, name='Server thread')
         server_thread.daemon = True
         server_thread.start()
         cls.server = server
         # Wait for server to be properly started
         time.sleep(0.1)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
 
     def setUp(self):
         # Connect to remote bus on localhost

--- a/test/remote_test.py
+++ b/test/remote_test.py
@@ -183,7 +183,7 @@ class RemoteBusTestCase(unittest.TestCase):
     def test_initialization(self):
         self.assertEqual(self.remote_bus.channel_info,
                          '%s on 127.0.0.1:54700' % self.real_bus.channel_info)
-        self.assertEqual(self.server.clients[-1].bitrate, 125000)
+        self.assertEqual(self.server.clients[-1].config["bitrate"], 125000)
 
         # Test to create a new bus with filters
         can_filters = [
@@ -196,8 +196,8 @@ class RemoteBusTestCase(unittest.TestCase):
                                 can_filters=can_filters)
         # Wait some time so that self.server.clients is updated
         time.sleep(0.1)
-        self.assertEqual(self.server.clients[-1].can_filters, can_filters)
-        self.assertEqual(self.server.clients[-1].bitrate, 1000000)
+        self.assertEqual(self.server.clients[-1].config["can_filters"], can_filters)
+        self.assertEqual(self.server.clients[-1].config["bitrate"], 1000000)
         bus.shutdown()
 
     def test_send(self):

--- a/test/remote_test.py
+++ b/test/remote_test.py
@@ -212,6 +212,10 @@ class RemoteBusTestCase(unittest.TestCase):
         self.assertIsNotNone(msg_received)
         self.assertEqual(msg_received, empty_msg)
 
+        # Test timeout
+        msg_received = self.remote_bus.recv(0.1)
+        self.assertIsNone(msg_received)
+
     def _test_send_failure(self):
         self.server.clients[-1].bus.send = raise_error
         msg = can.Message()

--- a/test/remote_test.py
+++ b/test/remote_test.py
@@ -206,15 +206,18 @@ class RemoteBusTestCase(unittest.TestCase):
         self.assertEqual(msg2_on_remote, ext_msg)
 
     def test_recv(self):
+        msg = can.Message(arbitration_id=0x123, data=[8, 7, 6, 5, 4, 3, 2, 1])
         empty_msg = can.Message()
+        self.real_bus.send(msg)
         self.real_bus.send(empty_msg)
-        msg_received = self.remote_bus.recv(2)
-        self.assertIsNotNone(msg_received)
-        self.assertEqual(msg_received, empty_msg)
-
-        # Test timeout
-        msg_received = self.remote_bus.recv(0.1)
-        self.assertIsNone(msg_received)
+        first_received = self.remote_bus.recv(0.1)
+        second_received = self.remote_bus.recv(0.1)
+        third_received = self.remote_bus.recv(0.1)
+        self.assertIsNotNone(first_received)
+        self.assertEqual(first_received, msg)
+        self.assertIsNotNone(second_received)
+        self.assertEqual(second_received, empty_msg)
+        self.assertIsNone(third_received)
 
     def test_recv_failure(self):
         self.server.clients[-1].bus.recv = raise_error

--- a/test/remote_test.py
+++ b/test/remote_test.py
@@ -216,12 +216,6 @@ class RemoteBusTestCase(unittest.TestCase):
         msg_received = self.remote_bus.recv(0.1)
         self.assertIsNone(msg_received)
 
-    def _test_send_failure(self):
-        self.server.clients[-1].bus.send = raise_error
-        msg = can.Message()
-        with self.assertRaisesRegexp(can.CanError, 'Transmission to CAN failed'):
-            self.remote_bus.send(msg)
-
     def test_recv_failure(self):
         self.server.clients[-1].bus.recv = raise_error
         with self.assertRaisesRegexp(can.CanError, 'This is some error'):

--- a/test/remote_test.py
+++ b/test/remote_test.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+import threading
+import time
+import can
+from can.interfaces.remote import events
+from can.interfaces.remote import connection
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def raise_error(msg):
+    raise can.CanError('This is some error')
+
+
+class EventsTestCase(unittest.TestCase):
+
+    def test_message(self):
+        messages = [
+            can.Message(timestamp=1470925506.0621243,
+                        arbitration_id=0x100,
+                        extended_id=False,
+                        data=[1, 2, 3, 4]),
+            can.Message(arbitration_id=0xabcdef,
+                        extended_id=True,
+                        data=[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+            can.Message(),
+            can.Message(is_error_frame=True),
+            can.Message(is_remote_frame=True,
+                        arbitration_id=0x123)
+        ]
+
+        for msg in messages:
+            send_event = events.CanMessage(msg)
+            buf = send_event.encode()
+            recv_event = events.CanMessage.from_buffer(buf)
+            self.assertEqual(recv_event, send_event)
+            self.assertAlmostEqual(recv_event.msg.timestamp, msg.timestamp)
+            self.assertEqual(len(recv_event), len(buf))
+
+    def test_bus_request(self):
+        event1 = events.BusRequest(12, 1000000)
+        buf = event1.encode()
+        event2 = events.BusRequest.from_buffer(buf)
+        self.assertEqual(event1, event2)
+        self.assertEqual(len(event2), len(buf))
+
+    def test_filter_config(self):
+        event1 = events.FilterConfig([
+            {'can_id': 0x123, 'can_mask': 0xFFF},
+            {'can_id': 0x001, 'can_mask': 0x00F}
+        ])
+        buf = event1.encode()
+        event2 = events.FilterConfig.from_buffer(buf)
+        self.assertEqual(event1, event2)
+        self.assertEqual(len(event2), len(buf))
+
+        event1 = events.FilterConfig([])
+        buf = event1.encode()
+        event2 = events.FilterConfig.from_buffer(buf)
+        self.assertEqual(event1, event2)
+        self.assertEqual(len(event2), len(buf))
+
+    def test_bus_response(self):
+        channel_info = 'This is some channel info'
+        event1 = events.BusResponse(channel_info)
+        buf = event1.encode()
+        event2 = events.BusResponse.from_buffer(buf)
+        self.assertEqual(event1, event2)
+        self.assertEqual(len(event2), len(buf))
+
+    def test_exception(self):
+        event1 = events.RemoteException(can.CanError('This is an error'))
+        buf = event1.encode()
+        event2 = events.RemoteException.from_buffer(buf)
+        self.assertEqual(str(event1.exc), str(event2.exc))
+        self.assertEqual(len(event2), len(buf))
+
+    def test_periodic_start(self):
+        msg = can.Message(0x123,
+                          extended_id=False,
+                          data=[1, 2, 3, 4, 5, 6, 7, 8])
+        event1 = events.PeriodicMessageStart(msg, 0.01)
+        buf = event1.encode()
+        event2 = events.PeriodicMessageStart.from_buffer(buf)
+        self.assertEqual(event1, event2)
+        self.assertAlmostEqual(event1.period, event2.period)
+        self.assertEqual(len(event2), len(buf))
+
+
+class ConnectionTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.sender = connection.Connection()
+        self.receiver = connection.Connection()
+
+    def test_send_and_receive(self):
+        event1 = events.CanMessage(can.Message())
+        self.sender.send_event(event1)
+        self.receiver.receive_data(self.sender.next_data())
+        event2 = self.receiver.next_event()
+        self.assertEqual(event1, event2)
+
+        # No more events shall be returned
+        self.assertIsNone(self.receiver.next_event())
+
+    def test_empty_events(self):
+        self.sender.send_event(events.TransmitSuccess())
+        self.receiver.receive_data(self.sender.next_data())
+        event = self.receiver.next_event()
+        self.assertIsInstance(event, events.TransmitSuccess)
+
+    def test_partial_transfer(self):
+        event1 = events.CanMessage(can.Message())
+        self.sender.send_event(event1)
+        data = self.sender.next_data()
+
+        # Send only first 8 bytes
+        self.receiver.receive_data(data[:8])
+        self.assertIsNone(self.receiver.next_event())
+
+        # Send the rest (and some more)
+        self.receiver.receive_data(data[8:])
+        self.receiver.receive_data(b'hello')
+        event2 = self.receiver.next_event()
+        self.assertEqual(event1, event2)
+
+    def test_iteration(self):
+        event1 = events.CanMessage(can.Message())
+        self.sender.send_event(event1)
+        data = self.sender.next_data()
+        self.receiver.receive_data(data * 8)
+
+        self.assertListEqual(list(self.receiver), [event1] * 8)
+
+    def test_invalid_event(self):
+        self.receiver.receive_data(b'\xf0')
+        with self.assertRaises(connection.ProtocolError):
+            self.receiver.next_event()
+
+    def test_close(self):
+        self.assertFalse(self.receiver.closed)
+        self.receiver.receive_data(b'')
+        event = self.receiver.next_event()
+        self.assertTrue(self.receiver.closed)
+        self.assertIsInstance(event, events.ConnectionClosed)
+
+
+#@unittest.skip('Take a lot of time')
+class RemoteBusTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        server = can.interfaces.remote.RemoteServer(54700, channel='unittest', bustype='virtual')
+        server_thread = threading.Thread(target=server.start)
+        server_thread.daemon = True
+        server_thread.start()
+        cls.server = server
+
+    def setUp(self):
+        # Connect to remote bus on localhost
+        self.remote_bus = can.interface.Bus('localhost:54700',
+                                            bustype='remote',
+                                            bitrate=125000)
+        # Connect to real bus directly
+        self.real_bus = can.interface.Bus('unittest', bustype='virtual')
+        # Wait some time so that self.server.clients is updated
+        time.sleep(0.1)
+
+    def tearDown(self):
+        self.remote_bus.shutdown()
+        self.real_bus.shutdown()
+
+    def test_initialization(self):
+        self.assertEqual(self.remote_bus.channel_info,
+                         '%s on localhost:54700' % self.real_bus.channel_info)
+        self.assertEqual(self.server.clients[-1].bitrate, 125000)
+
+        # Test to create a new bus with filters
+        can_filters = [
+            {'can_id': 0x12, 'can_mask': 0xFF},
+            {'can_id': 0x13, 'can_mask': 0xFF}
+        ]
+        bus = can.interface.Bus('localhost:54700',
+                                bustype='remote',
+                                bitrate=1000000,
+                                can_filters=can_filters)
+        # Wait some time so that self.server.clients is updated
+        time.sleep(0.1)
+        self.assertEqual(self.server.clients[-1].can_filters, can_filters)
+        self.assertEqual(self.server.clients[-1].bitrate, 1000000)
+        bus.shutdown()
+
+    def test_send(self):
+        std_msg = can.Message(arbitration_id=0x100, extended_id=False,
+                              data=[1, 2, 3, 4])
+        ext_msg = can.Message(arbitration_id=0xabcdef, extended_id=True,
+                           data=[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
+        self.remote_bus.send(std_msg)
+        self.remote_bus.send(ext_msg)
+        msg1_on_remote = self.real_bus.recv(5)
+        msg2_on_remote = self.real_bus.recv(5)
+        self.assertEqual(msg1_on_remote, std_msg)
+        self.assertEqual(msg2_on_remote, ext_msg)
+
+    def test_recv(self):
+        empty_msg = can.Message()
+        self.real_bus.send(empty_msg)
+        msg_received = self.remote_bus.recv(2)
+        self.assertIsNotNone(msg_received)
+        self.assertEqual(msg_received, empty_msg)
+
+    def test_send_failure(self):
+        self.server.clients[-1].bus.send = raise_error
+        msg = can.Message()
+        with self.assertRaisesRegexp(can.CanError, 'Transmission to CAN failed'):
+            self.remote_bus.send(msg)
+
+    def test_recv_failure(self):
+        self.server.clients[-1].bus.recv = raise_error
+        with self.assertRaisesRegexp(can.CanError, 'This is some error'):
+            self.remote_bus.recv(5)
+
+    def _test_cyclic(self):
+        can.rc['interface'] = 'remote'
+        can.rc['channel'] = 'localhost:54700'
+        msg = can.Message(arbitration_id=0xabcdef,
+                          data=[1, 2, 3, 4, 5, 6, 7, 8])
+        task = can.interfaces.remote.CyclicSendTask('localhost:54700', msg, 0.1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is pull request adds a special kind of interface which acts like a TCP/IP bridge between the application using python-can and a server which handles the physical interface on a different computer.

I think it's working pretty well now after I fixed an issue with closing the connection correctly.

The cyclic transmit API has not been fully implemented mostly because it doesn't fit well with backends other than socketcan. I think after #80 has been fixed, I can continue working on supporting that part.

I think it would be a nice addition to 2.0.

[Original pull request on Bitbucket](https://bitbucket.org/hardbyte/python-can/pull-requests/27/).