### PR TITLE
Store exception from Notifier thread

### DIFF
--- a/can/notifier.py
+++ b/can/notifier.py
@@ -1,8 +1,4 @@
 import threading
-try:
-    import queue
-except ImportError:
-    import Queue as queue
 
 
 class Notifier(object):
@@ -18,6 +14,8 @@ class Notifier(object):
         self.listeners = listeners
         self.bus = bus
         self.timeout = timeout
+        #: Exception raised in thread
+        self.exception = None
 
         self.running = threading.Event()
         self.running.set()
@@ -35,11 +33,15 @@ class Notifier(object):
             self._reader.join(self.timeout + 0.1)
 
     def rx_thread(self):
-        while self.running.is_set():
-            msg = self.bus.recv(self.timeout)
-            if msg is not None:
-                for callback in self.listeners:
-                    callback(msg)
-
-        for listener in self.listeners:
-            listener.stop()
+        try:
+            while self.running.is_set():
+                msg = self.bus.recv(self.timeout)
+                if msg is not None:
+                    for callback in self.listeners:
+                        callback(msg)
+        except Exception as exc:
+            self.exception = exc
+            raise
+        finally:
+            for listener in self.listeners:
+                listener.stop()


### PR DESCRIPTION
Currently the Notifier will just crash silently if an exception occurs during `.read()` or in any of the listeners without any means for the main thread to get any information.

This pull request will save the exception to `notifier.exception`.