### PR TITLE
Use entry points for scripts

### DIFF
--- a/can/interfaces/remote/__main__.py
+++ b/can/interfaces/remote/__main__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import logging
-logging.basicConfig(format='%(asctime)-15s %(message)s')
+logging.basicConfig(format='%(asctime)-15s %(message)s', level=logging.INFO)
 import argparse
 import can
 from can.interfaces import remote
@@ -56,7 +56,7 @@ def main():
     except KeyboardInterrupt:
         pass
     logging.info("Closing server")
-    server.shutdown()
+    server.server_close()
 
 
 if __name__ == "__main__":

--- a/can/io/__init__.py
+++ b/can/io/__init__.py
@@ -3,74 +3,10 @@ Read and Write CAN bus messages using a range of Readers
 and Writers based off the file extension.
 """
 
+from .logger import Logger
+from .player import LogReader
 from .asc import ASCWriter
 from .blf import BLFReader, BLFWriter
 from .csv import CSVWriter
 from .sqlite import SqlReader, SqliteWriter
 from .stdout import Printer
-
-
-class Logger(object):
-    """
-    Logs CAN messages to a file.
-
-    The format is determined from the file format which can be one of:
-      * .asc: :class:`can.ASCWriter`
-      * .blf :class:`can.BLFWriter`
-      * .csv: :class:`can.CSVWriter`
-      * .db: :class:`can.SqliteWriter`
-      * other: :class:`can.Printer`
-
-    Note this class itself is just a dispatcher,
-    an object that inherits from Listener will
-    be created when instantiating this class.
-    """
-
-    @classmethod
-    def __new__(cls, other, filename):
-        if not filename:
-            return Printer()
-        elif filename.endswith(".asc"):
-            return ASCWriter(filename)
-        elif filename.endswith(".blf"):
-            return BLFWriter(filename)
-        elif filename.endswith(".csv"):
-            return CSVWriter(filename)
-        elif filename.endswith(".db"):
-            return SqliteWriter(filename)
-        else:
-            return Printer(filename)
-
-
-class LogReader(object):
-    """
-    Replay logged CAN messages from a file.
-
-    The format is determined from the file format which can be one of:
-      * .asc
-      * .blf
-      * .csv
-      * .db
-
-    Exposes a simple iterator interface, to use simply:
-
-        >>> for m in LogReader(my_file):
-        ...     print(m)
-
-    Note there are no time delays, if you want to reproduce
-    the measured delays between messages look at the
-    :class:`can.util.MessageSync` class.
-    """
-
-    @classmethod
-    def __new__(cls, other, filename):
-        if filename.endswith(".asc"):
-            raise NotImplemented
-        #     return ASCReader(filename)
-        if filename.endswith(".blf"):
-            return BLFReader(filename)
-        if filename.endswith(".csv"):
-            raise NotImplemented
-        #     return CSVReader(filename)
-        if filename.endswith(".db"):
-            return SqlReader(filename)

--- a/can/util.py
+++ b/can/util.py
@@ -149,45 +149,6 @@ def choose_socketcan_implementation():
             raise Exception(msg)
 
 
-class MessageSync:
-
-    def __init__(self, messages, timestamps=True, gap=0.0001, skip=60):
-        """
-
-        :param messages: An iterable of :class:`can.Message` instances.
-        :param timestamps: Use the messages' timestamps.
-        :param gap: Minimum time between sent messages
-        :param skip: Skip periods of inactivity greater than this.
-        """
-        self.raw_messages = messages
-        self.timestamps = timestamps
-        self.gap = gap
-        self.skip = skip
-
-    def __iter__(self):
-        log.debug("Iterating over messages at real speed")
-        playback_start_time = time.time()
-        recorded_start_time = None
-
-        for m in self.raw_messages:
-            if recorded_start_time is None:
-                recorded_start_time = m.timestamp
-
-            if self.timestamps:
-                # Work out the correct wait time
-                now = time.time()
-                current_offset = now - playback_start_time
-                recorded_offset_from_start = m.timestamp - recorded_start_time
-                remaining_gap = recorded_offset_from_start - current_offset
-
-                sleep_period = max(self.gap, min(self.skip, remaining_gap))
-            else:
-                sleep_period = self.gap
-
-            time.sleep(sleep_period)
-            yield m
-
-
 def set_logging_level(level_name=None):
     """Set the logging level for the "can" logger.
     Expects one of: 'critical', 'error', 'warning', 'info', 'debug', 'subdebug'

--- a/doc/bin.rst
+++ b/doc/bin.rst
@@ -35,14 +35,14 @@ Command line help (``--help``)::
                             Which backend do you want to use?
 
 
-can_server.py
--------------
+canserver
+---------
 
 Command line help (``--help``)::
 
-      usage: can_server.py [-h] [-v] [-c CHANNEL]
-                          [-i {pcan,remote,ixxat,socketcan_ctypes,virtual,usb2can,nican,serial,kvaser,socketcan,socketcan_native}]
-                          [-p PORT]
+      usage: canserver [-h] [-v] [-c CHANNEL]
+                      [-i {pcan,remote,ixxat,socketcan_ctypes,virtual,usb2can,nican,serial,kvaser,socketcan,socketcan_native}]
+                      [-b BITRATE] [-H HOST] [-p PORT]
 
       Remote CAN server
 
@@ -55,9 +55,15 @@ Command line help (``--help``)::
                               For example with the serial interface the channel
                               might be a rfcomm device: "/dev/rfcomm0" With the
                               socketcan interfaces valid channel examples include:
-                              "can0", "vcan0"
+                              "can0", "vcan0". The server will only serve this
+                              channel. Start additional servers at different ports
+                              to share more channels.
         -i {pcan,remote,ixxat,socketcan_ctypes,virtual,usb2can,nican,serial,kvaser,socketcan,socketcan_native}, --interface {pcan,remote,ixxat,socketcan_ctypes,virtual,usb2can,nican,serial,kvaser,socketcan,socketcan_native}
                               Specify the backend CAN interface to use. If left
                               blank, fall back to reading from configuration files.
+        -b BITRATE, --bitrate BITRATE
+                              Force to use a specific bitrate. This will override
+                              any requested bitrate by the clients.
+        -H HOST, --host HOST  Host to listen to (default 0.0.0.0).
         -p PORT, --port PORT  TCP port to listen on (default 54701).
 

--- a/doc/bin.rst
+++ b/doc/bin.rst
@@ -3,42 +3,82 @@ Scripts
 
 The following scripts are installed along with python-can.
 
-can_logger.py
--------------
+canlogger
+---------
 
-Command line help (``--help``)::
+Command line help (``canlogger --help`` or ``python -m can.io.logger --help``)::
 
-    usage: can_logger.py [-h] [-f LOG_FILE] [-v] [-i {socketcan,kvaser,serial,ixxat}]
-                         channel ...
+    usage: canlogger [-h] [-f LOG_FILE] [-v] [-c CHANNEL]
+                    [-i {pcan,remote,ixxat,socketcan_ctypes,virtual,usb2can,nican,serial,kvaser,socketcan,socketcan_native}]
+                    [--filter ...]
 
     Log CAN traffic, printing messages to stdout or to a given file
-
-    positional arguments:
-      channel               Most backend interfaces require some sort of channel.
-                            For example with the serial interface the channel
-                            might be a rfcomm device: /dev/rfcomm0 Other channel
-                            examples are: can0, vcan0
-      filter                Comma separated filters can be specified for the given
-                            CAN interface: <can_id>:<can_mask> (matches when
-                            <received_can_id> & mask == can_id & mask)
-                            <can_id>~<can_mask> (matches when <received_can_id> &
-                            mask != can_id & mask)
 
     optional arguments:
       -h, --help            show this help message and exit
       -f LOG_FILE, --file_name LOG_FILE
                             Path and base log filename, extension can be .txt,
-                            .csv, .db, .npz
+                            .asc, .csv, .db, .npz
       -v                    How much information do you want to see at the command
                             line? You can add several of these e.g., -vv is DEBUG
-      -i {socketcan,kvaser,serial,ixxat}, --interface {socketcan,kvaser,serial,ixxat}
-                            Which backend do you want to use?
+      -c CHANNEL, --channel CHANNEL
+                            Most backend interfaces require some sort of channel.
+                            For example with the serial interface the channel
+                            might be a rfcomm device: "/dev/rfcomm0" With the
+                            socketcan interfaces valid channel examples include:
+                            "can0", "vcan0"
+      -i {pcan,remote,ixxat,socketcan_ctypes,virtual,usb2can,nican,serial,kvaser,socketcan,socketcan_native}, --interface {pcan,remote,ixxat,socketcan_ctypes,virtual,usb2can,nican,serial,kvaser,socketcan,socketcan_native}
+                            Specify the backend CAN interface to use. If left
+                            blank, fall back to reading from configuration files.
+      --filter ...          Comma separated filters can be specified for the given
+                            CAN interface: <can_id>:<can_mask> (matches when
+                            <received_can_id> & mask == can_id & mask)
+                            <can_id>~<can_mask> (matches when <received_can_id> &
+                            mask != can_id & mask)
+
+
+canplayer
+---------
+
+Command line help (``canplayer --help`` or ``python -m can.io.player --help``)::
+
+    usage: canplayer [-h] [-f LOG_FILE] [-v] [-c CHANNEL]
+                    [-i {pcan,remote,ixxat,socketcan_ctypes,virtual,usb2can,nican,serial,kvaser,socketcan,socketcan_native}]
+                    [--ignore-timestamps] [-g GAP] [-s SKIP]
+                    input-file
+
+    Replay CAN traffic
+
+    positional arguments:
+      input-file            The file to replay. Supported types: .db
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -f LOG_FILE, --file_name LOG_FILE
+                            Path and base log filename, extension can be .txt,
+                            .asc, .csv, .db, .npz
+      -v                    Also print can frames to stdout. You can add several
+                            of these to enable debugging
+      -c CHANNEL, --channel CHANNEL
+                            Most backend interfaces require some sort of channel.
+                            For example with the serial interface the channel
+                            might be a rfcomm device: "/dev/rfcomm0" With the
+                            socketcan interfaces valid channel examples include:
+                            "can0", "vcan0"
+      -i {pcan,remote,ixxat,socketcan_ctypes,virtual,usb2can,nican,serial,kvaser,socketcan,socketcan_native}, --interface {pcan,remote,ixxat,socketcan_ctypes,virtual,usb2can,nican,serial,kvaser,socketcan,socketcan_native}
+                            Specify the backend CAN interface to use. If left
+                            blank, fall back to reading from configuration files.
+      --ignore-timestamps   Ignore timestamps (send all frames immediately with
+                            minimum gap between frames)
+      -g GAP, --gap GAP     <ms> minimum time between replayed frames
+      -s SKIP, --skip SKIP  <s> skip gaps greater than 's' seconds
+
 
 
 canserver
 ---------
 
-Command line help (``--help``)::
+Command line help (``canserver --help`` or ``python -m can.interfaces.remote --help``)::
 
       usage: canserver [-h] [-v] [-c CHANNEL]
                       [-i {pcan,remote,ixxat,socketcan_ctypes,virtual,usb2can,nican,serial,kvaser,socketcan,socketcan_native}]

--- a/doc/interfaces/remote.rst
+++ b/doc/interfaces/remote.rst
@@ -17,11 +17,16 @@ servers must be started on different ports.
 
 Start a server using default interface and channel::
 
-    $ can_server.py
+    $ canserver
 
 Specify interface, channel and port number explicitly::
 
-    $ can_server.py --interface kvaser --channel 0 --port 54702
+    $ canserver --interface kvaser --channel 0 --port 54702
+
+It can also be started as a module::
+
+    $ python -m can.interfaces.remote
+
 
 Client
 ------
@@ -65,14 +70,21 @@ The server uses the following classes to implement the connections.
 
 .. autoclass:: can.interfaces.remote.RemoteServer
 
-   .. method:: serve_forever
+   .. method:: serve_forever(poll_interval=0.5)
 
       Start listening for incoming connections.
 
    .. method:: shutdown
 
-      Stop the server.
+      Stops the serve_forever loop.
 
+      Blocks until the loop has finished. This must be called while
+      serve_forever() is running in another thread, or it will
+      deadlock.
+
+   .. method:: server_close
+
+      Clean-up the server.
 
 .. autoclass:: can.interfaces.remote.server.ClientBusConnection
 

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,11 @@ setup(
 
     scripts=[
         "./bin/can_logger.py",
-        "./bin/can_player.py",
-        "./bin/can_server.py"
+        "./bin/can_player.py"
     ],
+    entry_points={"console_scripts": [
+        "canserver = can.interfaces.remote.__main__:main"
+    ]},
 
     # Tests can be run using `python setup.py test`
     test_suite="nose.collector",

--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,9 @@ setup(
         "": ["CONTRIBUTORS.txt", "LICENSE.txt"],
         "doc": ["*.*"]
     },
-
-    scripts=[
-        "./bin/can_logger.py",
-        "./bin/can_player.py"
-    ],
     entry_points={"console_scripts": [
+        "canlogger = can.io.logger:main",
+        "canplayer = can.io.player:main",
         "canserver = can.interfaces.remote.__main__:main"
     ]},
 


### PR DESCRIPTION
Proposal to install the CAN remote server script as a proper executable instead.

Could perhaps be nice to have all scripts like this since it makes starting the tools more consistent on all platforms.