### PR TITLE
Fix wrong channel value used to call PCANBasic API (#125)

### DIFF
--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -125,7 +125,7 @@ class PcanBus(BusABC):
 
         :return: The status code. See values in pcan_constants.py
         """
-        return self.m_objPCANBasic.GetStatus(self.channel_info)
+        return self.m_objPCANBasic.GetStatus(self.m_PcanHandle)
 
     def status_is_ok(self):
         """
@@ -137,7 +137,7 @@ class PcanBus(BusABC):
     def reset(self):
         # Command the PCAN driver to reset the bus after an error.
 
-        status = self.m_objPCANBasic.Reset(self.channel_info)
+        status = self.m_objPCANBasic.Reset(self.m_PcanHandle)
 
         return status == PCAN_ERROR_OK
 
@@ -224,7 +224,7 @@ class PcanBus(BusABC):
         Turn on or off flashing of the device's LED for physical
         identification purposes.
         """
-        self.m_objPCANBasic.SetValue(self.channel_info, PCAN_CHANNEL_IDENTIFYING, bool(flash))
+        self.m_objPCANBasic.SetValue(self.m_PcanHandle, PCAN_CHANNEL_IDENTIFYING, bool(flash))
 
     def shutdown(self):
         self.m_objPCANBasic.Uninitialize(self.m_PcanHandle)


### PR DESCRIPTION
It seems there was confusion with the attributes `channel_info` and `m_PcanHandle` used in the pcan interface. So, I replaced each call to the PCANBasic object using `channel_info` with `m_PcanHandle`.

Once applied, the `.status()` method returns no error:

```python
>>> from can.interfaces.pcan import PcanBus
>>> bus = PcanBus("PCAN_USBBUS1")
>>> bus.status()
0
```