### PR TITLE
Add timeout argument to send()

### DIFF
--- a/can/bus.py
+++ b/can/bus.py
@@ -56,8 +56,9 @@ class BusABC(object):
 
         :param msg: A :class:`can.Message` object.
         :param float timeout:
-            If given, wait for message to be ACK:ed.
-            Might not be supported by the interface.
+            If > 0, wait up to this many seconds for message to be ACK:ed.
+            If timeout is exceeded, an exception will be raised.
+            Might not be supported by all interfaces.
 
         :raise: :class:`can.CanError`
             if the message could not be written.

--- a/can/bus.py
+++ b/can/bus.py
@@ -50,11 +50,14 @@ class BusABC(object):
         raise NotImplementedError("Trying to read from a write only bus?")
 
     @abc.abstractmethod
-    def send(self, msg):
+    def send(self, msg, timeout=None):
         """Transmit a message to CAN bus.
         Override this method to enable the transmit path.
 
         :param msg: A :class:`can.Message` object.
+        :param float timeout:
+            If given, wait for message to be ACK:ed.
+            Might not be supported by the interface.
 
         :raise: :class:`can.CanError`
             if the message could not be written.

--- a/can/interfaces/nican.py
+++ b/can/interfaces/nican.py
@@ -230,7 +230,7 @@ class NicanBus(BusABC):
                       data=raw_msg.data[:dlc])
         return msg
 
-    def send(self, msg):
+    def send(self, msg, timeout=None):
         """
         Send a message to NI-CAN.
 
@@ -257,7 +257,7 @@ class NicanBus(BusABC):
         # bit overkill at the moment.
         #state = ctypes.c_ulong()
         #nican.ncWaitForState(
-        #    self.handle, NC_ST_WRITE_SUCCESS, 10, ctypes.byref(state))
+        #    self.handle, NC_ST_WRITE_SUCCESS, int(timeout * 1000), ctypes.byref(state))
 
     def flush_tx_buffer(self):
         """

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -190,7 +190,7 @@ class PcanBus(BusABC):
 
         return rx_msg
 
-    def send(self, msg):
+    def send(self, msg, timeout=None):
         if msg.id_type:
             msgType = PCAN_MESSAGE_EXTENDED
         else:

--- a/can/interfaces/remote/client.py
+++ b/can/interfaces/remote/client.py
@@ -91,7 +91,7 @@ class RemoteBus(can.bus.BusABC):
             raise event.exc
         return None
 
-    def send(self, msg):
+    def send(self, msg, timeout=None):
         """Transmit a message to CAN bus.
 
         :param can.Message msg: A Message object.

--- a/can/interfaces/serial/serial_can.py
+++ b/can/interfaces/serial/serial_can.py
@@ -36,7 +36,7 @@ class SerialBus(BusABC):
             self.ser = serial.Serial(channel, baudrate=115200, timeout=0.1)
         super(SerialBus, self).__init__(*args, **kwargs)
 
-    def send(self, msg):
+    def send(self, msg, timeout=None):
         raise NotImplementedError("This serial interface doesn't support transmit.")
 
     def recv(self, timeout=None):

--- a/can/interfaces/socketcan/socketcan_ctypes.py
+++ b/can/interfaces/socketcan/socketcan_ctypes.py
@@ -51,12 +51,12 @@ class SocketcanCtypes_Bus(BusABC):
         self.socket = createSocket()
 
         log.debug("Result of createSocket was %d", self.socket)
-        
+
         # Add any socket options such as can frame filters
         if 'can_filters' in kwargs and len(kwargs['can_filters']) > 0:
             log.debug("Creating a filtered can bus")
             self.set_filters(kwargs['can_filters'])
-        
+
         error = bindSocket(self.socket, channel)
 
         if receive_own_messages:
@@ -86,7 +86,7 @@ class SocketcanCtypes_Bus(BusABC):
         # TODO Is this serious enough to raise a CanError exception?
         if res != 0:
             log.error('Setting filters failed: ' + str(res))
-    
+
     def recv(self, timeout=None):
 
         log.debug("Trying to read a msg")
@@ -117,7 +117,7 @@ class SocketcanCtypes_Bus(BusABC):
 
         return rx_msg
 
-    def send(self, msg):
+    def send(self, msg, timeout=None):
         frame = _build_can_frame(msg)
         bytes_sent = libc.write(self.socket, ctypes.byref(frame), ctypes.sizeof(frame))
         if bytes_sent == -1:

--- a/can/interfaces/socketcan/socketcan_native.py
+++ b/can/interfaces/socketcan/socketcan_native.py
@@ -383,7 +383,7 @@ class SocketcanNative_Bus(BusABC):
 
         return rx_msg
 
-    def send(self, msg):
+    def send(self, msg, timeout=None):
         log.debug("We've been asked to write a message to the bus")
         arbitration_id = msg.arbitration_id
         if msg.id_type:

--- a/can/interfaces/usb2can/usb2canInterface.py
+++ b/can/interfaces/usb2can/usb2canInterface.py
@@ -123,9 +123,12 @@ class Usb2canBus(BusABC):
 
         self.handle = self.can.open(connector, enable_flags)
 
-    def send(self, msg):
+    def send(self, msg, timeout=None):
         tx = message_convert_tx(msg)
-        self.can.send(self.handle, byref(tx))
+        if timeout:
+            self.can.blocking_send(self.handle, byref(tx), int(timeout * 1000))
+        else:
+            self.can.send(self.handle, byref(tx))
 
     def recv(self, timeout=None):
 

--- a/can/interfaces/virtual.py
+++ b/can/interfaces/virtual.py
@@ -12,7 +12,7 @@ echoed back to the same bus.
 import logging
 import time
 try:
-    import queue as queue
+    import queue
 except ImportError:
     import Queue as queue
 from can.bus import BusABC
@@ -49,7 +49,7 @@ class VirtualBus(BusABC):
         logger.log(9, 'Received message:\n%s', msg)
         return msg
 
-    def send(self, msg):
+    def send(self, msg, timeout=None):
         msg.timestamp = time.time()
         # Add message to all listening on this channel
         for bus_queue in self.channel:

--- a/test/test_kvaser.py
+++ b/test/test_kvaser.py
@@ -15,7 +15,7 @@ except ImportError:
 
 
 class KvaserTest(unittest.TestCase):
-    
+
     def setUp(self):
         canlib.canGetNumberOfChannels = Mock(return_value=1)
         canlib.canOpenChannel = Mock(return_value=0)
@@ -27,7 +27,8 @@ class KvaserTest(unittest.TestCase):
         canlib.canSetBusOutputControl = Mock()
         canlib.canGetChannelData = Mock()
         canlib.canSetAcceptanceFilter = Mock()
-        canlib.canWriteWait = self.canWriteWait
+        canlib.canWriteSync = Mock()
+        canlib.canWrite = self.canWrite
         canlib.canReadWait = self.canReadWait
 
         self.msg = {}
@@ -160,7 +161,7 @@ class KvaserTest(unittest.TestCase):
         self.assertEqual(msg.id_type, False)
         self.assertSequenceEqual(msg.data, [100, 101])
 
-    def canWriteWait(self, handle, arb_id, buf, dlc, flags, timeout):
+    def canWrite(self, handle, arb_id, buf, dlc, flags):
         self.msg['arb_id'] = arb_id
         self.msg['dlc'] = dlc
         self.msg['flags'] = flags


### PR DESCRIPTION
Today, all interfaces except Kvaser queue messages to be sent, but never block. Kvaser, IXXAT and USB2CAN have support for blocking until the message has been ACK:ed. This behaviour could sometimes be desirable since it gives you an indication that something is wrong with the CAN bus or you are using the wrong bitrate.

This proposal adds a timeout argument to the `send()` method which _can_ be used by the interface to do a blocking transmission. Since a timeout of 0 makes no sense here as opposed to the `recv()` method, I suggest to only block if timeout is > 0, otherwise it should be queued as normal which should be the default.

Unfortunately I can only test this on Kvaser.