### PR TITLE
Fix USB2CAN recv timeout handling

### DIFF
--- a/can/interfaces/usb2can/usb2canInterface.py
+++ b/can/interfaces/usb2can/usb2canInterface.py
@@ -105,7 +105,7 @@ class Usb2canBus(BusABC):
         elif channel is not None:
             deviceID = channel
         else:
-            from can.interfaces.usb2can.usb2canSerialFindWin import serial
+            from can.interfaces.usb2can.serial_selector import serial
             deviceID = serial()
 
         # set baudrate in kb/s from bitrate

--- a/can/interfaces/usb2can/usb2canInterface.py
+++ b/can/interfaces/usb2can/usb2canInterface.py
@@ -131,16 +131,18 @@ class Usb2canBus(BusABC):
 
         messagerx = CanalMsg()
 
-        if timeout is None:
+        if timeout == 0:
             status = self.can.receive(self.handle, byref(messagerx))
 
         else:
-            time = c_ulong
-            time = timeout
+            time = 0 if timeout is None else int(timeout * 1000)
             status = self.can.blocking_receive(self.handle, byref(messagerx), time)
 
-        if status is 0:
+        if status == 0:
             rx = message_convert_rx(messagerx)
+        elif status == 19 or status == 32:
+            # CANAL_ERROR_RCV_EMPTY or CANAL_ERROR_TIMEOUT
+            rx = None
         else:
             log.error('Canal Error %s', status)
             rx = None


### PR DESCRIPTION
USB2CAN behaves differently to other interfaces.

- When timeout is `None`, it does not block
- Timeout is given in milliseconds instead of seconds
- An error is logged when no message has been received

This should fix those issues and an import bug.