### PR TITLE
Avoid using polling for PCAN

### DIFF
--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -33,7 +33,6 @@ else:
 
 # Set up logging
 log = logging.getLogger('can.pcan')
-log.setLevel(logging.WARNING)
 
 
 pcan_bitrate_objs = {1000000 : PCAN_BAUD_1M,
@@ -88,7 +87,7 @@ class PcanBus(BusABC):
         if result != PCAN_ERROR_OK:
             raise PcanError(self._get_formatted_error(result))
 
-        if win32event:
+        if win32event is not None:
             self._recv_event = win32event.CreateEvent(None, 0, 0, None)
             result = self.m_objPCANBasic.SetValue(
                 self.m_PcanHandle, PCAN_RECEIVE_EVENT, self._recv_event)
@@ -154,7 +153,7 @@ class PcanBus(BusABC):
         return status == PCAN_ERROR_OK
 
     def recv(self, timeout=None):
-        if win32event:
+        if win32event is not None:
             # We will utilize events for the timeout handling
             timeout_ms = int(timeout * 1000) if timeout is not None else win32event.INFINITE
         elif timeout is not None:
@@ -170,7 +169,7 @@ class PcanBus(BusABC):
         while result is None:
             result = self.m_objPCANBasic.Read(self.m_PcanHandle)
             if result[0] == PCAN_ERROR_QRCVEMPTY:
-                if win32event:
+                if win32event is not None:
                     result = None
                     val = win32event.WaitForSingleObject(self._recv_event, timeout_ms)
                     if val != win32event.WAIT_OBJECT_0:

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -32,8 +32,8 @@ else:
     timeout_clock = time.clock
 
 # Set up logging
-logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger('can.pcan')
+log.setLevel(logging.WARNING)
 
 
 pcan_bitrate_objs = {1000000 : PCAN_BAUD_1M,

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -163,7 +163,7 @@ class PcanBus(BusABC):
         result = None
         while result is None:
             result = self.m_objPCANBasic.Read(self.m_PcanHandle)
-            if result[0] == PCAN_ERROR_QRCVEMPTY or result[0] == PCAN_ERROR_BUSLIGHT or result[0] == PCAN_ERROR_BUSHEAVY:
+            if result[0] == PCAN_ERROR_QRCVEMPTY:
                 if win32event:
                     result = None
                     _timeout = int(timeout * 1000) if timeout is not None else win32event.INFINITE
@@ -175,6 +175,9 @@ class PcanBus(BusABC):
                 else:
                     result = None
                     time.sleep(0.001)
+            elif result[0] & (PCAN_ERROR_BUSLIGHT | PCAN_ERROR_BUSHEAVY):
+                log.warning(self._get_formatted_error(result[0]))
+                return None
             elif result[0] != PCAN_ERROR_OK:
                 raise PcanError(self._get_formatted_error(result[0]))
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -41,24 +41,18 @@ To install ``python-can`` using the Kvaser CANLib SDK as the backend:
 PCAN
 ~~~~
 
-To use the PCAN-Basic API as the backend (which has only been tested
-with Python 2.7):
-
-1. Download the latest version of the `PCAN-Basic
-   API <http://www.peak-system.com/Downloads.76.0.html?>`__.
-
-2. Extract ``PCANBasic.dll`` from the Win32 subfolder of the archive or
-   the x64 subfolder depending on whether you have a 32-bit or 64-bit
-   installation of Python.
-
-3. Copy ``PCANBasic.dll`` into the working directory where you will be
-   running your python script. There is probably a way to install the
-   dll properly, but I'm not certain how to do that.
+Download and install the latest driver for your interface from
+`PEAK-System's download page <http://www.peak-system.com/Support.55.0.html?&L=1>`__.
 
 Note that PCANBasic API timestamps count seconds from system startup. To
 convert these to epoch times, the uptime library is used. If it is not
 available, the times are returned as number of seconds from system
 startup. To install the uptime library, run ``pip install uptime``.
+
+This library can take advantage of the `Python for Windows Extensions
+<https://sourceforge.net/projects/pywin32>`__ library if installed.
+It will be used to get notified of new messages instead of
+the CPU intensive polling that will otherwise have be used.
 
 IXXAT
 ~~~~~


### PR DESCRIPTION
Utilize events instead of polling when the [pywin32](https://sourceforge.net/projects/pywin32) or [pypiwin32](https://pypi.python.org/pypi/pypiwin32) package is available.

Fixes #53.