### PR TITLE
Update Configuration Paths

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -28,14 +28,16 @@ Configuration File
 
 On Linux systems the config file is searched in the following paths:
 
-1. ``/etc/can.conf``
-2. ``$HOME/.can``
-3. ``$HOME/.canrc``
+1. ``~/can.conf``
+2. ``/etc/can.conf``
+3. ``$HOME/.can``
+4. ``$HOME/.canrc``
 
 On Windows systems the config file is searched in the following paths:
 
-1. ``can.ini`` (current working directory)
-2. ``$APPDATA/can.ini``
+1. ``~/can.conf``
+2. ``can.ini`` (current working directory)
+3. ``$APPDATA/can.ini``
 
 The configuration file sets the default interface and channel:
 


### PR DESCRIPTION
In  the source, ~/can.conf is checked on both Windows and Linux platforms. I added this to the documentation.