### PR TITLE
Split filtering for standard and extended IDs

### DIFF
--- a/can/bus.py
+++ b/can/bus.py
@@ -28,9 +28,10 @@ class BusABC(object):
             The can interface identifier. Expected type is backend dependent.
 
         :param list can_filters:
-            A list of dictionaries each containing a "can_id" and a "can_mask".
+            A list of dictionaries each containing a "can_id", a "can_mask",
+            and an "extended" key.
 
-            >>> [{"can_id": 0x11, "can_mask": 0x21}]
+            >>> [{"can_id": 0x11, "can_mask": 0x21, "extended": False}]
 
             A filter matches, when ``<received_can_id> & can_mask == can_id & can_mask``
 

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -256,7 +256,6 @@ class IXXATBus(BusABC):
         UniqueHardwareId = config.get('UniqueHardwareId', None)
         rxFifoSize = config.get('rxFifoSize', 16)
         txFifoSize = config.get('txFifoSize', 16)
-        extended = config.get('extended', False)
         # Usually comes as a string from the config file
         channel = int(channel)
 
@@ -319,14 +318,16 @@ class IXXATBus(BusABC):
         if can_filters is not None and len(can_filters):
             log.info("The IXXAT VCI backend is filtering messages")
             # Disable every message coming in
-            _canlib.canControlSetAccFilter(self._control_handle,
-                                           1 if extended else 0,
-                                           constants.CAN_ACC_CODE_NONE,
-                                           constants.CAN_ACC_MASK_NONE)
+            for extended in (0, 1):
+                _canlib.canControlSetAccFilter(self._control_handle,
+                                               extended,
+                                               constants.CAN_ACC_CODE_NONE,
+                                               constants.CAN_ACC_MASK_NONE)
             for can_filter in can_filters:
                 # Whitelist
                 code = int(can_filter['can_id'])
                 mask = int(can_filter['can_mask'])
+                extended = can_filter.get('extended', False)
                 _canlib.canControlAddFilterIds(self._control_handle, 1 if extended else 0, code, mask)
                 rtr = (code & 0x01) and (mask & 0x01)
                 log.info("Accepting ID:%d  MASK:%d RTR:%s", code>>1, mask>>1, "YES" if rtr else "NO")

--- a/can/interfaces/nican.py
+++ b/can/interfaces/nican.py
@@ -159,12 +159,16 @@ class NicanBus(BusABC):
                 can_id = can_filter["can_id"]
                 can_mask = can_filter["can_mask"]
                 logger.info("Filtering on ID 0x%X, mask 0x%X", can_id, can_mask)
-                config.extend([
-                    (NC_ATTR_CAN_COMP_STD, can_id),
-                    (NC_ATTR_CAN_MASK_STD, can_mask),
-                    (NC_ATTR_CAN_COMP_XTD, can_id | NC_FL_CAN_ARBID_XTD),
-                    (NC_ATTR_CAN_MASK_XTD, can_mask)
-                ])
+                if can_filter.get("extended"):
+                    config.extend([
+                        (NC_ATTR_CAN_COMP_XTD, can_id | NC_FL_CAN_ARBID_XTD),
+                        (NC_ATTR_CAN_MASK_XTD, can_mask)
+                    ])
+                else:
+                    config.extend([
+                        (NC_ATTR_CAN_COMP_STD, can_id),
+                        (NC_ATTR_CAN_MASK_STD, can_mask),
+                    ])
 
         if bitrate:
             config.append((NC_ATTR_BAUD_RATE, bitrate))

--- a/can/interfaces/remote/__init__.py
+++ b/can/interfaces/remote/__init__.py
@@ -3,6 +3,6 @@ from .server import RemoteServer
 
 
 # If the protocol changes, increase this number
-PROTOCOL_VERSION = 4
+PROTOCOL_VERSION = 5
 
 DEFAULT_PORT = 54701

--- a/can/interfaces/remote/events.py
+++ b/can/interfaces/remote/events.py
@@ -397,7 +397,7 @@ class FilterConfig(BaseEvent):
     +========+=======+========================================================+
     | 0      | U8    | Number of filters                                      |
     +--------+-------+--------------------------------------------------------+
-    | 1 - 4  | U32   | CAN ID for filter 1                                    |
+    | 1 - 4  | U32   | CAN ID for filter 1 (bit 31 set if extended)           |
     +--------+-------+--------------------------------------------------------+
     | 5 - 8  | U32   | CAN mask for filter 1                                  |
     +--------+-------+--------------------------------------------------------+
@@ -425,8 +425,11 @@ class FilterConfig(BaseEvent):
     def encode(self):
         data = [struct.pack('B', len(self.can_filters))]
         for can_filter in self.can_filters:
+            can_id = can_filter['can_id']
+            if can_filter.get('extended'):
+                can_id |= 0x80000000
             filter_data = self._STRUCT.pack(
-                can_filter['can_id'], can_filter['can_mask'])
+                can_id, can_filter['can_mask'])
             data.append(filter_data)
         return b''.join(data)
 
@@ -438,7 +441,11 @@ class FilterConfig(BaseEvent):
             for i in range(nof_filters):
                 offset = 1 + i * cls._STRUCT.size
                 can_id, can_mask = cls._STRUCT.unpack_from(buf, offset)
-                can_filters.append({'can_id': can_id, 'can_mask': can_mask})
+                extended = bool(can_id & 0x80000000)
+                can_filters.append({
+                    'can_id': can_id & 0x1FFFFFFF,
+                    'can_mask': can_mask,
+                    'extended': extended})
         except struct.error:
             raise NeedMoreDataError()
 

--- a/can/interfaces/socketcan/socketcan_common.py
+++ b/can/interfaces/socketcan/socketcan_common.py
@@ -4,18 +4,24 @@ Defines common socketcan functions.
 """
 import struct
 
+from can.interfaces.socketcan.socketcan_constants import CAN_EFF_FLAG
+
 
 def pack_filters(can_filters=None):
     if can_filters is None:
         # Pass all messages
         can_filters = [{
             'can_id': 0,
-            'can_mask': 0
+            'can_mask': 0,
+            'extended': False
         }]
 
     can_filter_fmt = "={}I".format(2 * len(can_filters))
     filter_data = []
     for can_filter in can_filters:
-        filter_data.append(can_filter['can_id'])
+        can_id = can_filter['can_id']
+        if can_filter.get('extended'):
+            can_id |= CAN_EFF_FLAG
+        filter_data.append(can_id)
         filter_data.append(can_filter['can_mask'])
     return struct.pack(can_filter_fmt, *filter_data)

--- a/test/remote_test.py
+++ b/test/remote_test.py
@@ -49,8 +49,8 @@ class EventsTestCase(unittest.TestCase):
 
     def test_filter_config(self):
         event1 = events.FilterConfig([
-            {'can_id': 0x123, 'can_mask': 0xFFF},
-            {'can_id': 0x001, 'can_mask': 0x00F}
+            {'can_id': 0x1FFFFFFF, 'can_mask': 0x1FFFFFFF, 'extended': True},
+            {'can_id': 0x001, 'can_mask': 0x00F, 'extended': False}
         ])
         buf = event1.encode()
         event2 = events.FilterConfig.from_buffer(buf)
@@ -187,8 +187,8 @@ class RemoteBusTestCase(unittest.TestCase):
 
         # Test to create a new bus with filters
         can_filters = [
-            {'can_id': 0x12, 'can_mask': 0xFF},
-            {'can_id': 0x13, 'can_mask': 0xFF}
+            {'can_id': 0x12, 'can_mask': 0xFF, 'extended': False},
+            {'can_id': 0x13, 'can_mask': 0xFF, 'extended': True}
         ]
         bus = can.interface.Bus('127.0.0.1:54700',
                                 bustype='remote',

--- a/test/test_kvaser.py
+++ b/test/test_kvaser.py
@@ -65,12 +65,10 @@ class KvaserTest(unittest.TestCase):
         # One filter, will be handled by canlib
         canlib.canSetAcceptanceFilter.reset_mock()
         self.bus.set_filters([
-            {'can_id': 0x8, 'can_mask': 0xff}
+            {'can_id': 0x8, 'can_mask': 0xff, 'extended': True}
         ])
         expected_args = [
-            ((0, 0x8, 0xff, 0),),       # Enable filtering STD on read handle
             ((0, 0x8, 0xff, 1),),       # Enable filtering EXT on read handle
-            ((0, 0x8, 0xff, 0),),       # Enable filtering STD on write handle
             ((0, 0x8, 0xff, 1),),       # Enable filtering EXT on write handle
         ]
         self.assertEqual(canlib.canSetAcceptanceFilter.call_args_list,
@@ -91,20 +89,6 @@ class KvaserTest(unittest.TestCase):
         ]
         self.assertEqual(canlib.canSetAcceptanceFilter.call_args_list,
                          expected_args)
-        self.assertEqual(self.bus.sw_filters, multiple_filters)
-
-    def test_sw_filtering(self):
-        self.bus.set_filters([
-            {'can_id': 0x8, 'can_mask': 0xff},
-            {'can_id': 0x9, 'can_mask': 0xffff}
-        ])
-        self.assertTrue(self.bus._is_filter_match(0x8))
-        self.assertTrue(self.bus._is_filter_match(0x9))
-        self.assertTrue(self.bus._is_filter_match(0x108))
-        self.assertTrue(self.bus._is_filter_match(0x10009))
-        self.assertFalse(self.bus._is_filter_match(0x10))
-        self.assertFalse(self.bus._is_filter_match(0x0))
-        self.assertFalse(self.bus._is_filter_match(0x109))
 
     def test_send_extended(self):
         msg = can.Message(


### PR DESCRIPTION
Allows for filtering differently on extended and standard IDs. The default is to filter on standard IDs if the "extended" key is not specified so it is fairly backwards compatible but not fully.

Need help to review the changes made to the different interfaces. @cowo78, could you check if the IXXAT changes are OK?

Update socketcan, kvaser, ixxat, nican, and remote filter configuration.
Remove SW filtering in kvaser and neovi. If it is needed at all it should be implemented in a way that all interfaces that cannot do HW filtering for some reason can use it.
Fixes issue #147.