### PR TITLE
changing default argument on socketcan_ctypes channel name

### DIFF
--- a/can/interfaces/socketcan/socketcan_ctypes.py
+++ b/can/interfaces/socketcan/socketcan_ctypes.py
@@ -39,7 +39,7 @@ class SocketcanCtypes_Bus(BusABC):
     channel_info = "ctypes socketcan channel"
 
     def __init__(self,
-                 channel=0,
+                 channel='vcan0',
                  receive_own_messages=False,
                  *args, **kwargs):
         """


### PR DESCRIPTION
The default value for the channel in the documentation, "channel=0", results in an error because these lines:

https://github.com/hardbyte/python-can/blob/develop/can/interfaces/socketcan/socketcan_ctypes.py#L247
https://github.com/hardbyte/python-can/blob/develop/can/interfaces/socketcan/socketcan_ctypes.py#L281

assume that the channel name is a string, not an integer. 

I suggest that this default variable be "vcan0", as suggested by the existing docstring.
