### PR TITLE
Add asyncio interfaces

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,4 @@
+requirements_file: doc/requirements.txt
+
+python:
+    version: 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ python:
   - "2.7"
   - "pypy"
   - "pypy3"
+  - "3.3"
   - "3.4"
   - "3.5"
-  - "3.5-dev" # 3.5 development branch
-  - "3.6-dev" # 3.6 development branch
+  - "3.6"
   - "nightly" # currently points to 3.7-dev
 
 # command to run tests

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -345,7 +345,7 @@ class IXXATBus(BusABC):
             else:
                 _canlib.canChannelReadMessage(self._channel_handle, 0, ctypes.byref(self._message))
 
-        super(IXXATBus, self).__init__()
+        super(IXXATBus, self).__init__(**config)
 
     def _inWaiting(self):
         try:

--- a/can/interfaces/kvaser/canlib.py
+++ b/can/interfaces/kvaser/canlib.py
@@ -375,7 +375,7 @@ class KvaserBus(BusABC):
         '''
         self.pc_time_offset = None
 
-        super(KvaserBus, self).__init__()
+        super(KvaserBus, self).__init__(**config)
 
     def set_filters(self, can_filters=None):
         """Apply filtering to all messages received by this Bus.

--- a/can/interfaces/neovi_api/neovi_api.py
+++ b/can/interfaces/neovi_api/neovi_api.py
@@ -72,6 +72,7 @@ class NeoVIBus(BusABC):
 
         self.network = int(channel) if channel is not None else None
         self.device.subscribe_to(self._rx_buffer, network=self.network)
+        super(NeoVIBus, self).__init__(**config)
 
     def __del__(self):
         self.shutdown()

--- a/can/interfaces/nican.py
+++ b/can/interfaces/nican.py
@@ -184,6 +184,8 @@ class NicanBus(BusABC):
         self.handle = ctypes.c_ulong()
         nican.ncOpenObject(channel, ctypes.byref(self.handle))
 
+        super(NicanBus, self).__init__(**kwargs)
+
     def recv(self, timeout=None):
         """
         Read a message from NI-CAN.

--- a/can/interfaces/socketcan/socketcan_native.py
+++ b/can/interfaces/socketcan/socketcan_native.py
@@ -10,6 +10,11 @@ import select
 import threading
 import socket
 import struct
+try:
+    import asyncio
+except ImportError:
+    asyncio = None
+import textwrap
 from collections import namedtuple
 
 import errno
@@ -118,6 +123,17 @@ def build_bcm_transmit_header(can_id, count, initial_period, subsequent_period):
 def dissect_can_frame(frame):
     can_id, can_dlc, data = struct.unpack(can_frame_fmt, frame)
     return can_id, can_dlc, data[:can_dlc]
+
+
+def convert_packet_to_message(packet):
+    return Message(timestamp=packet.timestamp,
+                   arbitration_id=packet.arbitration_id,
+                   extended_id=packet.is_extended_frame_format,
+                   is_remote_frame=packet.is_remote_transmission_request,
+                   is_error_frame=packet.is_error_frame,
+                   dlc=packet.dlc,
+                   data=packet.data
+                   )
 
 
 def create_bcm_socket(channel):
@@ -278,6 +294,7 @@ def createSocket(can_protocol=None):
         socket_type = socket.SOCK_DGRAM
 
     sock = socket.socket(socket.PF_CAN, socket_type, can_protocol)
+    sock.setblocking(False)
 
     log.info('Created a socket')
 
@@ -307,7 +324,7 @@ _CanPacket = namedtuple('_CanPacket',
                          'data'])
 
 
-def capturePacket(sock):
+def capturePacket(sock, cf=None):
     """
     Captures a packet of data from the given socket.
 
@@ -323,19 +340,20 @@ def capturePacket(sock):
          * dlc
          * data
     """
-    # Fetching the Arb ID, DLC and Data
-    try:
-        cf, addr = sock.recvfrom(can_frame_size)
-    except BlockingIOError:
-        log.debug('Captured no data, socket in non-blocking mode.')
-        return None
-    except socket.timeout:
-        log.debug('Captured no data, socket read timed out.')
-        return None
-    except OSError:
-        # something bad happened (e.g. the interface went down)
-        log.exception("Captured no data.")
-        return None
+    if cf is None:
+        # Fetching the Arb ID, DLC and Data
+        try:
+            cf = sock.recv(can_frame_size)
+        except BlockingIOError:
+            log.debug('Captured no data, socket in non-blocking mode.')
+            return None
+        except socket.timeout:
+            log.debug('Captured no data, socket read timed out.')
+            return None
+        except OSError:
+            # something bad happened (e.g. the interface went down)
+            log.exception("Captured no data.")
+            return None
 
     can_id, can_dlc, data = dissect_can_frame(cf)
     log.debug('Received: can_id=%x, can_dlc=%x, data=%s', can_id, can_dlc, data)
@@ -388,7 +406,7 @@ class SocketcanNative_Bus(BusABC):
             self.set_filters(kwargs['can_filters'])
 
         bindSocket(self.socket, channel)
-        super(SocketcanNative_Bus, self).__init__()
+        super(SocketcanNative_Bus, self).__init__(**kwargs)
 
     def shutdown(self):
         self.socket.close()
@@ -396,8 +414,7 @@ class SocketcanNative_Bus(BusABC):
     def recv(self, timeout=None):
         data_ready = True
         try:
-            if timeout is not None:
-                data_ready = len(select.select([self.socket], [], [], timeout)[0]) > 0
+            data_ready = len(select.select([self.socket], [], [], timeout)[0]) > 0
         except OSError:
             # something bad happened (e.g. the interface went down)
             log.exception("Error while waiting for timeout")
@@ -413,29 +430,13 @@ class SocketcanNative_Bus(BusABC):
             # socket wasn't readable or timeout occurred
             return None
 
-        rx_msg = Message(timestamp=packet.timestamp,
-                         arbitration_id=packet.arbitration_id,
-                         extended_id=packet.is_extended_frame_format,
-                         is_remote_frame=packet.is_remote_transmission_request,
-                         is_error_frame=packet.is_error_frame,
-                         dlc=packet.dlc,
-                         data=packet.data
-                         )
+        rx_msg = convert_packet_to_message(packet)
 
         return rx_msg
 
     def send(self, msg, timeout=None):
         log.debug("We've been asked to write a message to the bus")
-        arbitration_id = msg.arbitration_id
-        if msg.id_type:
-            log.debug("sending an extended id type message")
-            arbitration_id |= 0x80000000
-        if msg.is_remote_frame:
-            log.debug("requesting a remote frame")
-            arbitration_id |= 0x40000000
-        if msg.is_error_frame:
-            log.warning("Trying to send an error frame - this won't work")
-            arbitration_id |= 0x20000000
+        arbitration_id = _add_flags_to_can_id(msg)
         l = log.getChild("tx")
         l.debug("sending: %s", msg)
         try:
@@ -443,6 +444,20 @@ class SocketcanNative_Bus(BusABC):
         except OSError:
             l.warning("Failed to send: %s", msg)
             raise can.CanError("can.socketcan.native failed to transmit")
+
+    if asyncio is not None:
+        exec(textwrap.dedent("""
+        @asyncio.coroutine
+        def async_recv(self):
+            cf = yield from self._loop.sock_recv(self.socket, can_frame_size)
+            packet = capturePacket(self.socket, cf)
+            return convert_packet_to_message(packet)
+        """))
+
+        def async_send(self, msg):
+            arbitration_id = _add_flags_to_can_id(msg)
+            data = build_can_frame(arbitration_id, msg.data)
+            return self._loop.sock_sendall(self.socket, data)
 
     def send_periodic(self, msg, period, duration=None):
         task = CyclicSendTask(self.channel, msg, period)

--- a/can/interfaces/usb2can/usb2canInterface.py
+++ b/can/interfaces/usb2can/usb2canInterface.py
@@ -123,6 +123,8 @@ class Usb2canBus(BusABC):
 
         self.handle = self.can.open(connector, enable_flags)
 
+        super(Usb2canBus, self).__init__(**kwargs)
+
     def send(self, msg, timeout=None):
         tx = message_convert_tx(msg)
         if timeout:

--- a/can/interfaces/virtual.py
+++ b/can/interfaces/virtual.py
@@ -40,6 +40,8 @@ class VirtualBus(BusABC):
         self.channel = channels[channel]
         self.channel.append(self.queue)
 
+        super(VirtualBus, self).__init__(**config)
+
     def recv(self, timeout=None):
         try:
             msg = self.queue.get(block=True, timeout=timeout)

--- a/doc/bus.rst
+++ b/doc/bus.rst
@@ -44,3 +44,18 @@ by directly iterating over the bus::
 
 Alternatively the :class:`~can.Listener` api can be used, which is a list of :class:`~can.Listener`
 subclasses that receive notifications when new messages arrive.
+
+Asynchronous API
+''''''''''''''''
+
+It is also possible to use the :mod:`asyncio` module in Python 3 to write
+asynchronous code instead of using blocking operations.
+Asynchronous alternatives to :meth:`~can.BusABC.recv` and
+:meth:`~can.BusABC.send` are available as :meth:`~can.BusABC.async_recv`
+and :meth:`~can.BusABC.async_send`.
+
+Here are some examples:
+
+.. literalinclude:: ../examples/async.py
+    :language: python
+    :linenos:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,7 +35,8 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.intersphinx',
               'sphinx.ext.coverage',
               'sphinx.ext.viewcode',
-              'sphinx.ext.graphviz']
+              'sphinx.ext.graphviz',
+              'sphinxcontrib.asyncio']
 
 # Now, you can use the alias name as a new role, e.g. :issue:`123`.
 extlinks = {
@@ -43,7 +44,7 @@ extlinks = {
 }
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/2/', None),
+    'python': ('https://docs.python.org/3/', None),
 }
 
 # If this is True, todo and todolist produce output, else they produce nothing.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,1 @@
+sphinxcontrib-asyncio

--- a/examples/async.py
+++ b/examples/async.py
@@ -1,0 +1,72 @@
+import asyncio
+import can
+
+
+can.rc['interface'] = 'virtual'
+can.rc['channel'] = 'vcan0'
+
+loop = asyncio.get_event_loop()
+
+
+async def receiver():
+    bus = can.interface.Bus()
+    print("Receiver: Waiting for first message...")
+    msg = await bus.async_recv()
+    print("Receiver: Got %r" % msg)
+    print("Receiver: Waiting 1 second...")
+    await asyncio.sleep(1)
+    print("Receiver: Waiting for second message...")
+    msg = await bus.async_recv()
+    print("Receiver: Got %r" % msg)
+    print("Receiver: Waiting for a message with a timeout...")
+    try:
+        msg = await asyncio.wait_for(bus.async_recv(), timeout=1.1)
+    except asyncio.TimeoutError:
+        print("Receiver: Timeout occurred")
+    print("Receiver: Shutting down bus")
+    bus.shutdown()
+
+async def sender():
+    bus = can.interface.Bus()
+    msg = can.Message(arbitration_id=0x123, data=[1,2,3,4,5])
+    print("Sender: Waiting for 1 second...")
+    await asyncio.sleep(1)
+    print("Sender: Sending first message...")
+    await bus.async_send(msg)
+    await asyncio.sleep(0.01)
+    print("Sender: Sending second message...")
+    await bus.async_send(msg)
+    print("Sender: Shutting down bus")
+    bus.shutdown()
+
+print("Scheduling sender and receiver concurrently")
+loop.run_until_complete(asyncio.gather(receiver(), sender()))
+
+
+async def iterate_messages():
+    bus = can.interface.Bus()
+    print("Infinite loop started. Printing messages...")
+    try:
+        async for msg in bus:
+            print(msg)
+    except asyncio.CancelledError:
+        print("Iteration was cancelled")
+    finally:
+        bus.shutdown()
+
+async def cancel_infinite_loop():
+    print("Scheduling inifinite loop")
+    task = asyncio.ensure_future(iterate_messages())
+    # Allow task to start
+    await asyncio.sleep(0)
+    bus = can.interface.Bus()
+    for i in range(1, 4):
+        msg = can.Message(arbitration_id=i)
+        print("Sending message %d" % i)
+        await bus.async_send(msg)
+        await asyncio.sleep(1)
+    print("Stopping iterator task")
+    task.cancel()
+    bus.shutdown()
+
+loop.run_until_complete(cancel_infinite_loop())

--- a/test/remote_test.py
+++ b/test/remote_test.py
@@ -3,6 +3,10 @@
 import unittest
 import threading
 import time
+try:
+    import asyncio
+except ImportError:
+    asyncio = None
 import can
 from can.interfaces.remote import events
 from can.interfaces.remote import connection
@@ -246,6 +250,22 @@ class RemoteBusTestCase(unittest.TestCase):
                 msgs.append(msg)
         self.assertTrue(150 < len(msgs) < 220)
         self.assertEqual(msgs[0], test_msg)
+
+    @unittest.skipIf(asyncio is None, "Python >=3.3 required")
+    def test_async(self):
+        loop = asyncio.get_event_loop()
+        # Test recv
+        msg1 = can.Message(arbitration_id=0x123)
+        self.real_bus.send(msg1)
+        msg2 = loop.run_until_complete(self.remote_bus.async_recv())
+        self.assertEqual(msg2, msg1)
+        # Test send
+        msg3 = can.Message(arbitration_id=0x456)
+        loop.run_until_complete(self.remote_bus.async_send(msg3))
+        # Skip msg1
+        self.real_bus.recv(0)
+        msg4 = self.real_bus.recv(1)
+        self.assertEqual(msg4, msg3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request adds support for receiving (and to some extent sending) messages asynchronously using [asyncio](https://docs.python.org/3/library/asyncio.html). This can be useful when writing protocol implementations that should handle parallel communication channels with many nodes.

The default implementation first tries a non-blocking receive, then passes of a blocking call to a thread. Sending is just a non-blocking send operation. The SocketCAN and remote interfaces have custom implementations that are true asynchronous methods.

Since the files must be parseable by Python 2.7, there are some ugly workarounds to avoid using `yield from` directly in the code. Sometimes `exec` is used and sometimes they are regular functions returning a Future object.

To make the coroutines be documented as such correctly, I had to add a dependency to sphinxcontrib.asyncio when generating documentation. I tried to make this work with RTD.