### PR TITLE
Adding `from __future__ import absolute_import` to fix some python 2.x import issues.

### DIFF
--- a/can/CAN.py
+++ b/can/CAN.py
@@ -4,6 +4,7 @@ implementations of all the major classes in the library, now
 however all functionality has been refactored out. This api
 is left intact for version 2.0 to aide with migration.
 """
+from __future__ import absolute_import
 
 from can.message import Message
 from can.listener import Listener, BufferedReader, RedirectReader

--- a/can/__init__.py
+++ b/can/__init__.py
@@ -1,6 +1,8 @@
 """
 can is an object-orient Controller Area Network interface module.
 """
+from __future__ import absolute_import
+
 import logging
 
 __version__ = "2.0.0-alpha.2"

--- a/can/bus.py
+++ b/can/bus.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import abc
 import logging

--- a/can/interface.py
+++ b/can/interface.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import can
 import importlib
 
@@ -18,6 +20,7 @@ BACKENDS = {
     'virtual':          ('can.interfaces.virtual', 'VirtualBus'),
     'neovi':            ('can.interfaces.neovi_api', 'NeoVIBus')
 }
+
 
 class Bus(object):
     """

--- a/can/util.py
+++ b/can/util.py
@@ -2,8 +2,7 @@
 """
 Utilities and configuration file parsing.
 """
-
-import time
+from __future__ import absolute_import
 
 import can
 from can.interfaces import VALID_INTERFACES


### PR DESCRIPTION
Adding `from __future__ import absolute_import` to fix some python 2.x import issues.

Also removed unused `import time` in can.util