### PR TITLE
Boolean coercion to True, even for CAN frames with dlc==0

### DIFF
--- a/can/message.py
+++ b/can/message.py
@@ -83,6 +83,12 @@ class Message(object):
     def __len__(self):
         return len(self.data)
 
+    def __bool__(self):
+        return True
+
+    def __nonzero__(self):
+        return self.__bool__()
+
     def __repr__(self):
         data = ["{:#02x}".format(byte) for byte in self.data]
         args = ["timestamp={}".format(self.timestamp),

--- a/test/zero_dlc_test.py
+++ b/test/zero_dlc_test.py
@@ -1,0 +1,43 @@
+from time import sleep
+import unittest
+import logging
+import can
+
+logging.getLogger(__file__).setLevel(logging.DEBUG)
+
+
+class ZeroDLCTest(unittest.TestCase):
+
+    def test_recv_non_zero_dlc(self):
+        bus_send = can.interface.Bus(bustype='virtual')
+        bus_recv = can.interface.Bus(bustype='virtual')
+        msg_send = can.Message(extended_id=False, arbitration_id=0x100, data=[0,1,2,3,4,5,6,7])
+
+        bus_send.send(msg_send)
+        msg_recv = bus_recv.recv()
+
+        # Receiving a frame with data should evaluate msg_recv to True
+        self.assertTrue(msg_recv)
+
+    def test_recv_none(self):
+        bus_recv = can.interface.Bus(bustype='virtual')
+
+        msg_recv = bus_recv.recv(timeout=0)
+
+        # Receiving nothing should evaluate msg_recv to False
+        self.assertFalse(msg_recv)
+
+
+    def test_recv_zero_dlc(self):
+        bus_send = can.interface.Bus(bustype='virtual')
+        bus_recv = can.interface.Bus(bustype='virtual')
+        msg_send = can.Message(extended_id=False, arbitration_id=0x100, data=[])
+
+        bus_send.send(msg_send)
+        msg_recv = bus_recv.recv()
+
+        # Receiving a frame without data (dlc == 0) should evaluate msg_recv to True
+        self.assertTrue(msg_recv)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The following code did not print CAN frames that had zero data (dlc==0), because boolean coercion uses the overloaded `__len__()` 
```
msg = bus.recv(timeout=1)
if msg :
    print(msg)
```
By overloading `__bool__()` to return True, all CAN frames will be printed. Timeouts return None and will not be printed.