### PR TITLE
Remove intermediate namedtuple in socketcan_native interface.

### DIFF
--- a/doc/interfaces/socketcan_native.rst
+++ b/doc/interfaces/socketcan_native.rst
@@ -40,7 +40,7 @@ bindSocket
 .. autofunction:: can.interfaces.socketcan.socketcan_native.bindSocket
 
 
-capturePacket
+captureMessage
 ~~~~~~~~~~~~~
 
-.. autofunction:: can.interfaces.socketcan.socketcan_native.capturePacket
+.. autofunction:: can.interfaces.socketcan.socketcan_native.captureMessage


### PR DESCRIPTION
Hello,

first of all, thanks for a useful and easy to use package that serves its purpose well.

When I started implementing this PR I didn't realize that the `capturePacket()`-function was part of the user API, though, listed under "Internals" in the documentation. This PR makes non-backwards compatible changes to this interface since the function was both renamed and changed its return type from a namedtuple to a Message. Is this ok? Who is the intended user of the internal functions? Usually users use the Bus-object to communicate over a CAN BUS, right?

Anyway, the purpose of this PR is to improve performance and reduce the code size to make it easier to read.