### PR TITLE
ixxat: In recv(), avoid the use of canChannelWaitRxEvent()

### DIFF
--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -360,14 +360,12 @@ class IXXATBus(BusABC):
         self.channel = channel
 
         # Usually you get back 3 messages like "CAN initialized" ecc...
-        # Filter them out with low timeout
-        while True:
+        # Clear the FIFO by filter them out with low timeout
+        for i in range(rxFifoSize):
             try:
-                _canlib.canChannelWaitRxEvent(self._channel_handle, 0)
-            except VCITimeout:
-                break
-            else:
                 _canlib.canChannelReadMessage(self._channel_handle, 0, ctypes.byref(self._message))
+            except (VCITimeout, VCIRxQueueEmptyError):
+                break
 
         super(IXXATBus, self).__init__()
 


### PR DESCRIPTION
The function canChannelWaitRxEvent() does not always return even if there is one message in the FIFO. This looks like a regression with at least VCI V4 4.0.482 since with VCI v3 3.5.4 there is no problem.

This commit also refactor the recv() function in order to be more robust.
    
While testing this fix, I discover that canChannelReadMessage(), with VCI V4, can randomly return the error code VCI_E_RXQUEUE_EMPTY, which by the documentation should never happen, so catch it...

Fix #201