### PR TITLE
blf: Fix import to prevent log message about loading old CAN api

### DIFF
--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -16,7 +16,7 @@ import datetime
 import time
 
 from can.message import Message
-from can.CAN import Listener
+from can.listener import Listener
 
 
 # 0 = unknown, 2 = CANoe


### PR DESCRIPTION
Prevent loading can.CAN which will display "Loading python-can via the old CAN api"