### PR TITLE
Fix bug in socketcan_native send

### DIFF
--- a/can/bus.py
+++ b/can/bus.py
@@ -5,11 +5,12 @@ Contains the ABC bus implementation.
 """
 
 from __future__ import print_function, absolute_import
-
 import abc
 import logging
 import threading
 from can.broadcastmanager import ThreadBasedCyclicSendTask
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -22,7 +23,6 @@ class BusABC(object):
 
     As well as setting the `channel_info` attribute to a string describing the
     interface.
-
     """
 
     #: a string describing the underlying bus channel
@@ -45,6 +45,7 @@ class BusABC(object):
         :param dict config:
             Any backend dependent configurations are passed in this dictionary
         """
+        pass
 
     @abc.abstractmethod
     def recv(self, timeout=None):

--- a/can/notifier.py
+++ b/can/notifier.py
@@ -1,4 +1,7 @@
 import threading
+import logging
+
+logger = logging.getLogger('can.Notifier')
 
 
 class Notifier(object):
@@ -14,15 +17,15 @@ class Notifier(object):
         self.listeners = listeners
         self.bus = bus
         self.timeout = timeout
-        #: Exception raised in thread
+
+        # exception raised in thread
         self.exception = None
 
         self.running = threading.Event()
         self.running.set()
 
-        self._reader = threading.Thread(target=self.rx_thread)
+        self._reader = threading.Thread(target=self.rx_thread, name="can.notifier")
         self._reader.daemon = True
-
         self._reader.start()
 
     def stop(self):


### PR DESCRIPTION
raise an `can.CanError` on timeout with an explicit error message rather than indirectly on failing socket.send call

Rebased together 2 commits from #224 by @felixdivo 