### PR TITLE
Adding string representation to CAN Bus Abstract Base Class

### DIFF
--- a/can/bus.py
+++ b/can/bus.py
@@ -47,6 +47,9 @@ class BusABC(object):
         """
         pass
 
+    def __str__(self):
+        return self.channel_info
+
     @abc.abstractmethod
     def recv(self, timeout=None):
         """Block waiting for a message from the Bus.


### PR DESCRIPTION
Adding \_\_str\_\_ to CAN Bus Abstract Base Class for a nicely printable
string representation of an the Bus using channel_info.