### PR TITLE
More test platforms, most notably OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,12 @@ matrix:
       python: "3.7-dev"
     - os: osx
       python: "nightly"
+    - os: osx
+      python: "3.6-stable"
+    - os: osx
+      python: "3.6-dev"
+    - os: osx
+      python: "3.6-nightly"
   allow_failures:
     - python: "3.7-dev"
     - python: "nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   # CPython:
   - "2.7"
+  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
@@ -11,15 +12,16 @@ python:
   # PyPy:
   - "pypy"
   - "pypy3"
+  - "pypy-dev"
+  - "pypy3-dev"
 
 os:
   - linux   # Linux is officially supported and we test the software under
             # many different Python verions (see "python: ..." above)
 
-# - osx     # OSX is not officially supported by Travis CI as of Feb. 2018
-            # nevertheless, "nightly" and "3.7-dev" seem to work, so we
-            # include them explicitly below, but allow them to fail as well
-            # for now
+# - osx     # Python + OSX is not officially supported by Travis CI as of Feb. 2018
+            # nevertheless, "nightly" and "something-dev" seem to work, so we
+            # include them explicitly below
 
 # - windows # Windows is not supported at all by Travis CI as of Feb. 2018
 
@@ -31,17 +33,30 @@ matrix:
   # see "os: ..." above
   include:
     - os: osx
+      python: "2.7-dev"
+    - os: osx
+      python: "3.3-dev"
+    - os: osx
+      python: "3.4-dev"
+    - os: osx
+      python: "3.5-dev"
+    - os: osx
+      python: "3.6-dev"
+    - os: osx
       python: "3.7-dev"
     - os: osx
       python: "nightly"
     - os: osx
-      python: "3.6-stable"
+      python: "pypy-dev"
     - os: osx
-      python: "3.6-dev"
-    - os: osx
-      python: "3.6-nightly"
+      python: "pypy3-dev"
   allow_failures:
-    - python: "3.7-dev"
+    # allow dev/nighly builds to fail
+    #- python: "2.7-dev"
+    #- python: "3.4-dev"
+    #- python: "3.5-dev"
+    #- python: "3.6-dev"
+    - python: "*-dev"
     - python: "nightly"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,12 @@ python:
   - "pypy3"
 
 os:
-  - linux   # Linux is officially supported and we test the software under
+  - linux   # Linux is officially supported and we test the library under
             # many different Python verions (see "python: ..." above)
 
 # - osx     # OSX + Python is not officially supported by Travis CI as of Feb. 2018
-            # nevertheless, "nightly" and "something-dev" seem to work, so we
-            # include them explicitly below
+            # nevertheless, "nightly" and some "*-dev" versions seem to work, so we
+            # include them explicitly below (see "matrix: include: ..." below)
 
 # - windows # Windows is not supported at all by Travis CI as of Feb. 2018
 
@@ -37,10 +37,9 @@ matrix:
     - os: osx
       python: "nightly"
 
-  # allow dev/nighly builds to fail
+  # allow all nighly builds to fail, since these python versions might be unstable
+  # we do not allow dev builds to fail, since these builds are stable enough
   allow_failures:
-    - python: "3.6-dev"
-    - python: "3.7-dev"
     - python: "nightly"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,12 @@ sudo: false
 
 matrix:
   # see "os: ..." above
-  allow_failures:
-    - os: osx
-      python: "3.7-dev"
-    - os: osx
-      python: "nightly"
+  include:
+    allow_failures:
+      - os: osx
+        python: "3.7-dev"
+      - os: osx
+        python: "nightly"
 
 install:
   - travis_retry pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,13 @@ sudo: false
 matrix:
   # see "os: ..." above
   include:
-    allow_failures:
-      - os: osx
-        python: "3.7-dev"
-      - os: osx
-        python: "nightly"
+    - os: osx
+      python: "3.7-dev"
+    - os: osx
+      python: "nightly"
+  allow_failures:
+    - python: "3.7-dev"
+    - python: "nightly"
 
 install:
   - travis_retry pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,12 @@ python:
   # PyPy:
   - "pypy"
   - "pypy3"
-  - "pypy-dev"
-  - "pypy3-dev"
 
 os:
   - linux   # Linux is officially supported and we test the software under
             # many different Python verions (see "python: ..." above)
 
-# - osx     # Python + OSX is not officially supported by Travis CI as of Feb. 2018
+# - osx     # OSX + Python is not officially supported by Travis CI as of Feb. 2018
             # nevertheless, "nightly" and "something-dev" seem to work, so we
             # include them explicitly below
 
@@ -33,30 +31,16 @@ matrix:
   # see "os: ..." above
   include:
     - os: osx
-      python: "2.7-dev"
-    - os: osx
-      python: "3.3-dev"
-    - os: osx
-      python: "3.4-dev"
-    - os: osx
-      python: "3.5-dev"
-    - os: osx
       python: "3.6-dev"
     - os: osx
       python: "3.7-dev"
     - os: osx
       python: "nightly"
-    - os: osx
-      python: "pypy-dev"
-    - os: osx
-      python: "pypy3-dev"
+
+  # allow dev/nighly builds to fail
   allow_failures:
-    # allow dev/nighly builds to fail
-    #- python: "2.7-dev"
-    #- python: "3.4-dev"
-    #- python: "3.5-dev"
-    #- python: "3.6-dev"
-    - python: "*-dev"
+    - python: "3.6-dev"
+    - python: "3.7-dev"
     - python: "nightly"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,23 @@
 language: python
 sudo: false
+
 python:
+  # CPython:
   - "2.7"
-  - "pypy"
-  - "pypy3"
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7-dev"
+  - "3.7-dev" # TODO: change to "3.7" once it gets released
   - "nightly"
+  # PyPy:
+  - "pypy"
+  - "pypy3"
+
+os:
+  - linux
+  - osx
+  - windows
+
 install:
   - travis_retry pip install .
   - travis_retry pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,27 @@ python:
   - "pypy3"
 
 os:
-  - linux
-  - osx     # OSX 
-# - windows # Windows is not supported by Travis CI as of Feb. 2018
+  - linux   # Linux is officially supported and we test the software under
+            # many different Python verions (see "python: ..." above)
 
-sudo: false
+# - osx     # OSX is not officially supported by Travis CI as of Feb. 2018
+            # nevertheless, "nightly" and "3.7-dev" seem to work, so we
+            # include them explicitly below, but allow them to fail as well
+            # for now
+
+# - windows # Windows is not supported at all by Travis CI as of Feb. 2018
+
+# Linux setup
 dist: trusty
+sudo: false
 
 matrix:
+  # see "os: ..." above
   allow_failures:
     - os: osx
-      #python: 3.3
+      python: "3.7-dev"
+    - os: osx
+      python: "nightly"
 
 install:
   - travis_retry pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 
 python:
   # CPython:
@@ -15,8 +14,16 @@ python:
 
 os:
   - linux
-  - osx
-  - windows
+  - osx     # OSX 
+# - windows # Windows is not supported by Travis CI as of Feb. 2018
+
+sudo: false
+dist: trusty
+
+matrix:
+  allow_failures:
+    - os: osx
+      #python: 3.3
 
 install:
   - travis_retry pip install .

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ python-can
    :alt: Documentation Status
                 
 .. |build| image:: https://travis-ci.org/hardbyte/python-can.svg?branch=develop
-   :target: https://travis-ci.org/hardbyte/python-can
+   :target: https://travis-ci.org/hardbyte/python-can/branches
    :alt: CI Server for develop branch
 
 
@@ -26,7 +26,7 @@ Python developers; providing `common abstractions to
 different hardware devices`, and a suite of utilities for sending and receiving
 messages on a can bus.
 
-The library supports Python 2.7, Python 3.3+ and runs on Mac, Linux and Windows.
+The library supports Python 2.7, Python 3.3+ as well as PyPy and runs on Mac, Linux and Windows.
 
 You can find more information in the documentation, online at
 `python-can.readthedocs.org <https://python-can.readthedocs.org/en/stable/>`__.

--- a/can/__init__.py
+++ b/can/__init__.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 import logging
 
-__version__ = "2.0.0"
+__version__ = "2.1.0.rc2"
 
 log = logging.getLogger('can')
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
+# -*- coding: utf-8 -*-
+
 """
 python-can requires the setuptools package to be installed.
 """
+
 import re
 import logging
 from setuptools import setup, find_packages

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -70,11 +70,13 @@ class Back2BackTestCase(unittest.TestCase):
     def test_timestamp(self):
         self.bus2.send(can.Message())
         recv_msg1 = self.bus1.recv(TIMEOUT)
-        time.sleep(1)
+        time.sleep(5)
         self.bus2.send(can.Message())
         recv_msg2 = self.bus1.recv(TIMEOUT)
         delta_time = recv_msg2.timestamp - recv_msg1.timestamp
-        self.assertTrue(0.95 < delta_time < 1.05)
+        self.assertTrue(4.8 < delta_time < 5.2,
+                        'Time difference should have been 5s +/- 200ms.' 
+                        'But measured {}'.format(delta_time))
 
     def test_standard_message(self):
         msg = can.Message(extended_id=False,

--- a/test/simplecyclic_test.py
+++ b/test/simplecyclic_test.py
@@ -12,11 +12,11 @@ class SimpleCyclicSendTaskTest(unittest.TestCase):
         task = bus.send_periodic(msg, 0.01, 1)
         self.assertIsInstance(task, can.broadcastmanager.CyclicSendTaskABC)
 
-        sleep(1.5)
+        sleep(2)
         size = bus2.queue.qsize()
-        print(size)
         # About 100 messages should have been transmitted
-        self.assertTrue(90 < size < 110)
+        self.assertTrue(90 < size < 110,
+                        '100 +/- 10 messages should have been transmitted. But queue contained {}'.format(size))
         last_msg = bus2.recv()
         self.assertEqual(last_msg, msg)
 

--- a/test/simplecyclic_test.py
+++ b/test/simplecyclic_test.py
@@ -12,7 +12,7 @@ class SimpleCyclicSendTaskTest(unittest.TestCase):
         task = bus.send_periodic(msg, 0.01, 1)
         self.assertIsInstance(task, can.broadcastmanager.CyclicSendTaskABC)
 
-        sleep(2)
+        sleep(5)
         size = bus2.queue.qsize()
         # About 100 messages should have been transmitted
         self.assertTrue(90 < size < 110,


### PR DESCRIPTION
I added some more test platforms, most notably OSX tests for Python 3.6-dev, 3.7-dev and nighly. I also changed the Travis CI file to allow nightly Python builds to fail, but they are still tested and the results can be viewed. 

Now, there are generally more comments in `.travis.yml`. For someone reviewing this, I would kindly ask them to read the comments in there and decide whether the chosen approach for OSX support & disallowing/allwoing dev/nightly builds was OK.

For the failing tests, see #243. I think they are not directly connected to the changes in this PR. 