### PR TITLE
Support error frame messages in ASCWriter and ASCReader.

### DIFF
--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -93,8 +93,8 @@ class ASCReader(object):
 class ASCWriter(Listener):
     """Logs CAN data to an ASCII log file (.asc)"""
 
-    LOG_STRING      = "{time: 9.4f} {channel}  {id:<15} Rx   {dtype} {data}\n"
-    EVENT_STRING    = "{time: 9.4f} {message}\n"
+    LOG_STRING = "{time: 9.4f} {channel}  {id:<15} Rx   {dtype} {data}\n"
+    EVENT_STRING = "{time: 9.4f} {message}\n"
 
     def __init__(self, filename, channel=1):
         now = datetime.now().strftime("%a %b %m %I:%M:%S %p %Y")
@@ -120,15 +120,19 @@ class ASCWriter(Listener):
             logger.debug("ASCWriter: ignoring empty message")
             return
 
-        timestamp = (timestamp or time.time())
+        if timestamp is None:
+            timestamp = time.time()
+
         if timestamp >= self.started:
             timestamp -= self.started
 
         line = self.EVENT_STRING.format(time=timestamp, message=message)
+
         if not self.log_file.closed:
             self.log_file.write(line)
 
     def on_message_received(self, msg):
+
         if msg.is_error_frame:
             self.log_event("{}  ErrorFrame".format(self.channel), msg.timestamp)
             return
@@ -139,18 +143,18 @@ class ASCWriter(Listener):
         else:
             dtype = "d {}".format(msg.dlc)
             data = ["{:02X}".format(byte) for byte in msg.data]
+
         arb_id = "{:X}".format(msg.arbitration_id)
-        if msg.id_type:
-            arb_id = arb_id + "x"
-        timestamp = msg.timestamp
-        if timestamp >= self.started:
-            timestamp -= self.started
+        if msg.is_extended_id:
+            arb_id += "x"
 
         channel = msg.channel if isinstance(msg.channel, int) else self.channel
-        line = self.LOG_STRING.format(time=timestamp,
+
+        line = self.LOG_STRING.format(time=msg.timestamp,
                                       channel=channel,
                                       id=arb_id,
                                       dtype=dtype,
                                       data=" ".join(data))
+
         if not self.log_file.closed:
             self.log_file.write(line)

--- a/test/data/example_data.py
+++ b/test/data/example_data.py
@@ -9,7 +9,6 @@ import random
 
 from can import Message
 
-
 # make tests more reproducible
 random.seed(13339115)
 
@@ -73,12 +72,12 @@ TEST_MESSAGES_BASE = [
 
 TEST_MESSAGES_REMOTE_FRAMES = [
     Message(
-        arbitration_id=0xDADADA, extended_id=True, is_remote_frame=False,
+        arbitration_id=0xDADADA, extended_id=True, is_remote_frame=True,
         timestamp=TEST_TIME + .165,
         data=[1, 2, 3, 4, 5, 6, 7, 8]
     ),
     Message(
-        arbitration_id=0x123, extended_id=False, is_remote_frame=False,
+        arbitration_id=0x123, extended_id=False, is_remote_frame=True,
         timestamp=TEST_TIME + .365,
         data=[254, 255]
     ),
@@ -124,6 +123,5 @@ def generate_message(arbitration_id):
     Generates a new message with the given ID, some random data
     and a non-extended ID.
     """
-    data = [random.randrange(0, 2 ** 8 - 1) for _ in range(8)]
-    msg = Message(arbitration_id=arbitration_id, data=data, extended_id=False)
-    return msg
+    data = bytes([random.randrange(0, 2 ** 8 - 1) for _ in range(8)])
+    return Message(arbitration_id=arbitration_id, data=data, extended_id=False)

--- a/test/logformats_test.py
+++ b/test/logformats_test.py
@@ -112,7 +112,7 @@ def _test_writer_and_reader(test_case, writer_constructor, reader_constructor, s
     for i, (read, original) in enumerate(zip(read_messages, original_messages)):
         try:
             test_case.assertEqual(read, original)
-            test_case.assertAlmostEqual(read.timestamp, original.timestamp)
+            test_case.assertAlmostEqual(read.timestamp, original.timestamp, places=6)
         except Exception as exception:
             # attach the index
             exception.args += ("test failed at index #{}".format(i), )
@@ -142,7 +142,7 @@ class TestAscFileFormat(unittest.TestCase):
 
     def test_writer_and_reader(self):
         _test_writer_and_reader(self, can.ASCWriter, can.ASCReader,
-                                check_error_frames=False, # TODO this should get fixed, see Issue #218
+                                check_error_frames=True,
                                 check_comments=True)
 
 


### PR DESCRIPTION
Closes #218 (cherry picked from commit e17207c)

Replaces https://github.com/hardbyte/python-can/pull/247