### PR TITLE
add  a deprecated notice to 'SqlReader' for users

### DIFF
--- a/can/__init__.py
+++ b/can/__init__.py
@@ -26,7 +26,7 @@ from can.io import ASCWriter, ASCReader
 from can.io import BLFReader, BLFWriter
 from can.io import CanutilsLogReader, CanutilsLogWriter
 from can.io import CSVWriter
-from can.io import SqliteWriter, SqliteReader
+from can.io import SqliteWriter, SqliteReader, SqlReader
 
 from can.util import set_logging_level
 

--- a/can/io/__init__.py
+++ b/can/io/__init__.py
@@ -12,5 +12,5 @@ from .log import CanutilsLogReader, CanutilsLogWriter
 from .asc import ASCWriter, ASCReader
 from .blf import BLFReader, BLFWriter
 from .csv import CSVWriter
-from .sqlite import SqliteReader, SqliteWriter
+from .sqlite import SqliteReader, SqlReader, SqliteWriter
 from .stdout import Printer

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -52,7 +52,7 @@ class SqlReader:
     def __iter__(self):
         log.debug("Iterating through messages from sql db")
         for frame_data in self.cursor.execute(self._SELECT_ALL_COMMAND):
-            yield SqlReader._create_frame_from_db_tuple(frame_data)
+            yield self._create_frame_from_db_tuple(frame_data)
 
     def __len__(self):
         # this might not run in constant time

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -24,7 +24,7 @@ if sys.version_info > (3,):
     buffer = memoryview
 
 
-@deprecated(version='2.1', reason="Use the name SqliteReader instead")
+@deprecated(reason="Use the name SqliteReader instead. (Replaced in v2.1)")
 class SqlReader:
     """
     Reads recorded CAN messages from a simple SQL database.

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -13,6 +13,8 @@ import threading
 import logging
 import sqlite3
 
+from deprecated import deprecated
+
 from can.listener import BufferedReader
 from can.message import Message
 
@@ -22,7 +24,8 @@ if sys.version_info > (3,):
     buffer = memoryview
 
 
-class SqliteReader:
+@deprecated(version='2.1', reason="Use the name SqliteReader instead")
+class SqlReader:
     """
     Reads recorded CAN messages from a simple SQL database.
 
@@ -65,10 +68,8 @@ class SqliteReader:
         """Closes the connection to the database."""
         self.conn.close()
 
-
-# Backward compatibility
-# TODO remove in later releases?
-SqlReader = SqliteReader
+# SqliteReader is the newer name
+SqliteReader = SqlReader
 
 
 class SqliteWriter(BufferedReader):

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -52,7 +52,7 @@ class SqlReader:
     def __iter__(self):
         log.debug("Iterating through messages from sql db")
         for frame_data in self.cursor.execute(self._SELECT_ALL_COMMAND):
-            yield SqliteReader._create_frame_from_db_tuple(frame_data)
+            yield SqlReader._create_frame_from_db_tuple(frame_data)
 
     def __len__(self):
         # this might not run in constant time

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -24,7 +24,7 @@ if sys.version_info > (3,):
     buffer = memoryview
 
 
-@deprecated(reason="Use the name SqliteReader instead. (Replaced in v2.1)")
+@deprecated(reason="Use the name SqliteReader instead. Replaced in v2.1.")
 class SqlReader:
     """
     Reads recorded CAN messages from a simple SQL database.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-pyserial
+pyserial >= 3.0
+Deprecated >= 1.1.0

--- a/setup.py
+++ b/setup.py
@@ -19,24 +19,44 @@ with open('README.rst', 'r') as f:
 logging.basicConfig(level=logging.WARNING)
 
 setup(
+
+    # Description
     name="python-can",
     url="https://github.com/hardbyte/python-can",
-    version=version,
-    packages=find_packages(),
-    author="Brian Thorne",
-    author_email="brian@thorne.link",
     description="Controller Area Network interface module for Python",
     long_description=long_description,
+
+    # Code
+    version=version,
+    packages=find_packages(),
+    
+    # Author
+    author="Brian Thorne",
+    author_email="brian@thorne.link",
+
+    # License
     license="LGPL v3",
+
+    # Package data
     package_data={
         "": ["CONTRIBUTORS.txt", "LICENSE.txt"],
         "doc": ["*.*"]
     },
-    # Tests can be run using `python setup.py test`
-    test_suite="nose.collector",
-    tests_require=['mock', 'nose', 'pyserial'],
+
+    # Installation
+    install_requires=[
+        'Deprecated >= 1.1.0',
+    ],
     extras_require={
-        'serial': ['pyserial'],
+        'serial': ['pyserial >= 3.0'],
         'neovi': ['python-ics'],
-    }
+    },
+
+    # Testing
+    test_suite="nose.collector",
+    tests_require=[
+        'mock',
+        'nose',
+        'pyserial >= 3.0'
+    ],
 )


### PR DESCRIPTION
I changed the structure of `setup.py` a little bit and added the [Deprecated](https://github.com/tantale/deprecated) library as a dependency, as suggested by Brian. Then I added the `@deprecated` decorator to mark SqlReader as - you guessed it - deprecated.