### PR TITLE
Add CI testing on Appveyor (Windows)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,45 @@
+environment:
+
+  matrix:
+
+    # For Python versions available on Appveyor, see
+    # http://www.appveyor.com/docs/installed-software#python
+
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python33"
+    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python33-x64"
+    - PYTHON: "C:\\Python34-x64"
+    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36-x64"
+
+install:
+  # We need our usual libraries
+  - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
+  # We need wheel installed to build wheels
+  - "%PYTHON%\\python.exe -m pip install wheel"
+
+build: off
+
+test_script:
+  # Put your test command here.
+  # Note that you must use the environment variable %PYTHON% to refer to
+  # the interpreter you're using - Appveyor does not do anything special
+  # to put the Python version you want to use on PATH.
+  - "%PYTHON%\\python.exe setup.py test"
+
+#after_test:
+#  # This step builds your wheels.
+#  - "%PYTHON%\\python.exe setup.py bdist_wheel"
+
+#artifacts:
+#  # bdist_wheel puts your built wheel in the dist directory
+#  - path: dist\*
+
+#on_success:
+#  You can use this step to upload your artifacts to a public website.
+#  See Appveyor's documentation for more details. Or you can simply
+#  access your wheels from the Appveyor "artifacts" tab for your build.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,8 +19,8 @@ environment:
 install:
   # We need our usual libraries
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
-  # We need wheel installed to build wheels
-  #- "%PYTHON%\\python.exe -m pip install wheel"
+  # We need to install the python-can library itself
+  - "%PYTHON%\\python.exe -m pip install ."
 
 build: off
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,26 +20,12 @@ install:
   # We need our usual libraries
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
   # We need wheel installed to build wheels
-  - "%PYTHON%\\python.exe -m pip install wheel"
+  #- "%PYTHON%\\python.exe -m pip install wheel"
 
 build: off
 
 test_script:
-  # Put your test command here.
   # Note that you must use the environment variable %PYTHON% to refer to
   # the interpreter you're using - Appveyor does not do anything special
   # to put the Python version you want to use on PATH.
   - "%PYTHON%\\python.exe setup.py test"
-
-#after_test:
-#  # This step builds your wheels.
-#  - "%PYTHON%\\python.exe setup.py bdist_wheel"
-
-#artifacts:
-#  # bdist_wheel puts your built wheel in the dist directory
-#  - path: dist\*
-
-#on_success:
-#  You can use this step to upload your artifacts to a public website.
-#  See Appveyor's documentation for more details. Or you can simply
-#  access your wheels from the Appveyor "artifacts" tab for your build.

--- a/README.rst
+++ b/README.rst
@@ -1,19 +1,23 @@
 python-can
 ==========
 
-|release| |docs| |build|
+|release| |docs| |build_travis| |build_appveyor|
 
 .. |release| image:: https://img.shields.io/pypi/v/python-can.svg
    :target: https://pypi.python.org/pypi/python-can/
-   :alt: Latest Version
+   :alt: Latest Version on PyPi
 
 .. |docs| image:: https://readthedocs.org/projects/python-can/badge/?version=stable
    :target: https://python-can.readthedocs.io/en/stable/
-   :alt: Documentation Status
+   :alt: Documentation build Status
                 
-.. |build| image:: https://travis-ci.org/hardbyte/python-can.svg?branch=develop
+.. |build_travis| image:: https://travis-ci.org/hardbyte/python-can.svg?branch=develop
    :target: https://travis-ci.org/hardbyte/python-can/branches
-   :alt: CI Server for develop branch
+   :alt: Travis CI Server for develop branch
+
+.. |build_appveyor| image:: https://ci.appveyor.com/api/projects/status/github/hardbyte/python-can?branch=develop&svg=true
+   :target: https://ci.appveyor.com/project/hardbyte/python-can/history
+   :alt: AppVeyor CI Server for develop branch
 
 
 The **C**\ ontroller **A**\ rea **N**\ etwork is a bus standard designed

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -52,7 +52,7 @@ class SqlReader:
     def __iter__(self):
         log.debug("Iterating through messages from sql db")
         for frame_data in self.cursor.execute(self._SELECT_ALL_COMMAND):
-            yield SqlReader._create_frame_from_db_tuple(frame_data)
+            yield self._create_frame_from_db_tuple(frame_data)
 
     def __len__(self):
         # this might not run in constant time

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -24,7 +24,7 @@ if sys.version_info > (3,):
     buffer = memoryview
 
 
-@deprecated(version='2.1', reason="Use the name SqliteReader instead")
+@deprecated(reason="Use the name SqliteReader instead. (Replaced in v2.1)")
 class SqlReader:
     """
     Reads recorded CAN messages from a simple SQL database.

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -13,6 +13,8 @@ import threading
 import logging
 import sqlite3
 
+from deprecated import deprecated
+
 from can.listener import BufferedReader
 from can.message import Message
 
@@ -22,7 +24,8 @@ if sys.version_info > (3,):
     buffer = memoryview
 
 
-class SqliteReader:
+@deprecated(version='2.1', reason="Use the name SqliteReader instead")
+class SqlReader:
     """
     Reads recorded CAN messages from a simple SQL database.
 
@@ -65,10 +68,8 @@ class SqliteReader:
         """Closes the connection to the database."""
         self.conn.close()
 
-
-# Backward compatibility
-# TODO remove in later releases?
-SqlReader = SqliteReader
+# SqliteReader is the newer name
+SqliteReader = SqlReader
 
 
 class SqliteWriter(BufferedReader):

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -52,7 +52,7 @@ class SqlReader:
     def __iter__(self):
         log.debug("Iterating through messages from sql db")
         for frame_data in self.cursor.execute(self._SELECT_ALL_COMMAND):
-            yield SqliteReader._create_frame_from_db_tuple(frame_data)
+            yield SqlReader._create_frame_from_db_tuple(frame_data)
 
     def __len__(self):
         # this might not run in constant time

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-pyserial
+pyserial >= 3.0
+Deprecated >= 1.1.0

--- a/setup.py
+++ b/setup.py
@@ -19,24 +19,44 @@ with open('README.rst', 'r') as f:
 logging.basicConfig(level=logging.WARNING)
 
 setup(
+
+    # Description
     name="python-can",
     url="https://github.com/hardbyte/python-can",
-    version=version,
-    packages=find_packages(),
-    author="Brian Thorne",
-    author_email="brian@thorne.link",
     description="Controller Area Network interface module for Python",
     long_description=long_description,
+
+    # Code
+    version=version,
+    packages=find_packages(),
+    
+    # Author
+    author="Brian Thorne",
+    author_email="brian@thorne.link",
+
+    # License
     license="LGPL v3",
+
+    # Package data
     package_data={
         "": ["CONTRIBUTORS.txt", "LICENSE.txt"],
         "doc": ["*.*"]
     },
-    # Tests can be run using `python setup.py test`
-    test_suite="nose.collector",
-    tests_require=['mock', 'nose', 'pyserial'],
+
+    # Installation
+    install_requires=[
+        'Deprecated >= 1.1.0',
+    ],
     extras_require={
-        'serial': ['pyserial'],
+        'serial': ['pyserial >= 3.0'],
         'neovi': ['python-ics'],
-    }
+    },
+
+    # Testing
+    test_suite="nose.collector",
+    tests_require=[
+        'mock',
+        'nose',
+        'pyserial >= 3.0'
+    ],
 )

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+# coding: utf-8

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -3,22 +3,19 @@
 
 """
 This module tests two virtual busses attached to each other.
-
-Some tests are skipped when run on Travis CI because they are not
-reproducible, see #243 (https://github.com/hardbyte/python-can/issues/243).
 """
 
-import os
+from __future__ import absolute_import
+
 import unittest
 import time
 
 import can
 
-IS_TRAVIS = os.environ.get('TRAVIS', 'default') == 'true'
+from .config import *
 
 BITRATE = 500000
 TIMEOUT = 0.1
-TEST_CAN_FD = True
 
 INTERFACE_1 = 'virtual'
 CHANNEL_1 = 'vcan0'
@@ -79,7 +76,7 @@ class Back2BackTestCase(unittest.TestCase):
     def test_no_message(self):
         self.assertIsNone(self.bus1.recv(0.1))
 
-    @unittest.skipIf(IS_TRAVIS, "skip on Travis CI")
+    @unittest.skipIf(IS_CI, "the timing sensitive behaviour cannot be reproduced reliably on a CI server")
     def test_timestamp(self):
         self.bus2.send(can.Message())
         recv_msg1 = self.bus1.recv(TIMEOUT)

--- a/test/config.py
+++ b/test/config.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+"""
+This module contains some configuration for the tests.
+
+Some tests are skipped when run on a CI server because they are not
+reproducible, see #243 (https://github.com/hardbyte/python-can/issues/243).
+"""
+
+from os import environ as environment
+
+# see here for the environment variables that are set on the CI servers:
+#   - https://docs.travis-ci.com/user/environment-variables/
+#   - https://www.appveyor.com/docs/environment-variables/
+
+IS_TRAVIS = environment.get('TRAVIS', '').lower() == 'true'
+IS_APPVEYOR = environment.get('APPVEYOR', '').lower() == 'true'
+
+IS_CI = IS_TRAVIS or IS_APPVEYOR or \
+        environment.get('CI', '').lower() == 'true' or \
+        environment.get('CONTINUOUS_INTEGRATION', '').lower() == 'true'
+
+TEST_CAN_FD = True

--- a/test/listener_test.py
+++ b/test/listener_test.py
@@ -4,6 +4,8 @@
 """
 """
 
+from __future__ import absolute_import
+
 from time import sleep
 import unittest
 import random
@@ -14,7 +16,7 @@ import sqlite3
 
 import can
 
-from data.example_data import generate_message
+from .data.example_data import generate_message
 
 channel = 'vcan0'
 can.rc['interface'] = 'virtual'

--- a/test/logformats_test.py
+++ b/test/logformats_test.py
@@ -12,6 +12,7 @@ comments.
 """
 
 from __future__ import print_function
+from __future__ import absolute_import
 
 import unittest
 import tempfile
@@ -28,9 +29,9 @@ except ImportError:
 
 import can
 
-from data.example_data import TEST_MESSAGES_BASE, TEST_MESSAGES_REMOTE_FRAMES, \
-                              TEST_MESSAGES_ERROR_FRAMES, TEST_COMMENTS, \
-                              generate_message
+from .data.example_data import TEST_MESSAGES_BASE, TEST_MESSAGES_REMOTE_FRAMES, \
+                               TEST_MESSAGES_ERROR_FRAMES, TEST_COMMENTS, \
+                               generate_message
 
 
 def _test_writer_and_reader(test_case, writer_constructor, reader_constructor, sleep_time=None,

--- a/test/simplecyclic_test.py
+++ b/test/simplecyclic_test.py
@@ -3,22 +3,20 @@
 
 """
 This module tests cyclic send tasks.
-
-Some tests are skipped when run on Travis CI because they are not
-reproducible, see #243 (https://github.com/hardbyte/python-can/issues/243).
 """
 
-import os
+from __future__ import absolute_import
+
 from time import sleep
 import unittest
 
 import can
 
-IS_TRAVIS = os.environ.get('TRAVIS', 'default') == 'true'
+from .config import *
 
 class SimpleCyclicSendTaskTest(unittest.TestCase):
 
-    @unittest.skipIf(IS_TRAVIS, "skip on Travis CI")
+    @unittest.skipIf(IS_CI, "the timing sensitive behaviour cannot be reproduced reliably on a CI server")
     def test_cycle_time(self):
         msg = can.Message(extended_id=False, arbitration_id=0x100, data=[0,1,2,3,4,5,6,7])
         bus1 = can.interface.Bus(bustype='virtual')


### PR DESCRIPTION
This adds CI tests on Windows. I also factored out common skipping behavior (`@skipIf(IS_TRAVIS, "...")`) and replaced it with generic CI skipping behavior (`@skipIf(IS_CI, "...")`). The constants are defined in `test/config.py` and define some properties in a central place:

- IS_TRAVIS
- IS_APPVEYOR
- IS_CI
- TEST_CAN_FD
- More? Maybe whether to test on hardware, but is that the right place for stuff like that? Your thoughts?

Closes #260.

Still work in progress.