### PR TITLE
Remove `load_default_settings` call in init

### DIFF
--- a/can/interfaces/ics_neovi/neovi_bus.py
+++ b/can/interfaces/ics_neovi/neovi_bus.py
@@ -106,8 +106,6 @@ class NeoViBus(BusABC):
         )
         logger.info("Using device: {}".format(self.channel_info))
 
-        ics.load_default_settings(self.dev)
-
         self.sw_filters = None
         self.set_filters(can_filters)
         self.rx_buffer = deque()


### PR DESCRIPTION
`load_default_settings` is not supported in the open source version of icsneoapi