### PR TITLE
Feature: API for automatic configuration detection

### DIFF
--- a/can/__init__.py
+++ b/can/__init__.py
@@ -35,7 +35,7 @@ from can.bus import BusABC
 from can.notifier import Notifier
 from can.interfaces import VALID_INTERFACES
 from . import interface
-from .interface import Bus
+from .interface import Bus, detect_available_channels
 
 from can.broadcastmanager import send_periodic, \
     CyclicSendTaskABC, \

--- a/can/__init__.py
+++ b/can/__init__.py
@@ -35,7 +35,7 @@ from can.bus import BusABC
 from can.notifier import Notifier
 from can.interfaces import VALID_INTERFACES
 from . import interface
-from .interface import Bus, detect_available_channels
+from .interface import Bus, detect_available_configs
 
 from can.broadcastmanager import send_periodic, \
     CyclicSendTaskABC, \

--- a/can/bus.py
+++ b/can/bus.py
@@ -25,6 +25,11 @@ class BusABC(object):
 
     As well as setting the `channel_info` attribute to a string describing the
     interface.
+
+    They may implement :meth:`~can.BusABC._detect_available_configs` to allow
+    the interface to report which configurations are currently available for
+    new connections.
+
     """
 
     #: a string describing the underlying bus channel
@@ -145,5 +150,20 @@ class BusABC(object):
         in shutting down a bus.
         """
         self.flush_tx_buffer()
+
+    @staticmethod
+    def _detect_available_configs():
+        """Detect all configurations/channels that this interface could
+        currently connect with.
+
+        This might be quite time consuming.
+
+        May not to be implemented by every interface.
+
+        :rtype: Iterator[dict]
+        :return: an iterable of dicts, each being a configuration suitable
+                 for usage in the interface's bus constructor.
+        """
+        raise NotImplementedError()
 
     __metaclass__ = ABCMeta

--- a/can/bus.py
+++ b/can/bus.py
@@ -158,7 +158,7 @@ class BusABC(object):
 
         This might be quite time consuming.
 
-        May not to be implemented by every interface.
+        May not to be implemented by every interface on every platform.
 
         :rtype: Iterator[dict]
         :return: an iterable of dicts, each being a configuration suitable

--- a/can/interface.py
+++ b/can/interface.py
@@ -146,7 +146,7 @@ def detect_available_configs(search_only_in=None):
     # Figure out where to search
     if search_only_in is None:
         # use an iterator over the keys so we do not have to copy it
-        search_only_in = BACKENDS.iterkeys()
+        search_only_in = BACKENDS.keys()
     elif isinstance(search_only_in, basestring):
         search_only_in = [search_only_in, ]
     # else it is supposed to be an iterable of strings

--- a/can/interface.py
+++ b/can/interface.py
@@ -120,7 +120,7 @@ class Bus(BusABC):
         return cls(channel=config['channel'], *args, **kwargs)
 
 
-def detect_available_channels(search_only_in=None):
+def detect_available_configs(search_only_in=None):
     """Detect all configurations/channels that the interfaces could
     currently connect with.
 
@@ -153,7 +153,7 @@ def detect_available_channels(search_only_in=None):
 
         # get available channels
         try:
-            available = bus_class._detect_available_channels()
+            available = bus_class.detect_available_configs()
         except NotImplementedError:
             log.debug('interface "%s" does not support detection of available configurations', interface)
         else:

--- a/can/interface.py
+++ b/can/interface.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import
 import sys
 import importlib
 from pkg_resources import iter_entry_points
+import logging
 
 import can
 from .bus import BusABC
@@ -20,6 +21,9 @@ from .util import load_config
 
 if sys.version_info.major > 2:
     basestring = str
+
+
+log = logging.getLogger('can.interface')
 
 
 # interface_name => (module, classname)
@@ -137,6 +141,7 @@ def detect_available_configs(search_only_in=None):
     :return: an iterable of dicts, each suitable for usage in
              :class:`~can.interface.Bus`'s constructor.
     """
+    logger = log.getChild('detect_available_configs')
 
     # Figure out where to search
     if search_only_in is None:
@@ -153,11 +158,11 @@ def detect_available_configs(search_only_in=None):
 
         # get available channels
         try:
-            available = bus_class.detect_available_configs()
+            available = bus_class._detect_available_configs()
         except NotImplementedError:
-            log.debug('interface "%s" does not support detection of available configurations', interface)
+            logger.debug('interface "%s" does not support detection of available configurations', interface)
         else:
-            log.debug('interface "%s" detected %i available configurations', interface, len(available))
+            logger.debug('interface "%s" detected %i available configurations', interface, len(available))
 
             # add the interface name to the configs if it is not already present
             for config in available:

--- a/can/interface.py
+++ b/can/interface.py
@@ -62,7 +62,10 @@ def _get_class_for_interface(interface):
 
     # filter out the socketcan special case
     if interface == 'socketcan':
-        interface = can.util.choose_socketcan_implementation()
+        try:
+            interface = can.util.choose_socketcan_implementation()
+        except Exception as e:
+            raise ImportError("Cannot choose socketcan implementation: {}".format(e))
 
     # Find the correct backend
     try:
@@ -135,7 +138,9 @@ def detect_available_configs(search_only_in=None):
     This might be quite time consuming. 
 
     Automated configuration detection may not be implemented by
-    every interface on every platform.
+    every interface on every platform. This method will not raise
+    an error in that case, but with rather return an empty list
+    for that interface.
 
     :param search_only_in: either
         - the name of an interface to be searched in as a string,
@@ -166,7 +171,7 @@ def detect_available_configs(search_only_in=None):
 
         # get available channels
         try:
-            available = bus_class._detect_available_configs()
+            available = list(bus_class._detect_available_configs())
         except NotImplementedError:
             logger.debug('interface "%s" does not support detection of available configurations', interface)
         else:

--- a/can/interface.py
+++ b/can/interface.py
@@ -56,8 +56,8 @@ def _get_class_for_interface(interface):
     :raises:
         NotImplementedError if the interface is not known
     :raises:
-        ImportError if there was a problem while importing the
-        interface or the bus class within that
+        ImportError     if there was a problem while importing the
+                        interface or the bus class within that
     """
 
     # Find the correct backend
@@ -137,7 +137,7 @@ def detect_available_configs(search_only_in=None):
         - the name of an interface to be searched in as a string,
         - an iterable of interface names to search in, or
         - `None` to search in all known interfaces.
-    :rtype: Iterator[dict]
+    :rtype: list of `dict`s
     :return: an iterable of dicts, each suitable for usage in
              :class:`~can.interface.Bus`'s constructor.
     """
@@ -154,7 +154,11 @@ def detect_available_configs(search_only_in=None):
     result = []
     for interface in search_only_in:
 
-        bus_class = _get_class_for_interface(interface)
+        try:
+            bus_class = _get_class_for_interface(interface)
+        except ImportError:
+            logger.debug('interface "%s" can not be loaded for detection of available configurations', interface)
+            continue
 
         # get available channels
         try:

--- a/can/interface.py
+++ b/can/interface.py
@@ -9,12 +9,13 @@ CyclicSendTasks.
 
 from __future__ import absolute_import
 
-import can
 import importlib
 from pkg_resources import iter_entry_points
 
-from can.broadcastmanager import CyclicSendTaskABC, MultiRateCyclicSendTaskABC
-from can.util import load_config
+import can
+from .bus import BusABC
+from .broadcastmanager import CyclicSendTaskABC, MultiRateCyclicSendTaskABC
+from .util import load_config
 
 
 # interface_name => (module, classname)
@@ -77,7 +78,7 @@ def _get_class_for_interface(interface):
     return bus_class
 
 
-class Bus(object):
+class Bus(BusABC):
     """
     Instantiates a CAN Bus of the given `bustype`, falls back to reading a
     configuration file from default locations.

--- a/can/interface.py
+++ b/can/interface.py
@@ -60,6 +60,10 @@ def _get_class_for_interface(interface):
                         interface or the bus class within that
     """
 
+    # filter out the socketcan special case
+    if interface == 'socketcan':
+        interface = can.util.choose_socketcan_implementation()
+
     # Find the correct backend
     try:
         module_name, class_name = BACKENDS[interface]

--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -7,6 +7,7 @@ Interfaces contain low level implementations that interact with CAN hardware.
 
 from pkg_resources import iter_entry_points
 
+# TODO: isn't this a unnecessary information duplicate of `can/interface.py :: BACKENDS`?
 VALID_INTERFACES = set(['kvaser', 'serial', 'pcan', 'socketcan_native',
                         'socketcan_ctypes', 'socketcan', 'usb2can', 'ixxat',
                         'nican', 'iscan', 'vector', 'virtual', 'neovi',

--- a/can/interfaces/socketcan/__init__.py
+++ b/can/interfaces/socketcan/__init__.py
@@ -2,6 +2,7 @@
 # coding: utf-8
 
 """
+See: https://www.kernel.org/doc/Documentation/networking/can.txt
 """
 
 from can.interfaces.socketcan import socketcan_constants as constants

--- a/can/interfaces/socketcan/socketcan_common.py
+++ b/can/interfaces/socketcan/socketcan_common.py
@@ -58,17 +58,17 @@ def find_available_interfaces():
         # it might be good to add "type vcan", but that might (?) exclude physical can devices
         command = ["ip", "-o", "link", "list", "up"]
         output = subprocess.check_output(command, universal_newlines=True)
-        log.debug("find_available_interfaces(): output=\n%s", output)
 
     except Exception as e: # subprocess.CalledProcessError was too specific
         log.error("failed to fetch opened can devices: %s", e)
         return []
 
     else:
+        #log.debug("find_available_interfaces(): output=\n%s", output)
         # output contains some lines like "1: vcan42: <NOARP,UP,LOWER_UP> ..."
         # extract the "vcan42" of each line
         interface_names = [line.split(": ", 3)[1] for line in output.splitlines()]
-        log.debug("find_available_interfaces(): detected names: %s", interface_names)
+        log.debug("find_available_interfaces(): detected: %s", interface_names)
         return filter(_PATTERN_CAN_INTERFACE.match, interface_names)
 
 def error_code_to_str(code):

--- a/can/interfaces/socketcan/socketcan_common.py
+++ b/can/interfaces/socketcan/socketcan_common.py
@@ -10,7 +10,7 @@ import os
 import errno
 import struct
 import sys
-if sys.version_info.major < 3: # and os.name == 'posix'
+if sys.version_info[0] < 3 and os.name == 'posix':
     import subprocess32 as subprocess
 else:
     import subprocess
@@ -55,7 +55,7 @@ def find_available_interfaces():
         command = ["ip", "-br", "-0", "link", "list", "up"]
         output = subprocess.check_output(command, universal_newlines=True)
 
-    except (subprocess.SubprocessError, FileNotFoundError) as e:
+    except (subprocess.CalledProcessError, FileNotFoundError, Exception) as e:
         log.error("failed to fetch opened can devices: %s", e)
         return []
 

--- a/can/interfaces/socketcan/socketcan_common.py
+++ b/can/interfaces/socketcan/socketcan_common.py
@@ -58,6 +58,7 @@ def find_available_interfaces():
         # it might be good to add "type vcan", but that might (?) exclude physical can devices
         command = ["ip", "-o", "link", "list", "up"]
         output = subprocess.check_output(command, universal_newlines=True)
+        log.debug('find_available_interfaces(): output="%s"', output)
 
     except Exception as e: # subprocess.CalledProcessError was too specific
         log.error("failed to fetch opened can devices: %s", e)

--- a/can/interfaces/socketcan/socketcan_common.py
+++ b/can/interfaces/socketcan/socketcan_common.py
@@ -67,8 +67,8 @@ def find_available_interfaces():
     else:
         # output contains some lines like "1: vcan42: <NOARP,UP,LOWER_UP> ..."
         # extract the "vcan42" of each line
-        interface_names = [line.split(": ", 3)[0] for line in output.splitlines()]
-        log.debug("interface names: %s", interface_names)
+        interface_names = [line.split(": ", 3)[1] for line in output.splitlines()]
+        log.debug("find_available_interfaces(): detected names: %s", interface_names)
         return filter(_PATTERN_CAN_INTERFACE.match, interface_names)
 
 def error_code_to_str(code):

--- a/can/interfaces/socketcan/socketcan_common.py
+++ b/can/interfaces/socketcan/socketcan_common.py
@@ -58,7 +58,7 @@ def find_available_interfaces():
         # it might be good to add "type vcan", but that might (?) exclude physical can devices
         command = ["ip", "-o", "link", "list", "up"]
         output = subprocess.check_output(command, universal_newlines=True)
-        log.debug('find_available_interfaces(): output="%s"', output)
+        log.debug("find_available_interfaces(): output=\n%s", output)
 
     except Exception as e: # subprocess.CalledProcessError was too specific
         log.error("failed to fetch opened can devices: %s", e)
@@ -68,6 +68,7 @@ def find_available_interfaces():
         # output contains some lines like "1: vcan42: <NOARP,UP,LOWER_UP> ..."
         # extract the "vcan42" of each line
         interface_names = [line.split(": ", 3)[0] for line in output.splitlines()]
+        log.debug("interface names: %s", interface_names)
         return filter(_PATTERN_CAN_INTERFACE.match, interface_names)
 
 def error_code_to_str(code):

--- a/can/interfaces/socketcan/socketcan_common.py
+++ b/can/interfaces/socketcan/socketcan_common.py
@@ -47,7 +47,7 @@ def find_available_interfaces():
     the ``ip link list`` command. If the lookup fails, an error
     is logged to the console and an empty list is returned.
 
-    :rtype: Iterator[:class:`str`]
+    :rtype: an iterable of :class:`str`
     """
 
     try:
@@ -62,8 +62,7 @@ def find_available_interfaces():
     else:
         # output contains some lines like "vcan42           UNKNOWN        <NOARP,UP,LOWER_UP>"
         # return the first entry of each line
-        for line in output.splitlines():
-            yield line.split()[0]
+        return [line.split()[0] for line in output.splitlines()]
 
 def error_code_to_str(code):
     """

--- a/can/interfaces/socketcan/socketcan_common.py
+++ b/can/interfaces/socketcan/socketcan_common.py
@@ -55,7 +55,7 @@ def find_available_interfaces():
         command = ["ip", "-br", "-0", "link", "list", "up"]
         output = subprocess.check_output(command, universal_newlines=True)
 
-    except subprocess.CalledProcessError as e:
+    except (subprocess.SubprocessError, FileNotFoundError) as e:
         log.error("failed to fetch opened can devices: %s", e)
         return []
 

--- a/can/interfaces/socketcan/socketcan_common.py
+++ b/can/interfaces/socketcan/socketcan_common.py
@@ -55,7 +55,7 @@ def find_available_interfaces():
         command = ["ip", "-br", "-0", "link", "list", "up"]
         output = subprocess.check_output(command, universal_newlines=True)
 
-    except subprocess.CalledProcessError, e:
+    except subprocess.CalledProcessError as e:
         log.error("failed to fetch opened can devices: %s", e)
         return []
 

--- a/can/interfaces/socketcan/socketcan_ctypes.py
+++ b/can/interfaces/socketcan/socketcan_ctypes.py
@@ -167,7 +167,8 @@ class SocketcanCtypes_Bus(BusABC):
 
     @staticmethod
     def _detect_available_configs():
-        return find_available_interfaces()
+        return [{'interface': 'socketcan_ctypes', 'channel': channel}
+                for channel in find_available_interfaces()]
 
 
 class SOCKADDR(ctypes.Structure):

--- a/can/interfaces/socketcan/socketcan_ctypes.py
+++ b/can/interfaces/socketcan/socketcan_ctypes.py
@@ -18,7 +18,8 @@ from can.broadcastmanager import CyclicSendTaskABC, RestartableCyclicTaskABC, Mo
 from can.bus import BusABC
 from can.message import Message
 from can.interfaces.socketcan.socketcan_constants import *  # CAN_RAW
-from can.interfaces.socketcan.socketcan_common import *
+from can.interfaces.socketcan.socketcan_common import \
+    pack_filters, find_available_interfaces, error_code_to_str
 
 # Set up logging
 log = logging.getLogger('can.socketcan.ctypes')
@@ -163,6 +164,10 @@ class SocketcanCtypes_Bus(BusABC):
             threading.Timer(duration, task.stop).start()
 
         return task
+
+    @staticmethod
+    def _detect_available_configs():
+        return find_available_interfaces()
 
 
 class SOCKADDR(ctypes.Structure):

--- a/can/interfaces/socketcan/socketcan_native.py
+++ b/can/interfaces/socketcan/socketcan_native.py
@@ -3,7 +3,9 @@
 
 """
 This implementation is for versions of Python that have native
-can socket and can bcm socket support: >=3.5
+can socket and can bcm socket support.
+
+See :meth:`can.util.choose_socketcan_implementation()`.
 """
 
 import logging
@@ -32,13 +34,12 @@ except:
     log.error("CAN_* properties not found in socket module. These are required to use native socketcan")
 
 import can
-
-from can.interfaces.socketcan.socketcan_constants import *  # CAN_RAW, CAN_*_FLAG
+from can import Message, BusABC
+from can.broadcastmanager import ModifiableCyclicTaskABC, \
+    RestartableCyclicTaskABC, LimitedDurationCyclicSendTaskABC
+from can.interfaces.socketcan.socketcan_constants import * # CAN_RAW, CAN_*_FLAG
 from can.interfaces.socketcan.socketcan_common import \
     pack_filters, find_available_interfaces, error_code_to_str
-from can import Message, BusABC
-
-from can.broadcastmanager import ModifiableCyclicTaskABC, RestartableCyclicTaskABC, LimitedDurationCyclicSendTaskABC
 
 # struct module defines a binary packing format:
 # https://docs.python.org/3/library/struct.html#struct-format-strings

--- a/can/interfaces/socketcan/socketcan_native.py
+++ b/can/interfaces/socketcan/socketcan_native.py
@@ -495,7 +495,8 @@ class SocketcanNative_Bus(BusABC):
 
     @staticmethod
     def _detect_available_configs():
-        return find_available_interfaces()
+        return [{'interface': 'socketcan_native', 'channel': channel}
+                for channel in find_available_interfaces()]
 
 
 if __name__ == "__main__":

--- a/can/interfaces/socketcan/socketcan_native.py
+++ b/can/interfaces/socketcan/socketcan_native.py
@@ -34,7 +34,8 @@ except:
 import can
 
 from can.interfaces.socketcan.socketcan_constants import *  # CAN_RAW, CAN_*_FLAG
-from can.interfaces.socketcan.socketcan_common import *
+from can.interfaces.socketcan.socketcan_common import \
+    pack_filters, find_available_interfaces, error_code_to_str
 from can import Message, BusABC
 
 from can.broadcastmanager import ModifiableCyclicTaskABC, RestartableCyclicTaskABC, LimitedDurationCyclicSendTaskABC
@@ -491,6 +492,10 @@ class SocketcanNative_Bus(BusABC):
         self.socket.setsockopt(socket.SOL_CAN_RAW,
                                socket.CAN_RAW_FILTER,
                                filter_struct)
+
+    @staticmethod
+    def _detect_available_configs():
+        return find_available_interfaces()
 
 
 if __name__ == "__main__":

--- a/can/interfaces/virtual.py
+++ b/can/interfaces/virtual.py
@@ -100,4 +100,9 @@ class VirtualBus(BusABC):
         while extra in available_channels:
             extra = get_extra()
 
-        return available_channels + [extra]
+        available_channels += [extra]
+
+        return [
+            {'interface': 'virtual', 'channel': channel}
+            for channel in available_channels
+        ]

--- a/can/interfaces/virtual.py
+++ b/can/interfaces/virtual.py
@@ -92,7 +92,7 @@ class VirtualBus(BusABC):
         autodetected busses are used at once.
         """
         with channels_lock:
-            available_channels = channels.keys()
+            available_channels = list(channels.keys())
 
         # find a currently unused channel
         get_extra = lambda: "channel-{}".format(random.randint(0, 9999))

--- a/can/interfaces/virtual.py
+++ b/can/interfaces/virtual.py
@@ -44,15 +44,15 @@ class VirtualBus(BusABC):
     def __init__(self, channel=None, receive_own_messages=False, **config):
         # the channel identifier may be an arbitrary object
         self.channel_id = channel
-        self.channel_info = 'Virtual bus channel %s' % channel_id
+        self.channel_info = 'Virtual bus channel %s' % self.channel_id
         self.receive_own_messages = receive_own_messages
 
         with channels_lock:
 
             # Create a new channel if one does not exist
-            if channel_id not in channels:
-                channels[channel_id] = []
-            self.channel = channels[channel_id]
+            if self.channel_id not in channels:
+                channels[self.channel_id] = []
+            self.channel = channels[self.channel_id]
 
             self.queue = queue.Queue()
             self.channel.append(self.queue)
@@ -80,7 +80,7 @@ class VirtualBus(BusABC):
 
             # remove if emtpy
             if not self.channel:
-                del channels[channel_id]
+                del channels[self.channel_id]
 
     @staticmethod
     def _detect_available_configs():

--- a/setup.py
+++ b/setup.py
@@ -39,13 +39,13 @@ setup(
 
     # Package data
     package_data={
-        "": ["CONTRIBUTORS.txt", "LICENSE.txt"],
+        "": ["CONTRIBUTORS.txt", "LICENSE.txt", "CHANGELOG.txt"],
         "doc": ["*.*"]
     },
 
-    # Installation
+    # Installation; see https://www.python.org/dev/peps/pep-0440/#version-specifiers
     install_requires=[
-        #'Deprecated >= 1.1.0',
+        'subprocess32 ~= 3.2.7',
     ],
     extras_require={
         'serial': ['pyserial >= 3.0'],
@@ -55,8 +55,8 @@ setup(
     # Testing
     test_suite="nose.collector",
     tests_require=[
-        'mock',
-        'nose',
+        'mock >= 2.0.0',
+        'nose >= 1.3.7',
         'pyserial >= 3.0'
     ],
 )

--- a/test/sockectan_helpers.py
+++ b/test/sockectan_helpers.py
@@ -14,7 +14,7 @@ from can.interfaces.socketcan.socketcan_common import \
 
 from .config import *
 
-@unittest.skipUnless(IS_UNIX, "skip if not on UNIX")
+@unittest.skipUnless(IS_LINUX, "skip if not on UNIX")
 class TestSocketCanHelpers(unittest.TestCase):
 
     def test_error_code_to_str(self):

--- a/test/sockectan_helpers.py
+++ b/test/sockectan_helpers.py
@@ -2,18 +2,21 @@
 # coding: utf-8
 
 """
+Tests helpers in `can.interfaces.socketcan.socketcan_common`.
 """
 
 from __future__ import absolute_import
 
 import unittest
 
-from .config import *
-from can.interfaces.socketcan.socketcan_common import error_code_to_str
+from can.interfaces.socketcan.socketcan_common import \
+    find_available_interfaces, error_code_to_str
 
+from .config import *
+
+@unittest.skipUnless(IS_UNIX, "skip if not on UNIX")
 class TestSocketCanHelpers(unittest.TestCase):
 
-    @unittest.skipUnless(IS_UNIX, "skip if not on UNIX")
     def test_error_code_to_str(self):
         """
         Check that the function does not crash & always
@@ -26,6 +29,15 @@ class TestSocketCanHelpers(unittest.TestCase):
         for error_code in test_data:
             string = error_code_to_str(error_code)
             self.assertTrue(string) # not None or empty
+
+    def test_find_available_interfaces(self):
+        result = list(find_available_interfaces())
+        self.assertGreaterEqual(len(result), 1)
+        for entry in result:
+            self.assertRegexpMatches(entry, r"v?can\d+")
+        if IS_CI:
+            self.assertIn("vcan0", result)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/sockectan_helpers.py
+++ b/test/sockectan_helpers.py
@@ -14,7 +14,7 @@ from can.interfaces.socketcan.socketcan_common import \
 
 from .config import *
 
-@unittest.skipUnless(IS_LINUX, "skip if not on UNIX")
+@unittest.skipUnless(IS_LINUX, "socketcan is only available on Linux")
 class TestSocketCanHelpers(unittest.TestCase):
 
     def test_error_code_to_str(self):

--- a/test/sockectan_helpers.py
+++ b/test/sockectan_helpers.py
@@ -14,9 +14,10 @@ from can.interfaces.socketcan.socketcan_common import \
 
 from .config import *
 
-@unittest.skipUnless(IS_LINUX, "socketcan is only available on Linux")
+
 class TestSocketCanHelpers(unittest.TestCase):
 
+    @unittest.skipUnless(IS_LINUX, "socketcan is only available on Linux")
     def test_error_code_to_str(self):
         """
         Check that the function does not crash & always
@@ -30,12 +31,14 @@ class TestSocketCanHelpers(unittest.TestCase):
             string = error_code_to_str(error_code)
             self.assertTrue(string) # not None or empty
 
+    @unittest.skipUnless(IS_LINUX, "socketcan is only available on Linux")
     def test_find_available_interfaces(self):
         result = list(find_available_interfaces())
-        self.assertGreaterEqual(len(result), 1)
+        self.assertGreaterEqual(len(result), 0)
         for entry in result:
             self.assertRegexpMatches(entry, r"v?can\d+")
         if IS_CI:
+            self.assertGreaterEqual(len(result), 1)
             self.assertIn("vcan0", result)
 
 

--- a/test/test_detect_available_configs.py
+++ b/test/test_detect_available_configs.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+"""
+This module tests :meth:`can.BusABC._detect_available_configs` /
+:meth:`can.BusABC.detect_available_configs`.
+"""
+
+import sys
+import unittest
+
+from can import detect_available_configs
+
+if sys.version_info.major > 2:
+    basestring = str
+
+
+class TestDetectAvailableConfigs(unittest.TestCase):
+
+    def test_count_returned(self):
+        # At least virtual has to always return at least one interface
+        self.assertGreaterEqual (len(detect_available_configs()                             ), 1)
+        self.assertEquals       (len(detect_available_configs(search_only_in=[])            ), 0)
+        self.assertGreaterEqual (len(detect_available_configs(search_only_in='virtual')     ), 1)
+        self.assertGreaterEqual (len(detect_available_configs(search_only_in=['virtual'])   ), 1)
+        self.assertGreaterEqual (len(detect_available_configs(search_only_in=None)          ), 1)
+
+    def test_general_values(self):
+        returned = detect_available_configs()
+        for config in returned:
+            self.assertIn('interface', config)
+            self.assertIn('channel', config)
+            self.assertIsInstance(config['interface'], basestring)
+
+    def test_content_virtual(self):
+        returned = detect_available_configs(search_only_in='virtual')
+        for config in returned:
+            self.assertEqual(config['interface'], 'virtual')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_detect_available_configs.py
+++ b/test/test_detect_available_configs.py
@@ -6,13 +6,16 @@ This module tests :meth:`can.BusABC._detect_available_configs` /
 :meth:`can.BusABC.detect_available_configs`.
 """
 
+from __future__ import absolute_import
+
 import sys
 import unittest
+if sys.version_info.major > 2:
+    basestring = str
 
 from can import detect_available_configs
 
-if sys.version_info.major > 2:
-    basestring = str
+from .config import IS_LINUX
 
 
 class TestDetectAvailableConfigs(unittest.TestCase):

--- a/test/test_detect_available_configs.py
+++ b/test/test_detect_available_configs.py
@@ -29,21 +29,26 @@ class TestDetectAvailableConfigs(unittest.TestCase):
         self.assertGreaterEqual (len(detect_available_configs(search_only_in=None)          ), 1)
 
     def test_general_values(self):
-        returned = detect_available_configs()
-        for config in returned:
+        configs = detect_available_configs()
+        for config in configs:
             self.assertIn('interface', config)
             self.assertIn('channel', config)
             self.assertIsInstance(config['interface'], basestring)
 
     def test_content_virtual(self):
-        returned = detect_available_configs(search_only_in='virtual')
-        for config in returned:
+        configs = detect_available_configs(search_only_in='virtual')
+        for config in configs:
             self.assertEqual(config['interface'], 'virtual')
 
     def test_content_socketcan(self):
-        returned = detect_available_configs(search_only_in='socketcan')
-        for config in returned:
-            self.assertRegexpMatches(config['interface'], r"socketcan(_(ctypes|native))?")
+        configs = detect_available_configs(search_only_in='socketcan')
+        for config in configs:
+            self.assertIn(config['interface'], ('socketcan_native', 'socketcan_ctypes'))
+
+    def test_socketcan_on_ci_server(self):
+        configs = detect_available_configs(search_only_in='socketcan')
+        self.assertGreaterEqual(len(configs), 1)
+        self.assertIn('vcan0', [config['channel'] for config in configs])
 
     # see TestSocketCanHelpers.test_find_available_interfaces()
 

--- a/test/test_detect_available_configs.py
+++ b/test/test_detect_available_configs.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 
 """
-This module tests :meth:`can.BusABC._detect_available_configs` /
+This module tests :meth:`can.BusABC._detect_available_configs` and
 :meth:`can.BusABC.detect_available_configs`.
 """
 
@@ -22,11 +22,11 @@ class TestDetectAvailableConfigs(unittest.TestCase):
 
     def test_count_returned(self):
         # At least virtual has to always return at least one interface
-        self.assertGreaterEqual (len(detect_available_configs()                             ), 1)
-        self.assertEquals       (len(detect_available_configs(search_only_in=[])            ), 0)
-        self.assertGreaterEqual (len(detect_available_configs(search_only_in='virtual')     ), 1)
-        self.assertGreaterEqual (len(detect_available_configs(search_only_in=['virtual'])   ), 1)
-        self.assertGreaterEqual (len(detect_available_configs(search_only_in=None)          ), 1)
+        self.assertGreaterEqual (len(detect_available_configs()                         ), 1)
+        self.assertEquals       (len(detect_available_configs(interfaces=[])            ), 0)
+        self.assertGreaterEqual (len(detect_available_configs(interfaces='virtual')     ), 1)
+        self.assertGreaterEqual (len(detect_available_configs(interfaces=['virtual'])   ), 1)
+        self.assertGreaterEqual (len(detect_available_configs(interfaces=None)          ), 1)
 
     def test_general_values(self):
         configs = detect_available_configs()
@@ -36,18 +36,18 @@ class TestDetectAvailableConfigs(unittest.TestCase):
             self.assertIsInstance(config['interface'], basestring)
 
     def test_content_virtual(self):
-        configs = detect_available_configs(search_only_in='virtual')
+        configs = detect_available_configs(interfaces='virtual')
         for config in configs:
             self.assertEqual(config['interface'], 'virtual')
 
     def test_content_socketcan(self):
-        configs = detect_available_configs(search_only_in='socketcan')
+        configs = detect_available_configs(interfaces='socketcan')
         for config in configs:
             self.assertIn(config['interface'], ('socketcan_native', 'socketcan_ctypes'))
 
     @unittest.skipUnless(IS_LINUX, "socketcan is only available on Linux")
     def test_socketcan_on_ci_server(self):
-        configs = detect_available_configs(search_only_in='socketcan')
+        configs = detect_available_configs(interfaces='socketcan')
         self.assertGreaterEqual(len(configs), 1)
         self.assertIn('vcan0', [config['channel'] for config in configs])
 

--- a/test/test_detect_available_configs.py
+++ b/test/test_detect_available_configs.py
@@ -37,5 +37,13 @@ class TestDetectAvailableConfigs(unittest.TestCase):
         for config in returned:
             self.assertEqual(config['interface'], 'virtual')
 
+    def test_content_socketcan(self):
+        returned = detect_available_configs(search_only_in='socketcan')
+        for config in returned:
+            self.assertRegexpMatches(config['interface'], r"socketcan(_(ctypes|native))?")
+
+    # see TestSocketCanHelpers.test_find_available_interfaces()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_detect_available_configs.py
+++ b/test/test_detect_available_configs.py
@@ -45,6 +45,7 @@ class TestDetectAvailableConfigs(unittest.TestCase):
         for config in configs:
             self.assertIn(config['interface'], ('socketcan_native', 'socketcan_ctypes'))
 
+    @unittest.skipUnless(IS_LINUX, "socketcan is only available on Linux")
     def test_socketcan_on_ci_server(self):
         configs = detect_available_configs(search_only_in='socketcan')
         self.assertGreaterEqual(len(configs), 1)


### PR DESCRIPTION
I added an API for interfaces to support automatic detection of currently available configurations/channels. **The API does not require any changes to existing interfaces.**

It only supports our internal interfaces for now, but I am open to suggestions on how to make it accessible for user defined buses as well.

I implemented the config detection in the virtual bus for now but plan to add more. While adding it, I also added some locks to the virtual bus since I noticed they are required there. 

Based on #51. Closes #51.