### PR TITLE
Fix SocketCAN version selection, many crashes and re-enabled tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,6 +14,14 @@ environment:
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
 
+    # officially unsupported
+    - PYTHON: "C:\\Python33"
+    - PYTHON: "C:\\Python33-x64"
+
+    allow_failures:
+      - PYTHON: "C:\\Python33"
+      - PYTHON: "C:\\Python33-x64"
+
 install:
   # We need to install the python-can library itself
   - "%PYTHON%\\python.exe -m pip install .[test]"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,6 @@ environment:
     # http://www.appveyor.com/docs/installed-software#python
 
     - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python33"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,6 @@ environment:
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python33-x64"
     - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,9 +18,10 @@ environment:
     - PYTHON: "C:\\Python33"
     - PYTHON: "C:\\Python33-x64"
 
-    allow_failures:
-      - PYTHON: "C:\\Python33"
-      - PYTHON: "C:\\Python33-x64"
+matrix:
+  allow_failures:
+    - PYTHON: "C:\\Python33"
+    - PYTHON: "C:\\Python33-x64"
 
 install:
   # We need to install the python-can library itself

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
   # CPython:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   # CPython:
   - "2.7"
+  - "3.3" # but allowed to fail
   - "3.4"
   - "3.5"
   - "3.6"
@@ -36,10 +37,14 @@ matrix:
     - os: osx
       python: "nightly"
 
-  # allow all nighly builds to fail, since these python versions might be unstable
-  # we do not allow dev builds to fail, since these builds are stable enough
   allow_failures:
+    # allow all nighly builds to fail, since these python versions might be unstable
     - python: "nightly"
+
+    # we do not allow dev builds to fail, since these builds are considered stable enough
+
+    # Python 3.3 tests are allowed to fail since Python 3.3 is not offically supported any more
+    - python: "3.3"
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo bash test/open_vcan.sh ; fi

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Python developers; providing `common abstractions to
 different hardware devices`, and a suite of utilities for sending and receiving
 messages on a can bus.
 
-The library supports Python 2.7, Python 3.3+ as well as PyPy 2 & 3 and runs on Mac, Linux and Windows.
+The library supports Python 2.7, Python 3.4+ as well as PyPy 2 & 3 and runs on Mac, Linux and Windows.
 
 You can find more information in the documentation, online at
 `python-can.readthedocs.org <https://python-can.readthedocs.org/en/stable/>`__.

--- a/can/util.py
+++ b/can/util.py
@@ -175,42 +175,50 @@ def choose_socketcan_implementation():
     :return:
         either 'socketcan_ctypes' or 'socketcan_native',
         depending on the current platform and environment
-    :raises Exception: If the system doesn't support SocketCAN
+    :raises Exception: If the system doesn't support SocketCAN at all
     """
 
-    # to support possible future versions of current platforms as well as potential
-    # other ones, we take the approach of feature checking instead of version checking
+    # Check OS: SocketCAN is available only under Linux
+    if not sys.platform.startswith('linux'):
+        msg = 'SocketCAN not available under {}'.format(sys.platform)
+        raise Exception(msg)
+
+    # Check release: SocketCAN was added to Linux 2.6.25
+    rel_string = platform.release()
+    m = re.match(r'\d+\.\d+\.\d', rel_string)
+    if not m: # None or empty
+        msg = 'Bad linux release {}'.format(rel_string)
+        raise Exception(msg)
+    rel_num = [int(i) for i in rel_string[:m.end()].split('.')]
+
+    if (rel_num < [2, 6, 25]):
+        msg = 'SocketCAN not available under Linux {}'.format(rel_string)
+        raise Exception(msg)
+
+    # Check Python version:
+    #
+    # CPython:
+    # Support for SocketCAN was added in Python 3.3, but support for
+    # CAN FD frames (with socket.CAN_RAW_FD_FRAMES) was just added
+    # to Python in version 3.5.
+    # So we want to use socketcan_native only on Python >= 3.5 (see #274).
+    #
+    # PyPy:
+    # Furthermore, socket.CAN_* is not supported by PyPy 2 or 3 (as of
+    # April 2018) at all. Thus we want to use socketcan_ctypes there as well.
+    #
+    # General approach:
+    # To support possible future versions of current platforms as well as
+    # potential other ones, we take the approach of feature checking instead
+    # of platform/version checking.
+
     try:
+        # try to import typical attributes
         from socket import CAN_RAW, CAN_BCM, CAN_RAW_FD_FRAMES
     except ImportError:
         return 'socketcan_ctypes'
     else:
         return 'socketcan_native'
-
-    # Check OS: SocketCAN is available only under Linux
-    if not sys.platform.startswith('linux'):
-        msg = 'SocketCAN not available under {}'.format(
-            sys.platform)
-        raise Exception(msg)
-    else:
-        # Check release: SocketCAN was added to Linux 2.6.25
-        rel_string = platform.release()
-        m = re.match(r'\d+\.\d+\.\d', rel_string)
-        if m is None:
-            msg = 'Bad linux release {}'.format(rel_string)
-            raise Exception(msg)
-        rel_num = [int(i) for i in rel_string[:m.end()].split('.')]
-        if (rel_num >= [2, 6, 25]):
-            # Check Python version: SocketCAN was added in Python 3.3
-            # but support for CAN FD frames (with socket.CAN_RAW_FD_FRAMES)
-            # was just added to Python in version 3.5, so we want to use
-            # socketcan native only on Python >= 3.5 (see #274)
-            # furthermore, CAN is not supported by PyPy 2 or 3 (as of April 2018)
-            # thus we want to use socketcan_ctypes there as well
-            return 'socketcan_native' if sys.version_info >= (3, 5) else 'socketcan_ctypes'
-        else:
-            msg = 'SocketCAN not available under Linux {}'.format(rel_string)
-            raise Exception(msg)
 
 
 def set_logging_level(level_name=None):

--- a/can/util.py
+++ b/can/util.py
@@ -169,9 +169,13 @@ def load_config(path=None, config=None):
 
 
 def choose_socketcan_implementation():
-    """Set the best version of SocketCAN for this system.
+    """Set the best version of the SocketCAN module for this system.
 
-    :param config: The can.rc configuration dictionary
+    :param config: The `can.rc` configuration dictionary
+    :rtype: str
+    :return:
+        either 'socketcan_ctypes' or 'socketcan_native',
+        depending on the current platform and environment
     :raises Exception: If the system doesn't support SocketCAN
     """
     # Check OS: SocketCAN is available only under Linux
@@ -188,11 +192,13 @@ def choose_socketcan_implementation():
             raise Exception(msg)
         rel_num = [int(i) for i in rel_string[:m.end()].split('.')]
         if (rel_num >= [2, 6, 25]):
-            # Check Python version: SocketCAN was added in 3.3
-            return 'socketcan_native' if sys.version_info >= (3, 3) else 'socketcan_ctypes'
+            # Check Python version: SocketCAN was added in Python 3.3
+            # but support for CAN FD frames (with socket.CAN_RAW_FD_FRAMES)
+            # was just added to Python in version 3.5, so we want to use
+            # socketcan native only on Python >= 3.5 (see #274)
+            return 'socketcan_native' if sys.version_info >= (3, 5) else 'socketcan_ctypes'
         else:
-            msg = 'SocketCAN not available under Linux {}'.format(
-                    rel_string)
+            msg = 'SocketCAN not available under Linux {}'.format(rel_string)
             raise Exception(msg)
 
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     # Code
     version=version,
     packages=find_packages(),
-    
+
     # Author
     author="Brian Thorne",
     author_email="brian@thorne.link",
@@ -44,6 +44,7 @@ setup(
     },
 
     # Installation
+    python_requires="2.7,>=3.4",
     install_requires=[
         #'Deprecated >= 1.1.0',
     ],

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -135,9 +135,7 @@ class Back2BackTestCase(unittest.TestCase):
                           data=[0xff] * 48)
         self._send_and_receive(msg)
 
-# FIXME
-@unittest.skip("skip until CAN FD support is fixed, see issue #274")
-#@unittest.skipUnless(TEST_INTERFACE_SOCKETCAN, "skip testing of socketcan")
+@unittest.skipUnless(TEST_INTERFACE_SOCKETCAN, "skip testing of socketcan")
 class BasicTestSocketCan(unittest.TestCase):
 
     def setUp(self):

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -137,6 +137,9 @@ class Back2BackTestCase(unittest.TestCase):
 
 @unittest.skipUnless(TEST_INTERFACE_SOCKETCAN, "skip testing of socketcan")
 class BasicTestSocketCan(unittest.TestCase):
+    """
+    TODO Test more thoroughly. See #273.
+    """
 
     def setUp(self):
         socketcan_version = can.util.choose_socketcan_implementation()


### PR DESCRIPTION
See [here](https://github.com/hardbyte/python-can/issues/274#issuecomment-378639034). Closes #274.

I also implemented feature detection (instead of checking the type of the OS and Python distribution as well as the version of Linux and Python) to find out whether `socketcan_ctypes` or `socketcan_native` should be used. This not correctly works on PyPy 2/3 and Python 3.4 as well as the re-enabled tests show, and should be more compatible with future OS and Python distributions and versions. 