### PR TITLE
Feature: Additional thread safe bus instance wrapper

### DIFF
--- a/can/__init__.py
+++ b/can/__init__.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 
 """
-can is an object-orient Controller Area Network interface module.
+can is an object-oriented Controller Area Network interface module.
 """
 
 from __future__ import absolute_import
@@ -17,27 +17,31 @@ rc = dict()
 
 
 class CanError(IOError):
+    """
+    Indicates an error related to CAN messages or busses.
+    """
     pass
 
-from can.listener import Listener, BufferedReader, RedirectReader
+from .listener import Listener, BufferedReader, RedirectReader
 
-from can.io import Logger, Printer, LogReader
-from can.io import ASCWriter, ASCReader
-from can.io import BLFReader, BLFWriter
-from can.io import CanutilsLogReader, CanutilsLogWriter
-from can.io import CSVWriter, CSVReader
-from can.io import SqliteWriter, SqliteReader
+from .io import Logger, Printer, LogReader
+from .io import ASCWriter, ASCReader
+from .io import BLFReader, BLFWriter
+from .io import CanutilsLogReader, CanutilsLogWriter
+from .io import CSVWriter, CSVReader
+from .io import SqliteWriter, SqliteReader
 
-from can.util import set_logging_level
+from .util import set_logging_level
 
-from can.message import Message
-from can.bus import BusABC
-from can.notifier import Notifier
-from can.interfaces import VALID_INTERFACES
+from .message import Message
+from .bus import BusABC
+from .notifier import Notifier
+from .interfaces import VALID_INTERFACES
 from . import interface
 from .interface import Bus
+from .thread_safe_bus import ThreadSafeBus
 
-from can.broadcastmanager import send_periodic, \
+from .broadcastmanager import send_periodic, \
     CyclicSendTaskABC, \
     LimitedDurationCyclicSendTaskABC, \
     ModifiableCyclicTaskABC, \

--- a/can/bus.py
+++ b/can/bus.py
@@ -100,7 +100,7 @@ class BusABC(object):
             least *duration* seconds.
 
         """
-        if not hasattr(self, "_lock_send"):
+        if not hasattr(self, "_lock_send_periodic"):
             # Create send lock for this bus
             self._lock_send_periodic = threading.Lock()
         return ThreadBasedCyclicSendTask(self, self._lock_send_periodic, msg, period, duration)

--- a/can/bus.py
+++ b/can/bus.py
@@ -100,10 +100,10 @@ class BusABC(object):
             least *duration* seconds.
 
         """
-        if not hasattr(self, "_lock"):
+        if not hasattr(self, "_lock_send"):
             # Create send lock for this bus
-            self._lock = threading.Lock()
-        return ThreadBasedCyclicSendTask(self, self._lock, msg, period, duration)
+            self._lock_send_periodic = threading.Lock()
+        return ThreadBasedCyclicSendTask(self, self._lock_send_periodic, msg, period, duration)
 
     def __iter__(self):
         """Allow iteration on messages as they are received.

--- a/can/interface.py
+++ b/can/interface.py
@@ -93,7 +93,7 @@ class Bus(object):
                 )
             )
 
-        return cls(channel, **kwargs)
+        return cls(channel, *args, **kwargs)
 
 
 class CyclicSendTask(CyclicSendTaskABC):

--- a/can/interfaces/socketcan/socketcan_ctypes.py
+++ b/can/interfaces/socketcan/socketcan_ctypes.py
@@ -60,7 +60,7 @@ class SocketcanCtypes_Bus(BusABC):
         log.debug("Result of createSocket was %d", self.socket)
 
         # Add any socket options such as can frame filters
-        if 'can_filters' in kwargs and len(kwargs['can_filters']) > 0:
+        if 'can_filters' in kwargs:
             log.debug("Creating a filtered can bus")
             self.set_filters(kwargs['can_filters'])
 

--- a/can/thread_safe_bus.py
+++ b/can/thread_safe_bus.py
@@ -6,16 +6,67 @@
 
 from __future__ import print_function, absolute_import
 
-from abc import ABCMeta, abstractmethod
-import threading
+from threading import RLock
+
+from can import BusABC
 
 
-class ThreadSafeBus(object):
+class NullContextManager(object):
+    """
+    A context manager that does nothing at all.
+    """
+    def __init__(self, resource=None):
+        self.resource = resource
+    def __enter__(self):
+        return self.resource
+    def __exit__(self, *args):
+        pass
+
+
+class ThreadSafeBus(BusABC):
     """
     Contains a thread safe :class:`~can.BusABC` implementation that
-    wraps around an existing interface instance.
+    wraps around an existing interface instance. All methods of that
+    base class are now safe to be called from multiple threads.
 
     This approach assumes that both :meth:`~can.BusABC.send` and
-    :meth:`~can.BusABC.recv` of the underlying .
+    :meth:`~can.BusABC.recv` of the underlying bus instance can be
+    called simultaneously.
+
+    Use this as a drop in replacement for :class:`can.BusABC`.
     """
-    pass
+
+    @classmethod
+    def __new__(cls, channel=None, *args, **kwargs):    
+        self = super().__new__(channel=channel, *args, **kwargs)
+        return self
+
+    def __init__(self, channel=None, can_filters=None, *args, **config):
+        super().__init__(channel=channel, can_filters=can_filters, *args, **config)
+        # init a lock for sending and one for receiving
+        self._lock_send = RLock()
+        self._lock_recv = RLock()
+        # now the send periodic does not need a lock anymore, but the
+        # implementation still requires a context manager to be able
+        # to be called
+        self._lock_send_periodic = NullContextManager()
+
+    def recv(self, timeout=None, *args, **kwargs):
+        with self._lock_recv:
+            return super().recv(timeout=timeout, *args, **kwargs)
+
+    def send(self, msg, timeout=None, *args, **kwargs):
+        with self._lock_send:
+            return super().send(msg, timeout=timeout, *args, **kwargs)
+
+    def set_filters(self, can_filters=None, *args, **kwargs):
+        with self._lock_recv:
+            return super().set_filters(can_filters=can_filters, *args, **kwargs)
+
+    def flush_tx_buffer(self, *args, **kwargs):
+        with self._lock_send:
+            return super().flush_tx_buffer(*args, **kwargs)
+
+    def shutdown(self, *args, **kwargs):
+        with self._lock_send, self._lock_recv:
+            return super().shutdown(*args, **kwargs)

--- a/can/thread_safe_bus.py
+++ b/can/thread_safe_bus.py
@@ -8,7 +8,7 @@ from __future__ import print_function, absolute_import
 
 from threading import RLock
 
-from can import BusABC
+from can import Bus, BusABC
 
 
 class NullContextManager(object):
@@ -23,7 +23,7 @@ class NullContextManager(object):
         pass
 
 
-class ThreadSafeBus(BusABC):
+class ThreadSafeBus():
     """
     Contains a thread safe :class:`~can.BusABC` implementation that
     wraps around an existing interface instance. All methods of that
@@ -36,37 +36,41 @@ class ThreadSafeBus(BusABC):
     Use this as a drop in replacement for :class:`can.BusABC`.
     """
 
-    @classmethod
-    def __new__(cls, channel=None, *args, **kwargs):    
-        self = super().__new__(channel=channel, *args, **kwargs)
-        return self
+    def __init__(self, *args, **kwargs):
+        # create the underlying bus
+        setattr(self, '_bus', Bus(*args, **kwargs))
 
-    def __init__(self, channel=None, can_filters=None, *args, **config):
-        super().__init__(channel=channel, can_filters=can_filters, *args, **config)
         # init a lock for sending and one for receiving
-        self._lock_send = RLock()
-        self._lock_recv = RLock()
+        setattr(self, '_lock_send', RLock())
+        setattr(self, '_lock_recv', RLock())
+
         # now the send periodic does not need a lock anymore, but the
         # implementation still requires a context manager to be able
         # to be called
-        self._lock_send_periodic = NullContextManager()
+        self._bus._lock_send_periodic = NullContextManager()
+
+    def __getattribute__(self, name):
+        return getattr(self._bus, name)
+
+    def __setattr__(self, name, value):
+        setattr(self._bus, name, value)
 
     def recv(self, timeout=None, *args, **kwargs):
         with self._lock_recv:
-            return super().recv(timeout=timeout, *args, **kwargs)
+            return self._bus.recv(timeout=timeout, *args, **kwargs)
 
     def send(self, msg, timeout=None, *args, **kwargs):
         with self._lock_send:
-            return super().send(msg, timeout=timeout, *args, **kwargs)
+            return self._bus.send(msg, timeout=timeout, *args, **kwargs)
 
     def set_filters(self, can_filters=None, *args, **kwargs):
         with self._lock_recv:
-            return super().set_filters(can_filters=can_filters, *args, **kwargs)
+            return self._bus.set_filters(can_filters=can_filters, *args, **kwargs)
 
     def flush_tx_buffer(self, *args, **kwargs):
         with self._lock_send:
-            return super().flush_tx_buffer(*args, **kwargs)
+            return self._bus.flush_tx_buffer(*args, **kwargs)
 
     def shutdown(self, *args, **kwargs):
         with self._lock_send, self._lock_recv:
-            return super().shutdown(*args, **kwargs)
+            return self._bus.shutdown(*args, **kwargs)

--- a/can/thread_safe_bus.py
+++ b/can/thread_safe_bus.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+"""
+"""
+
+from __future__ import print_function, absolute_import
+
+from abc import ABCMeta, abstractmethod
+import threading
+
+
+class ThreadSafeBus(object):
+    """
+    Contains a thread safe :class:`~can.BusABC` implementation that
+    wraps around an existing interface instance.
+
+    This approach assumes that both :meth:`~can.BusABC.send` and
+    :meth:`~can.BusABC.recv` of the underlying .
+    """
+    pass


### PR DESCRIPTION
This PR adds a thread safe wrapper around existing interfaces. Calls to `send()` and `recv()` are locked independently. 

```Python
# this
from can import Bus
bus = Bus(bustype='some_interface', channel='0')

# becomes this
from can import ThreadSafeBus
bus = ThreadSafeBus(bustype='some_interface', channel='0')
```

In that case, the locking of `send_periodic()` is disabled since it is redundant. 

Testing and docs are still left to be done. 