### PR TITLE
cleanups,fixes & docs in Bus.__new__() and util.load_config()

### DIFF
--- a/can/interface.py
+++ b/can/interface.py
@@ -129,8 +129,6 @@ class Bus(BusABC):
             raise ValueError("channel argument missing")
 
         # the channel attribute should be present in **config
-        print("DEBUGGING: ", args)
-        print("DEBUGGING: ", config)
         return cls(*args, **config)
 
 

--- a/can/interface.py
+++ b/can/interface.py
@@ -7,7 +7,7 @@ as a list of all avalibale backends and some implemented
 CyclicSendTasks.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import sys
 import importlib
@@ -129,6 +129,8 @@ class Bus(BusABC):
             raise ValueError("channel argument missing")
 
         # the channel attribute should be present in **config
+        print("DEBUGGING: ", args)
+        print("DEBUGGING: ", config)
         return cls(*args, **config)
 
 

--- a/can/interface.py
+++ b/can/interface.py
@@ -100,35 +100,36 @@ class Bus(BusABC):
     """
 
     @classmethod
-    def __new__(cls, other, channel=None, *args, **kwargs):
+    def __new__(cls, *args, **config):
         """
-        Takes the same arguments as :class:`can.BusABC` with the addition of:
+        Takes the same arguments as :class:`can.BusABC.__init__` with the addition of:
 
-        :param kwargs:
-            Should contain a bustype key with a valid interface name.
+        :param dict config:
+            Should contain an ``interface`` key with a valid interface name. If not,
+            it is completed using :meth:`can.util.load_config`.
 
-        :raises:
-            NotImplementedError if the bustype isn't recognized
-        :raises:
-            ValueError if the bustype or channel isn't either passed as an argument
-            or set in the can.rc config.
+        :raises: NotImplementedError
+            if the ``interface`` isn't recognized
 
+        :raises: ValueError
+            if the ``channel`` could not be determined
         """
 
-        # Figure out the configuration
-        config = load_config(config={
-            'interface': kwargs.get('bustype', kwargs.get('interface')),
-            'channel': channel
-        })
+        # figure out the rest of the configuration; this might raise an error
+        config = load_config(**config)
 
-        # remove the bustype & interface so it doesn't get passed to the backend
-        if 'bustype' in kwargs:
-            del kwargs['bustype']
-        if 'interface' in kwargs:
-            del kwargs['interface']
-
+        # resolve the bus class to use for that interface
         cls = _get_class_for_interface(config['interface'])
-        return cls(channel=config['channel'], *args, **kwargs)
+
+        # remove the 'interface' key so it doesn't get passed to the backend
+        del config['interface']
+
+        # make sure the bus can handle this config
+        if 'channel' not in config:
+            raise ValueError("channel argument missing")
+
+        # the channel attribute should be present in **config
+        return cls(*args, **config)
 
 
 def detect_available_configs(interfaces=None):

--- a/can/interface.py
+++ b/can/interface.py
@@ -116,7 +116,7 @@ class Bus(BusABC):
         """
 
         # figure out the rest of the configuration; this might raise an error
-        config = load_config(**config)
+        config = load_config(config=config)
 
         # resolve the bus class to use for that interface
         cls = _get_class_for_interface(config['interface'])

--- a/can/interface.py
+++ b/can/interface.py
@@ -99,7 +99,7 @@ class Bus(BusABC):
     configuration file from default locations.
     """
 
-    @classmethod
+    @staticmethod
     def __new__(cls, *args, **config):
         """
         Takes the same arguments as :class:`can.BusABC.__init__` with the addition of:

--- a/can/interfaces/virtual.py
+++ b/can/interfaces/virtual.py
@@ -33,7 +33,7 @@ class VirtualBus(BusABC):
     A virtual CAN bus using an internal message queue. It can be
     used for example for testing.
 
-    In this interface, a channel is an arbitarty object used as
+    In this interface, a channel is an arbitrary object used as
     an identifier for connected buses.
 
     Implements :meth:`can.BusABC._detect_available_configs`; see
@@ -78,7 +78,7 @@ class VirtualBus(BusABC):
         with channels_lock:
             self.channel.remove(self.queue)
 
-            # remove if emtpy
+            # remove if empty
             if not self.channel:
                 del channels[self.channel_id]
 

--- a/can/util.py
+++ b/can/util.py
@@ -167,9 +167,9 @@ def load_config(path=None, config=None):
     for cfg in config_sources:
         if callable(cfg):
             cfg = cfg()
-        # remove legacy operator
+        # remove legacy operator (and copy to interface if not already present)
         if 'bustype' in cfg:
-            if not cfg['interface']:
+            if 'interface' not in cfg or not cfg['interface']:
                 cfg['interface'] = cfg['bustype']
             del cfg['bustype']
         # copy all new parameters


### PR DESCRIPTION
This PR changes `util.load_config()` to pass through any unused parameters. It is made more clear in the code what `Bus.__new__()` is doing and what not. A lot has moved to `util.load_config()` to remove code and responsibility duplication. The documentation has each been changed to reflect what the methods are actually doing, that was not done correct before. 

Based an @randycoulman's comment [over here](https://github.com/hardbyte/python-can/issues/280#issuecomment-373426370)
Fixes #280