### PR TITLE
Add support for new BLF files

### DIFF
--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -19,6 +19,7 @@ import struct
 import zlib
 import datetime
 import time
+import logging
 
 from can.message import Message
 from can.listener import Listener
@@ -29,6 +30,7 @@ class BLFParseError(Exception):
     """BLF file could not be parsed correctly."""
     pass
 
+LOG = logging.getLogger(__name__)
 
 # 0 = unknown, 2 = CANoe
 APPLICATION_ID = 5
@@ -160,6 +162,7 @@ class BLFReader(object):
                     data = zlib.decompress(container_data, 15, uncompressed_size)
                 else:
                     # Unknown compression method
+                    LOG.warning("Unknown compression method (%d)", method)
                     continue
 
                 if tail:
@@ -189,6 +192,7 @@ class BLFReader(object):
                         pos += OBJ_HEADER_V2_STRUCT.size
                     else:
                         # Unknown header version
+                        LOG.warning("Unknown object header version (%d)", header_version)
                         pos = next_pos
                         continue
 

--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -76,6 +76,7 @@ CAN_MESSAGE = 1
 CAN_ERROR = 2
 LOG_CONTAINER = 10
 CAN_ERROR_EXT = 73
+CAN_MESSAGE2 = 86
 GLOBAL_MARKER = 96
 CAN_FD_MESSAGE = 100
 
@@ -203,7 +204,8 @@ class BLFReader(object):
                     timestamp = timestamp * factor + self.start_timestamp
 
                     obj_type = header[4]
-                    if obj_type == CAN_MESSAGE:
+                    # Both CAN message types have the same starting content
+                    if obj_type in (CAN_MESSAGE, CAN_MESSAGE2):
                         (channel, flags, dlc, can_id,
                          can_data) = CAN_MSG_STRUCT.unpack_from(data, pos)
                         msg = Message(timestamp=timestamp,


### PR DESCRIPTION
Supports version 2 of object headers.
Supports any file header size.
Better exceptions on parse errors.

Fixes #314.