### PR TITLE
Fix possible problems in Bus constructor

### DIFF
--- a/can/bus.py
+++ b/can/bus.py
@@ -28,7 +28,7 @@ class BusABC(object):
     channel_info = 'unknown'
 
     @abstractmethod
-    def __init__(self, channel=None, can_filters=None, **config):
+    def __init__(self, channel, can_filters=None, **config):
         """Construct and open a CAN bus instance of the specified type.
 
         Subclasses should call though this method with all given parameters

--- a/can/interface.py
+++ b/can/interface.py
@@ -78,13 +78,13 @@ class Bus(BusABC):
     """
 
     @staticmethod
-    def __new__(cls, channel, *args, **config):
+    def __new__(cls, channel=None, *args, **config):
         """
         Takes the same arguments as :class:`can.BusABC.__init__`.
         Some might have a special meaning, see below.
 
         :param channel:
-            Set to ``None`` te lat it be reloved automatically from the default
+            Set to ``None`` to let it be reloved automatically from the default
             configuration. That might fail, see below.
 
             Expected type is backend dependent.

--- a/can/interface.py
+++ b/can/interface.py
@@ -123,6 +123,7 @@ class Bus(BusABC):
                 return cls(*args, **config)
             except TypeError as error:
                 search_for = r"__init__\(\) got multiple values for argument '(\w+)'"
+                print(error.message)
                 match = re.match(search_for, error.message, re.UNICODE)
                 if match:
                     argument = match.group(0)

--- a/can/interfaces/ics_neovi/neovi_bus.py
+++ b/can/interfaces/ics_neovi/neovi_bus.py
@@ -82,7 +82,7 @@ class NeoViBus(BusABC):
     https://github.com/intrepidcs/python_ics
     """
 
-    def __init__(self, channel=None, can_filters=None, **config):
+    def __init__(self, channel, can_filters=None, **config):
         """
         :param int channel:
             The Channel id to create this bus with.

--- a/can/interfaces/nican.py
+++ b/can/interfaces/nican.py
@@ -130,8 +130,7 @@ class NicanBus(BusABC):
 
     """
 
-    def __init__(self, channel, can_filters=None, bitrate=None, log_errors=True,
-                 **kwargs):
+    def __init__(self, channel, can_filters=None, bitrate=None, log_errors=True, **kwargs):
         """
         :param str channel:
             Name of the object to open (e.g. 'CAN0')

--- a/can/interfaces/socketcan/socketcan_ctypes.py
+++ b/can/interfaces/socketcan/socketcan_ctypes.py
@@ -45,10 +45,7 @@ class SocketcanCtypes_Bus(BusABC):
     Implements :meth:`can.BusABC._detect_available_configs`.
     """
 
-    def __init__(self,
-                 channel='vcan0',
-                 receive_own_messages=False,
-                 *args, **kwargs):
+    def __init__(self, channel, receive_own_messages=False, *args, **kwargs):
         """
         :param str channel:
             The can interface name with which to create this bus. An example channel

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -169,8 +169,13 @@ class BasicTestSocketCan(unittest.TestCase):
         self.assertEqual(message, reader.get_message(timeout=2.0))
         notifier.stop()
 
-    def test_constructor(self):
-        """Tests that no exceptions are thrown."""
+
+class TestConstructor(unittest.TestCase):
+    """Tests that no exceptions are thrown when duplicate
+    values for constructor arguments are given.#
+    """
+
+    def test_duplicate_values(self):
         can.Bus(channel='vcan0', bustype='socketcan')
         can.Bus('vcan0', channel='vcan0', bustype='socketcan')
 

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -171,8 +171,8 @@ class BasicTestSocketCan(unittest.TestCase):
 
     def test_constructor(self):
         """Tests that no exceptions are thrown."""
-        can.Bus(channel='vcan0', bustype=socketcan_version)
-        can.Bus('vcan0', channel='vcan0', bustype=socketcan_version) # what shall we do about this?
+        can.Bus(channel='vcan0', bustype='socketcan')
+        can.Bus('vcan0', channel='vcan0', bustype='socketcan') # what shall we do about this?
 
 
 if __name__ == '__main__':

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -23,9 +23,9 @@ BITRATE = 500000
 TIMEOUT = 0.1
 
 INTERFACE_1 = 'virtual'
-CHANNEL_1 = 'vcan0'
+CHANNEL_1 = 'virtual_channel_0'
 INTERFACE_2 = 'virtual'
-CHANNEL_2 = 'vcan0'
+CHANNEL_2 = 'virtual_channel_0'
 
 
 class Back2BackTestCase(unittest.TestCase):
@@ -35,16 +35,16 @@ class Back2BackTestCase(unittest.TestCase):
     """
 
     def setUp(self):
-        self.bus1 = can.interface.Bus(channel=CHANNEL_1,
-                                      bustype=INTERFACE_1,
-                                      bitrate=BITRATE,
-                                      fd=TEST_CAN_FD,
-                                      single_handle=True)
-        self.bus2 = can.interface.Bus(channel=CHANNEL_2,
-                                      bustype=INTERFACE_2,
-                                      bitrate=BITRATE,
-                                      fd=TEST_CAN_FD,
-                                      single_handle=True)
+        self.bus1 = can.Bus(channel=CHANNEL_1,
+                            bustype=INTERFACE_1,
+                            bitrate=BITRATE,
+                            fd=TEST_CAN_FD,
+                            single_handle=True)
+        self.bus2 = can.Bus(channel=CHANNEL_2,
+                            bustype=INTERFACE_2,
+                            bitrate=BITRATE,
+                            fd=TEST_CAN_FD,
+                            single_handle=True)
 
     def tearDown(self):
         self.bus1.shutdown()
@@ -146,14 +146,14 @@ class BasicTestSocketCan(unittest.TestCase):
         print("testing python-can's socketcan version:",
               socketcan_version)
 
-        self.bus1 = can.interface.Bus(channel="vcan0",
-                                      bustype=socketcan_version,
-                                      bitrate=250000,
-                                      fd=TEST_CAN_FD)
-        self.bus2 = can.interface.Bus(channel="vcan0",
-                                      bustype=socketcan_version,
-                                      bitrate=250000,
-                                      fd=TEST_CAN_FD)
+        self.bus1 = can.Bus(channel="vcan0",
+                            bustype=socketcan_version,
+                            bitrate=250000,
+                            fd=TEST_CAN_FD)
+        self.bus2 = can.Bus(channel="vcan0",
+                            bustype=socketcan_version,
+                            bitrate=250000,
+                            fd=TEST_CAN_FD)
 
     def tearDown(self):
         self.bus1.shutdown()
@@ -168,6 +168,11 @@ class BasicTestSocketCan(unittest.TestCase):
 
         self.assertEqual(message, reader.get_message(timeout=2.0))
         notifier.stop()
+
+    def test_constructor(self):
+        """Tests that no exceptions are thrown."""
+        can.Bus(channel='vcan0', bustype=socketcan_version)
+        can.Bus('vcan0', channel='vcan0', bustype=socketcan_version) # what shall we do about this?
 
 
 if __name__ == '__main__':

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -170,15 +170,5 @@ class BasicTestSocketCan(unittest.TestCase):
         notifier.stop()
 
 
-class TestConstructor(unittest.TestCase):
-    """Tests that no exceptions are thrown when duplicate
-    values for constructor arguments are given.#
-    """
-
-    def test_duplicate_values(self):
-        can.Bus(channel='vcan0', bustype='socketcan')
-        can.Bus('vcan0', channel='vcan0', bustype='socketcan')
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -172,7 +172,7 @@ class BasicTestSocketCan(unittest.TestCase):
     def test_constructor(self):
         """Tests that no exceptions are thrown."""
         can.Bus(channel='vcan0', bustype='socketcan')
-        can.Bus('vcan0', channel='vcan0', bustype='socketcan') # what shall we do about this?
+        can.Bus('vcan0', channel='vcan0', bustype='socketcan')
 
 
 if __name__ == '__main__':

--- a/test/listener_test.py
+++ b/test/listener_test.py
@@ -4,7 +4,7 @@
 """
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 from time import sleep
 import unittest
@@ -18,12 +18,12 @@ import can
 
 from .data.example_data import generate_message
 
-channel = 'vcan0'
+channel = 'virtual_channel_0'
 can.rc['interface'] = 'virtual'
 
 logging.getLogger('').setLevel(logging.DEBUG)
 
-# make tests more reproducible
+# makes the random number generator deterministic
 random.seed(13339115)
 
 
@@ -54,7 +54,7 @@ class ListenerImportTest(unittest.TestCase):
 
         self.assertTrue(hasattr(can, 'LogReader'))
 
-        self.assertTrue(hasattr(can.io.player, 'MessageSync'))
+        self.assertTrue(hasattr(can, 'MessageSync'))
 
 
 class BusTest(unittest.TestCase):
@@ -106,7 +106,7 @@ class ListenerTest(BusTest):
         # test file extensions that are not supported
         with self.assertRaisesRegexp(NotImplementedError, "xyz_42"):
             test_filetype_to_instance("xyz_42", can.Printer)
-        with self.assertRaises(BaseException):
+        with self.assertRaises(Exception):
             test_filetype_to_instance(None, can.Printer)
 
     def testLoggerTypeResolution(self):


### PR DESCRIPTION
Basically, this unifies how the channel argument is passed through the method cascade when creating an new `Bus` instance.

@christiansandberg Here is the fix for the bug you found.