### PR TITLE
Removed Python 3.3 CI testing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,4 @@
 environment:
-
   matrix:
 
     # For Python versions available on Appveyor, see
@@ -14,14 +13,7 @@ environment:
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
 
-    # officially unsupported
-    - PYTHON: "C:\\Python33"
-    - PYTHON: "C:\\Python33-x64"
-
-matrix:
-  allow_failures:
-    - PYTHON: "C:\\Python33"
-    - PYTHON: "C:\\Python33-x64"
+    # Python 3.3 has reached EOL
 
 install:
   # Prepend Python installation to PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@ language: python
 python:
   # CPython:
   - "2.7"
-  - "3.3" # but allowed to fail
+  # Python 3.3 has reached EOL and pytest fails there
   - "3.4"
   - "3.5"
   - "3.6"
   - "3.7-dev" # TODO: change to "3.7" once it gets released
   - "nightly"
   # PyPy:
-  - "pypy"
-  - "pypy3"
+  - "pypy2.7"
+  - "pypy3.5"
 
 os:
   - linux   # Linux is officially supported and we test the library under
@@ -42,9 +42,6 @@ matrix:
     - python: "nightly"
 
     # we do not allow dev builds to fail, since these builds are considered stable enough
-
-    # Python 3.3 tests are allowed to fail since Python 3.3 is not offically supported any more
-    - python: "3.3"
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo bash test/open_vcan.sh ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - "3.7-dev" # TODO: change to "3.7" once it gets released
   - "nightly"
   # PyPy:
-  - "pypy2.7"
+  - "pypy"
   - "pypy3.5"
 
 os:


### PR DESCRIPTION
The Travis CI tests in CPython 3.3 recently broke because `pytest` removed support for Python 3.3. So this removes the CI tests for that Python version; it was already allowed to fail. 