### PR TITLE
Setting _filters to None when filter Iterator is empty

### DIFF
--- a/can/bus.py
+++ b/can/bus.py
@@ -201,7 +201,7 @@ class BusABC(object):
         """Apply filtering to all messages received by this Bus.
 
         All messages that match at least one filter are returned.
-        If `filters` is `None` or a a zero size interable, all 
+        If `filters` is `None` or a zero length sequence, all 
         messages are matched.
 
         Calling without passing any filters will reset the applied

--- a/can/bus.py
+++ b/can/bus.py
@@ -201,8 +201,8 @@ class BusABC(object):
         """Apply filtering to all messages received by this Bus.
 
         All messages that match at least one filter are returned.
-        If `filters` is `None`, all messages are matched.
-        If it is a zero size interable, no messages are matched.
+        If `filters` is `None` or a a zero size interable, all 
+        messages are matched.
 
         Calling without passing any filters will reset the applied
         filters to `None`.

--- a/can/bus.py
+++ b/can/bus.py
@@ -219,7 +219,7 @@ class BusABC(object):
             only on the arbitration ID and mask.
 
         """
-        self._filters = filters
+        self._filters = filters or None
         self._apply_filters(self._filters)
 
     def _apply_filters(self, filters):

--- a/test/test_message_filtering.py
+++ b/test/test_message_filtering.py
@@ -46,10 +46,10 @@ class TestMessageFiltering(unittest.TestCase):
         self.bus.set_filters(None)
         self.assertTrue(self.bus._matches_filters(EXAMPLE_MSG))
 
-    def test_match_nothing(self):
+    def test_match_filters_is_empty(self):
         self.bus.set_filters([])
         for msg in TEST_ALL_MESSAGES:
-            self.assertFalse(self.bus._matches_filters(msg))
+            self.assertTrue(self.bus._matches_filters(msg))
 
     def test_match_example_message(self):
         self.bus.set_filters(MATCH_EXAMPLE)


### PR DESCRIPTION
For example when using `can.logger` the default `can_filters` value is a empty list, this leads to filtering all message. This change fix the issue by treating any empty Iterator same as `filters=None`