### PR TITLE
Stop raising accuracy error for NeoVi

### DIFF
--- a/can/interfaces/ics_neovi/neovi_bus.py
+++ b/can/interfaces/ics_neovi/neovi_bus.py
@@ -188,8 +188,6 @@ class NeoViBus(BusABC):
 
             for msg in ics.get_error_messages(self.dev):
                 error = ICSApiError(*msg)
-                if error.is_critical:
-                    raise error
                 logger.warning(error)
 
     def _get_timestamp_for_msg(self, ics_msg):


### PR DESCRIPTION
Only keep logging the error that ICS lib consider critical and stop raising exception. In most case, the error is affecting the accuracy but the device can still be use normally (i.e. Rx buffer overflow). In these cases, we do not want for example to kill a notifier using this bus, etc.