### PR TITLE
Log received messages for all interfaces

### DIFF
--- a/can/bus.py
+++ b/can/bus.py
@@ -29,6 +29,9 @@ class BusABC(object):
     #: a string describing the underlying bus and/or channel
     channel_info = 'unknown'
 
+    #: Log level for received messages
+    RECV_LOGGING_LEVEL = 9
+
     @abstractmethod
     def __init__(self, channel, can_filters=None, **config):
         """Construct and open a CAN bus instance of the specified type.
@@ -72,7 +75,7 @@ class BusABC(object):
 
             # return it, if it matches
             if msg and (already_filtered or self._matches_filters(msg)):
-                LOG.log(9, 'Received: %s', msg)
+                LOG.log(self.RECV_LOGGING_LEVEL, 'Received: %s', msg)
                 return msg
 
             # if not, and timeout is None, try indefinitely

--- a/can/bus.py
+++ b/can/bus.py
@@ -12,9 +12,11 @@ import logging
 import threading
 from time import time
 from collections import namedtuple
+import logging
 
 from .broadcastmanager import ThreadBasedCyclicSendTask
 
+LOG = logging.getLogger(__name__)
 
 BusState = namedtuple('BusState', 'ACTIVE, PASSIVE, ERROR')
 
@@ -70,6 +72,7 @@ class BusABC(object):
 
             # return it, if it matches
             if msg and (already_filtered or self._matches_filters(msg)):
+                LOG.log(9, 'Received: %s', msg)
                 return msg
 
             # if not, and timeout is None, try indefinitely

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -474,7 +474,7 @@ class IXXATBus(BusABC):
             channel=self.channel
         )
 
-        log.debug('Recv()ed message %s', rx_msg)
+        #log.debug('Recv()ed message %s', rx_msg)
         return rx_msg, True
 
     def send(self, msg, timeout=None):

--- a/can/interfaces/kvaser/canlib.py
+++ b/can/interfaces/kvaser/canlib.py
@@ -484,7 +484,7 @@ class KvaserBus(BusABC):
         else:
             timeout = int(timeout * 1000)
 
-        log.log(9, 'Reading for %d ms on handle: %s' % (timeout, self._read_handle))
+        #log.log(9, 'Reading for %d ms on handle: %s' % (timeout, self._read_handle))
         status = canReadWait(
             self._read_handle,
             ctypes.byref(arb_id),

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -187,7 +187,7 @@ class PcanBus(BusABC):
             # Calculate max time
             end_time = timeout_clock() + timeout
 
-        log.debug("Trying to read a msg")
+        #log.debug("Trying to read a msg")
 
         result = None
         while result is None:
@@ -212,17 +212,10 @@ class PcanBus(BusABC):
         theMsg = result[1]
         itsTimeStamp = result[2]
 
-        log.debug("Received a message")
+        #log.debug("Received a message")
 
         bIsRTR = (theMsg.MSGTYPE & PCAN_MESSAGE_RTR.value) == PCAN_MESSAGE_RTR.value
         bIsExt = (theMsg.MSGTYPE & PCAN_MESSAGE_EXTENDED.value) == PCAN_MESSAGE_EXTENDED.value
-
-        if bIsExt:
-            #rx_msg.id_type = ID_TYPE_EXTENDED
-            log.debug("CAN: Extended")
-        else:
-            #rx_msg.id_type = ID_TYPE_STANDARD
-            log.debug("CAN: Standard")
 
         dlc = theMsg.LEN
         timestamp = boottimeEpoch + ((itsTimeStamp.micros + (1000 * itsTimeStamp.millis)) / (1000.0 * 1000.0))

--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -391,7 +391,7 @@ def capture_message(sock, get_channel=False):
         raise can.CanError("Error receiving: %s" % exc)
 
     can_id, can_dlc, flags, data = dissect_can_frame(cf)
-    log.debug('Received: can_id=%x, can_dlc=%x, data=%s', can_id, can_dlc, data)
+    #log.debug('Received: can_id=%x, can_dlc=%x, data=%s', can_id, can_dlc, data)
 
     # Fetching the timestamp
     binary_structure = "@LL"
@@ -413,11 +413,11 @@ def capture_message(sock, get_channel=False):
     error_state_indicator = bool(flags & CANFD_ESI)
 
     if is_extended_frame_format:
-        log.debug("CAN: Extended")
+        #log.debug("CAN: Extended")
         # TODO does this depend on SFF or EFF?
         arbitration_id = can_id & 0x1FFFFFFF
     else:
-        log.debug("CAN: Standard")
+        #log.debug("CAN: Standard")
         arbitration_id = can_id & 0x000007FF
 
     msg = Message(timestamp=timestamp,
@@ -432,7 +432,7 @@ def capture_message(sock, get_channel=False):
                   dlc=can_dlc,
                   data=data)
 
-    log_rx.debug('Received: %s', msg)
+    #log_rx.debug('Received: %s', msg)
 
     return msg
 


### PR DESCRIPTION
Move received message logging to `can.BusABC.recv()` and comment out unneeded logging lines in interface implementations (unless debugging the implementation). Use level 9 (lower than debug) to be able to opt-in since the log can easily be overwhelmed by random CAN data.