### PR TITLE
Add coverage report generation

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,3 +29,4 @@ build: off
 
 test_script:
   - "pytest -v --timeout=300 --cov=can"
+  - "codecov"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,7 @@ install:
   - set PATH=%PYTHON_INSTALL%\\Scripts;%PATH%
 
   # We need to install the python-can library itself
-  - "python -m pip install .[test]"
+  - "python -m pip install .[test,neovi]"
 
 build: off
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,4 +28,4 @@ install:
 build: off
 
 test_script:
-  - "pytest -v --timeout=300"
+  - "pytest -v --timeout=300 --cov=can"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,12 +45,12 @@ matrix:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo bash test/open_vcan.sh ; fi
+  - travis_retry pip install sphinx codecov pytest-cov
   - travis_retry pip install .[test]
-  - travis_retry pip install sphinx
 
 script:
-  - pytest -v --timeout=300
+  - pytest -v --timeout=300 --cov=./can/*
+
   # Build Docs with Sphinx
-  #
   # -a Write all files
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then python -m sphinx -an doc build; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo bash test/open_vcan.sh ; fi
-  - travis_retry pip install sphinx codecov pytest-cov
+  - travis_retry pip install sphinx
   - travis_retry pip install .[test]
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
   - travis_retry pip install .[test]
 
 script:
-  - pytest -v --timeout=300 --cov=./can/*
+  - pytest -v --timeout=300 --cov=can
 
   # Build Docs with Sphinx
   # -a Write all files

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ install:
 
 script:
   - pytest -v --timeout=300 --cov=can
-
+  - codecov
   # Build Docs with Sphinx
   # -a Write all files
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then python -m sphinx -an doc build; fi

--- a/can/interfaces/ics_neovi/neovi_bus.py
+++ b/can/interfaces/ics_neovi/neovi_bus.py
@@ -136,7 +136,7 @@ class NeoViBus(BusABC):
     def shutdown(self):
         super(NeoViBus, self).shutdown()
         ics.close_device(self.dev)
-    
+
     @staticmethod
     def _detect_available_configs():
         """Detect all configurations/channels that this interface could
@@ -148,14 +148,18 @@ class NeoViBus(BusABC):
         """
         if ics is None:
             return []
-        # TODO: add the channel(s)
+
         try:
-            return [{
-                'serial': NeoViBus.get_serial_number(device)
-            } for device in ics.find_devices()]
+            devices = ics.find_devices()
         except Exception as e:
             logger.debug("Failed to detect configs: %s", e)
             return []
+
+        # TODO: add the channel(s)
+        return [{
+            'interface': 'neovi',
+            'serial': NeoViBus.get_serial_number(device)
+        } for device in devices]
 
     def _find_device(self, type_filter=None, serial=None):
         if type_filter is not None:

--- a/can/interfaces/ics_neovi/neovi_bus.py
+++ b/can/interfaces/ics_neovi/neovi_bus.py
@@ -149,9 +149,13 @@ class NeoViBus(BusABC):
         if ics is None:
             return []
         # TODO: add the channel(s)
-        return [{
-            'serial': NeoViBus.get_serial_number(device)
-        } for device in ics.find_devices()]
+        try:
+            return [{
+                'serial': NeoViBus.get_serial_number(device)
+            } for device in ics.find_devices()]
+        except Exception as e:
+            logger.debug("Failed to detect configs: %s", e)
+            return []
 
     def _find_device(self, type_filter=None, serial=None):
         if type_filter is not None:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ python-can requires the setuptools package to be installed.
 from sys import version_info
 import re
 import logging
-from itertools import chain
 from setuptools import setup, find_packages
 
 logging.basicConfig(level=logging.WARNING)
@@ -25,6 +24,7 @@ extras_require = {
     'serial':   ['pyserial ~= 3.0'],
     'neovi':    ['python-ics >= 2.12']
 }
+
 tests_require = [
     'mock ~= 2.0',
     'nose ~= 1.3',
@@ -33,8 +33,7 @@ tests_require = [
     'pytest-cov ~= 2.5',
     'codecov ~= 2.0'
 ] + extras_require['serial']
-#for key, requirements in extras_require.items():
-#    tests_require += requirements
+
 extras_require['test'] = tests_require
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ tests_require = [
     'pytest ~= 3.6',
     'pytest-timeout ~= 1.2',
     'pytest-cov ~= 2.5',
+    'codecov ~= 2.0'
 ] + extras_require['serial']
 #for key, requirements in extras_require.items():
 #    tests_require += requirements

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ python-can requires the setuptools package to be installed.
 from sys import version_info
 import re
 import logging
+from itertools import chain
 from setuptools import setup, find_packages
 
 logging.basicConfig(level=logging.WARNING)
@@ -31,6 +32,8 @@ tests_require = [
     'pytest-timeout ~= 1.2',
     'pytest-cov ~= 2.5',
 ]
+for key, requirements in extras_require:
+    tests_require += requirements
 extras_require['test'] = tests_require
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ tests_require = [
     'pytest-timeout ~= 1.2',
     'pytest-cov ~= 2.5',
 ]
-for key, requirements in extras_require:
+for key, requirements in extras_require.items():
     tests_require += requirements
 extras_require['test'] = tests_require
 

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,9 @@ tests_require = [
     'pytest ~= 3.6',
     'pytest-timeout ~= 1.2',
     'pytest-cov ~= 2.5',
-]
-for key, requirements in extras_require.items():
-    tests_require += requirements
+] + extras_require['serial']
+#for key, requirements in extras_require.items():
+#    tests_require += requirements
 extras_require['test'] = tests_require
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -20,13 +20,18 @@ with open('README.rst', 'r') as f:
     long_description = f.read()
 
 # Dependencies
+extras_require = {
+    'serial':   ['pyserial ~= 3.0'],
+    'neovi':    ['python-ics >= 2.12']
+}
 tests_require = [
     'mock ~= 2.0',
-    'nose ~= 1.3.7',
+    'nose ~= 1.3',
     'pytest ~= 3.6',
     'pytest-timeout ~= 1.2',
-    'pyserial ~= 3.0'
+    'pytest-cov ~= 2.5',
 ]
+extras_require['test'] = tests_require
 
 setup(
     # Description
@@ -58,11 +63,7 @@ setup(
     install_requires=[
         'wrapt ~= 1.10',
     ],
-    extras_require={
-        'serial': ['pyserial >= 3.0'],
-        'neovi': ['python-ics >= 2.12'],
-        'test': tests_require
-    },
+    extras_require=extras_require,
 
     # Testing
     test_suite="nose.collector",


### PR DESCRIPTION
This adds very simple statement coverage reports like [this one](https://travis-ci.org/hardbyte/python-can/jobs/398444150#L630) to the Travis CI & AppVeyor test routines. 

It would be nice to also add some tool like [Codecov.io](https://codecov.io/). That might help us identify poorly tested regions of code. 

Adding coverage tool support via the GitHub Marketplace should be quite straightforward, but I do not have the required admin permissions. @hardbyte Can you do that? 