### PR TITLE
Only expose SocketCAN classes directly on Linux

### DIFF
--- a/can/interface.py
+++ b/can/interface.py
@@ -20,7 +20,10 @@ from .broadcastmanager import CyclicSendTaskABC, MultiRateCyclicSendTaskABC
 from .util import load_config
 from .interfaces import BACKENDS
 
-from can.interfaces.socketcan.socketcan import CyclicSendTask, MultiRateCyclicSendTask
+if 'linux' in sys.platform:
+    # Deprecated and undocumented access to SocketCAN cyclic tasks
+    # Will be removed in version 3.0
+    from can.interfaces.socketcan import CyclicSendTask, MultiRateCyclicSendTask
 
 # Required by "detect_available_configs" for argument interpretation
 if sys.version_info.major > 2:


### PR DESCRIPTION
Fixes #349.