### PR TITLE
typo in usb2canInterface.py

### DIFF
--- a/can/interfaces/usb2can/usb2canInterface.py
+++ b/can/interfaces/usb2can/usb2canInterface.py
@@ -112,7 +112,7 @@ class Usb2canBus(BusABC):
             deviceID = serial()
 
         # get baudrate in b/s from bitrate or use default
-        bitrate = kwargs.get("bitrate", d=500000)
+        bitrate = kwargs.get("bitrate", 500000)
         # convert to kb/s (eg:500000 bitrate must be 500), max rate is 1000 kb/s
         baudrate = min(1000, int(bitrate/1000))
 


### PR DESCRIPTION
the function get() of a dictionary get(key[, default]) doesn't support an argument named 'd'