### PR TITLE
NI-CAN: Add reset method and remove flush_tx_buffer method

### DIFF
--- a/can/interfaces/nican.py
+++ b/can/interfaces/nican.py
@@ -282,9 +282,9 @@ class NicanBus(BusABC):
         #nican.ncWaitForState(
         #    self.handle, NC_ST_WRITE_SUCCESS, int(timeout * 1000), ctypes.byref(state))
 
-    def flush_tx_buffer(self):
+    def reset(self):
         """
-        Resets the CAN chip which includes clearing receive and transmit queues.
+        Resets the CAN chip.
         """
         nican.ncAction(self.handle, NC_OP_RESET, 0)
 

--- a/can/interfaces/nican.py
+++ b/can/interfaces/nican.py
@@ -284,7 +284,9 @@ class NicanBus(BusABC):
 
     def reset(self):
         """
-        Resets the CAN chip.
+        Resets network interface. Stops network interface, then resets the CAN
+        chip to clear the CAN error counters (clear error passive state).
+        Resetting includes clearing all entries from read and write queues.
         """
         nican.ncAction(self.handle, NC_OP_RESET, 0)
 


### PR DESCRIPTION
Actually renames the old `flush_tx_buffer` which did a reset which is not really the same thing.