### PR TITLE
Add a .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,19 @@
+codecov:
+  archive:
+    uploads: no
+
+coverage:
+  precision: 2
+  round: down
+  range: 50...100
+
+comment:
+  layout: "header, diff, changes"
+
+coverage:
+  status:
+    # pull-requests only
+    patch:
+      default:
+        # coverage may fall by <1.0% and still be considered "passing"
+        threshold: 1.0%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,14 +6,12 @@ coverage:
   precision: 2
   round: down
   range: 50...100
-
-comment:
-  layout: "header, diff, changes"
-
-coverage:
   status:
     # pull-requests only
     patch:
       default:
         # coverage may fall by <1.0% and still be considered "passing"
         threshold: 1.0%
+
+comment:
+  layout: "header, diff, changes"

--- a/README.rst
+++ b/README.rst
@@ -19,9 +19,9 @@ python-can
    :target: https://ci.appveyor.com/project/hardbyte/python-can/history
    :alt: AppVeyor CI Server for develop branch
 
-.. |coverage| image:: https://codecov.io/gh/hardbyte/python-can/branch/master/graph/badge.svg
-   :target: https://codecov.io/gh/hardbyte/python-can
-   :alt: Coverage reports on Codecov.io
+.. |coverage| image:: https://codecov.io/gh/hardbyte/python-can/branch/develop/graph/badge.svg
+   :target: https://codecov.io/gh/hardbyte/python-can/branch/develop
+   :alt: Test coverage reports on Codecov.io
 
 
 The **C**\ ontroller **A**\ rea **N**\ etwork is a bus standard designed

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 python-can
 ==========
 
-|release| |docs| |build_travis| |build_appveyor|
+|release| |docs| |build_travis| |build_appveyor| |coverage|
 
 .. |release| image:: https://img.shields.io/pypi/v/python-can.svg
    :target: https://pypi.python.org/pypi/python-can/
@@ -18,6 +18,10 @@ python-can
 .. |build_appveyor| image:: https://ci.appveyor.com/api/projects/status/github/hardbyte/python-can?branch=develop&svg=true
    :target: https://ci.appveyor.com/project/hardbyte/python-can/history
    :alt: AppVeyor CI Server for develop branch
+
+.. |coverage| image:: https://codecov.io/gh/hardbyte/python-can/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/hardbyte/python-can
+   :alt: Coverage reports on Codecov.io
 
 
 The **C**\ ontroller **A**\ rea **N**\ etwork is a bus standard designed


### PR DESCRIPTION
Adds a `.codecov.yml` file that is used to configure the coverage reports. Decreasing the coverage by up to 1.0 % is now still allowed. The layout of the Coverage.io bot comments can now be adjusted.

Closes #372