### PR TITLE
Fix entry points for 3rd party interfaces

### DIFF
--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -28,4 +28,10 @@ BACKENDS.update({
     for interface in iter_entry_points('can.interface')
 })
 
+# Old entry point name. May be removed in 3.0.
+BACKENDS.update({
+    interface.name: (interface.module_name, interface.attrs[0])
+    for interface in iter_entry_points('python_can.interface')
+})
+
 VALID_INTERFACES = frozenset(list(BACKENDS.keys()) + ['socketcan_native', 'socketcan_ctypes'])

--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -5,7 +5,11 @@
 Interfaces contain low level implementations that interact with CAN hardware.
 """
 
+import logging
+
 from pkg_resources import iter_entry_points
+
+logger = logging.getLogger(__name__)
 
 # interface_name => (module, classname)
 BACKENDS = {
@@ -29,9 +33,9 @@ BACKENDS.update({
 })
 
 # Old entry point name. May be removed in 3.0.
-BACKENDS.update({
-    interface.name: (interface.module_name, interface.attrs[0])
-    for interface in iter_entry_points('python_can.interface')
-})
+for interface in iter_entry_points('python_can.interface'):
+    BACKENDS[interface.name] = (interface.module_name, interface.attrs[0])
+    logger.warning('%s is using the deprecated python_can.interface entry point. '
+                   'Please change to can.interface instead.', interface.name)
 
 VALID_INTERFACES = frozenset(list(BACKENDS.keys()) + ['socketcan_native', 'socketcan_ctypes'])

--- a/doc/interfaces.rst
+++ b/doc/interfaces.rst
@@ -25,10 +25,10 @@ The available interfaces are:
    interfaces/virtual
 
 Additional interfaces can be added via a plugin interface. An external package
-can register a new interface by using the ``can.interface`` entry point in setup.py.
+can register a new interface by using the ``can.interface`` entry point in its setup.py.
 
 The format of the entry point is ``interface_name=module:classname`` where
-``classname`` is a :class:`can.BusABC` concrete implementation.
+``classname`` is a concrete :class:`can.BusABC` implementation.
 
 ::
 

--- a/doc/interfaces.rst
+++ b/doc/interfaces.rst
@@ -25,7 +25,7 @@ The available interfaces are:
    interfaces/virtual
 
 Additional interfaces can be added via a plugin interface. An external package
-can register a new interface by using the ``python_can.interface`` entry point.
+can register a new interface by using the ``can.interface`` entry point in setup.py.
 
 The format of the entry point is ``interface_name=module:classname`` where
 ``classname`` is a :class:`can.BusABC` concrete implementation.
@@ -33,7 +33,7 @@ The format of the entry point is ``interface_name=module:classname`` where
 ::
 
  entry_points={
-     'python_can.interface': [
+     'can.interface': [
          "interface_name=module:classname",
      ]
  },


### PR DESCRIPTION
Fixes backwards incompatible change introduced in 2.2.0. Updated documentation to new entry point.