### PR TITLE
serial: switch to serial_for_url instead of Serial

### DIFF
--- a/can/interfaces/serial/serial_can.py
+++ b/can/interfaces/serial/serial_can.py
@@ -54,7 +54,8 @@ class SerialBus(BusABC):
             raise ValueError("Must specify a serial port.")
 
         self.channel_info = "Serial interface: " + channel
-        self.ser = serial.Serial(channel, baudrate=baudrate, timeout=timeout)
+        self.ser = serial.serial_for_url(
+            channel, baudrate=baudrate, timeout=timeout)
 
         super(SerialBus, self).__init__(channel=channel, *args, **kwargs)
 

--- a/can/interfaces/slcan.py
+++ b/can/interfaces/slcan.py
@@ -65,7 +65,8 @@ class slcanBus(BusABC):
         if '@' in channel:
             (channel, ttyBaudrate) = channel.split('@')
 
-        self.serialPortOrig = serial.Serial(channel, baudrate=ttyBaudrate, timeout=timeout)
+        self.serialPortOrig = serial.serial_for_url(
+            channel, baudrate=ttyBaudrate, timeout=timeout)
 
         time.sleep(self._SLEEP_AFTER_SERIAL_OPEN)
 

--- a/doc/interfaces/serial.rst
+++ b/doc/interfaces/serial.rst
@@ -4,6 +4,10 @@ CAN over Serial
 ===============
 A text based interface. For example use over serial ports like
 ``/dev/ttyS1`` or ``/dev/ttyUSB0`` on Linux machines or ``COM1`` on Windows.
+Remote ports can be also used via a special URL. Both raw TCP sockets as
+also RFC2217 ports are supported: ``socket://192.168.254.254:5000`` or
+``rfc2217://192.168.254.254:5000``. In addition a virtual loopback can be
+used via ``loop://`` URL.
 The interface is a simple implementation that has been used for
 recording CAN traces.
 

--- a/doc/interfaces/slcan.rst
+++ b/doc/interfaces/slcan.rst
@@ -5,10 +5,12 @@ CAN over Serial / SLCAN
 
 A text based interface: compatible to slcan-interfaces (slcan ASCII protocol) should also support LAWICEL direct.
 These interfaces can also be used with socketcan and slcand with Linux.
-This driver directly uses the serial port, it makes slcan-compatible interfaces usable with Windows also.
+This driver directly uses either the local or remote serial port, it makes slcan-compatible interfaces usable with Windows also.
+Remote serial ports will be specified via special URL. Both raw TCP sockets as also RFC2217 ports are supported.
 
-Usage: use ``port[@baurate]`` to open the device.
-For example use ``/dev/ttyUSB0@115200`` or ``COM4@9600``
+Usage: use ``port or URL[@baurate]`` to open the device.
+For example use ``/dev/ttyUSB0@115200`` or ``COM4@9600`` for local serial ports and
+``socket://192.168.254.254:5000`` or ``rfc2217://192.168.254.254:5000`` for remote ports.
 
 .. note:
     An Arduino-Interface could easily be build with this:


### PR DESCRIPTION
This way one can also use remote ports via socket:// or rfc2217:// URLs.