### PR TITLE
Fix issue #394

### DIFF
--- a/can/thread_safe_bus.py
+++ b/can/thread_safe_bus.py
@@ -64,8 +64,8 @@ class ThreadSafeBus(ObjectProxy):
         self.__wrapped__._lock_send_periodic = nullcontext()
 
         # init locks for sending and receiving separately
-        _lock_send = RLock()
-        _lock_recv = RLock()
+        self._lock_send = RLock()
+        self._lock_recv = RLock()
 
     def recv(self, timeout=None, *args, **kwargs):
         with self._lock_recv:

--- a/can/thread_safe_bus.py
+++ b/can/thread_safe_bus.py
@@ -18,10 +18,10 @@ from .interface import Bus
 
 
 try:
-    from contextlib import nullcontext as NullContextManager
+    from contextlib import nullcontext
 
 except ImportError:
-    class NullContextManager(object):
+    class nullcontext(object):
         """A context manager that does nothing at all.
         A fallback for Python 3.7's :class:`contextlib.nullcontext` manager.
         """
@@ -53,10 +53,6 @@ class ThreadSafeBus(ObjectProxy):
         instead of :meth:`~can.BusABC.recv` directly.
     """
 
-    # init locks for sending and receiving separately
-    _lock_send = RLock()
-    _lock_recv = RLock()
-
     def __init__(self, *args, **kwargs):
         if import_exc is not None:
             raise import_exc
@@ -65,7 +61,11 @@ class ThreadSafeBus(ObjectProxy):
 
         # now, BusABC.send_periodic() does not need a lock anymore, but the
         # implementation still requires a context manager
-        self.__wrapped__._lock_send_periodic = NullContextManager()
+        self.__wrapped__._lock_send_periodic = nullcontext()
+
+        # init locks for sending and receiving separately
+        _lock_send = RLock()
+        _lock_recv = RLock()
 
     def recv(self, timeout=None, *args, **kwargs):
         with self._lock_recv:


### PR DESCRIPTION
Makes the locks in `ThreadSafeBus` object-local. They have been accidentally class-local with caused multiple instance to block each other.