### PR TITLE
Message dlc alignment in string representation

### DIFF
--- a/can/message.py
+++ b/can/message.py
@@ -86,7 +86,7 @@ class Message(object):
 
         field_strings.append(flag_string)
 
-        field_strings.append("DLC: {0:d}".format(self.dlc))
+        field_strings.append("DLC: {0:2d}".format(self.dlc))
         data_strings = []
         if self.data is not None:
             for index in range(0, min(self.dlc, len(self.data))):


### PR DESCRIPTION
Changes the logger output from:
```
Timestamp:     3064.687553        ID: 0000    S     F    DLC: 8    00 01 02 03 04 05 06 07
Timestamp:     3064.887836        ID: 0001    S     F    DLC: 64    00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f 20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f 30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f
```

to:
```
Timestamp:     3109.265685        ID: 0000    S     F    DLC:  8    00 01 02 03 04 05 06 07
Timestamp:     3109.465969        ID: 0001    S     F    DLC: 64    00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f 20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f 30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f
```