### PR TITLE
Feature socketcan bcm owned by bus

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,4 @@
+# Validate with curl --data-binary @.codecov.yml https://codecov.io/validate
 codecov:
   archive:
     uploads: no

--- a/can/bus.py
+++ b/can/bus.py
@@ -206,22 +206,26 @@ class BusABC(object):
         # we wrap the task's stop method to also remove it from the Bus's list of tasks
         original_stop_method = task.stop
 
-        def wrapped_stop_method():
-            try:
-                self._periodic_tasks.remove(task)
-            except ValueError:
-                pass
+        def wrapped_stop_method(remove_task=True):
+            if remove_task:
+                try:
+                    self._periodic_tasks.remove(task)
+                except ValueError:
+                    pass
             original_stop_method()
         task.stop = wrapped_stop_method
         if store_task:
             self._periodic_tasks.append(task)
         return task
 
-    def stop_all_periodic_tasks(self):
+    def stop_all_periodic_tasks(self, remove_tasks=True):
         """Stop sending any messages that were started using bus.send_periodic
+
+        :param bool remove_tasks:
+            Stop tracking the stopped tasks.
         """
         for task in self._periodic_tasks:
-            task.stop()
+            task.stop(remove_task=remove_tasks)
 
     def __iter__(self):
         """Allow iteration on messages as they are received.

--- a/can/bus.py
+++ b/can/bus.py
@@ -203,7 +203,7 @@ class BusABC(object):
             # Create a send lock for this bus
             self._lock_send_periodic = threading.Lock()
         task = ThreadBasedCyclicSendTask(self, self._lock_send_periodic, msg, period, duration)
-        # we wrap the task`s stop method to also remove it from the Bus's list of tasks
+        # we wrap the task's stop method to also remove it from the Bus's list of tasks
         original_stop_method = task.stop
 
         def wrapped_stop_method():

--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -214,6 +214,7 @@ def send_bcm(bcm_socket, data):
         else:
             raise e
 
+
 def _add_flags_to_can_id(message):
     can_id = message.arbitration_id
     if message.is_extended_id:
@@ -240,21 +241,21 @@ class CyclicSendTask(LimitedDurationCyclicSendTaskABC,
 
     """
 
-    def __init__(self, channel, message, period, duration=None):
+    def __init__(self, bcm_socket, message, period, duration=None):
         """
-        :param str channel: The name of the CAN channel to connect to.
+        :param bcm_socket: An open bcm socket on the desired CAN channel.
         :param can.Message message: The message to be sent periodically.
         :param float period: The rate in seconds at which to send the message.
         :param float duration: Approximate duration in seconds to send the message.
         """
         super(CyclicSendTask, self).__init__(message, period, duration)
-        self.channel = channel
+        self.bcm_socket = bcm_socket
         self.duration = duration
         self._tx_setup(message)
         self.message = message
 
     def _tx_setup(self, message):
-        self.bcm_socket = create_bcm_socket(self.channel)
+
         # Create a low level packed frame to pass to the kernel
         self.can_id_with_flags = _add_flags_to_can_id(message)
         self.flags = CAN_FD_FRAME if message.is_fd else 0
@@ -283,7 +284,6 @@ class CyclicSendTask(LimitedDurationCyclicSendTaskABC,
 
         stopframe = build_bcm_tx_delete_header(self.can_id_with_flags, self.flags)
         send_bcm(self.bcm_socket, stopframe)
-        self.bcm_socket.close()
 
     def modify_data(self, message):
         """Update the contents of this periodically sent message.
@@ -460,8 +460,9 @@ class SocketcanBus(BusABC):
         self.socket = create_socket()
         self.channel = channel
         self.channel_info = "socketcan channel '%s'" % channel
+        self._bcm_sockets = {}
 
-        # set the receive_own_messages paramater
+        # set the receive_own_messages parameter
         try:
             self.socket.setsockopt(SOL_CAN_RAW,
                                    CAN_RAW_RECV_OWN_MSGS,
@@ -481,12 +482,17 @@ class SocketcanBus(BusABC):
                                0x1FFFFFFF)
 
         bind_socket(self.socket, channel)
-
         kwargs.update({'receive_own_messages': receive_own_messages, 'fd': fd})
         super(SocketcanBus, self).__init__(channel=channel, **kwargs)
 
     def shutdown(self):
-        """Closes the socket."""
+        """Stops all active periodic tasks and closes the socket."""
+        self.stop_all_periodic_tasks()
+        for channel in self._bcm_sockets:
+            log.debug("Closing bcm socket for channel {}".format(channel))
+            bcm_socket = self._bcm_sockets[channel]
+            bcm_socket.close()
+        log.debug("Closing raw can socket")
         self.socket.close()
 
     def _recv_internal(self, timeout):
@@ -568,7 +574,8 @@ class SocketcanBus(BusABC):
     def send_periodic(self, msg, period, duration=None):
         """Start sending a message at a given period on this bus.
 
-        The kernel's broadcast manager will be used.
+        The kernel's broadcast manager will be used and the task will
+        be active while this Bus instance is still in scope.
 
         :param can.Message msg:
             Message to transmit
@@ -578,7 +585,9 @@ class SocketcanBus(BusABC):
             The duration to keep sending this message at given rate. If
             no duration is provided, the task will continue indefinitely.
 
-        :return: A started task instance
+        :return:
+            A started task instance. This can be used to modify the data,
+            pause/resume the transmission and to stop the transmission.
         :rtype: can.interfaces.socketcan.CyclicSendTask
 
         .. note::
@@ -589,7 +598,15 @@ class SocketcanBus(BusABC):
             least *duration* seconds.
 
         """
-        return CyclicSendTask(msg.channel or self.channel, msg, period, duration)
+        bcm_socket = self._get_bcm_socket(msg.channel or self.channel)
+        task = CyclicSendTask(bcm_socket, msg, period, duration)
+        self._periodic_tasks.append(task)
+        return task
+
+    def _get_bcm_socket(self, channel):
+        if channel not in self._bcm_sockets:
+            self._bcm_sockets[channel] = create_bcm_socket(self.channel)
+        return self._bcm_sockets[channel]
 
     def _apply_filters(self, filters):
         try:

--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -574,8 +574,7 @@ class SocketcanBus(BusABC):
     def send_periodic(self, msg, period, duration=None):
         """Start sending a message at a given period on this bus.
 
-        The kernel's broadcast manager will be used and the task will
-        be active while this Bus instance is still in scope.
+        The kernel's broadcast manager will be used.
 
         :param can.Message msg:
             Message to transmit

--- a/doc/bcm.rst
+++ b/doc/bcm.rst
@@ -1,3 +1,5 @@
+.. _bcm:
+
 Broadcast Manager
 =================
 

--- a/doc/bcm.rst
+++ b/doc/bcm.rst
@@ -3,11 +3,9 @@ Broadcast Manager
 
 .. module:: can.broadcastmanager
 
-The broadcast manager isn't yet supported by all interfaces.
-Currently SocketCAN and IXXAT are supported at least partially.
-It allows the user to setup periodic message jobs.
-
-If periodic transmission is not supported natively, a software thread
+The broadcast manager allows the user to setup periodic message jobs.
+For example sending a particular message at a given period. The broadcast
+manager supported natively by several interfaces and a software thread
 based scheduler is used as a fallback.
 
 This example shows the socketcan backend using the broadcast manager:
@@ -23,6 +21,10 @@ Message Sending Tasks
 The class based api for the broadcast manager uses a series of
 `mixin classes <https://www.ianlewis.org/en/mixins-and-python>`_.
 All mixins inherit from :class:`~can.broadcastmanager.CyclicSendTaskABC`
+which inherits from :class:`~can.broadcastmanager.CyclicTask`.
+
+.. autoclass:: can.broadcastmanager.CyclicTask
+    :members:
 
 .. autoclass:: can.broadcastmanager.CyclicSendTaskABC
     :members:

--- a/doc/bus.rst
+++ b/doc/bus.rst
@@ -11,8 +11,7 @@ class, for example::
     vector_bus = can.Bus(interface='vector', ...)
 
 That bus is then able to handle the interface specific software/hardware interactions
-and implements the :class:`~can.BusABC` API. It itself is an instance of ``VectorBus``,
-but these specififc buses should not be instantiated directly.
+and implements the :class:`~can.BusABC` API.
 
 A thread safe bus wrapper is also available, see `Thread safe bus`_.
 
@@ -35,8 +34,9 @@ API
 Transmitting
 ''''''''''''
 
-Writing to the bus is done by calling the :meth:`~can.BusABC.send` method and
-passing a :class:`~can.Message` instance.
+Writing individual messages to the bus is done by calling the :meth:`~can.BusABC.send` method
+and passing a :class:`~can.Message` instance. Periodic sending is controlled by the
+:ref:`broadcast manager <bcm>`.
 
 
 Receiving

--- a/test/simplecyclic_test.py
+++ b/test/simplecyclic_test.py
@@ -14,6 +14,7 @@ import can
 
 from .config import *
 
+
 class SimpleCyclicSendTaskTest(unittest.TestCase):
 
     @unittest.skipIf(IS_CI, "the timing sensitive behaviour cannot be reproduced reliably on a CI server")
@@ -34,6 +35,31 @@ class SimpleCyclicSendTaskTest(unittest.TestCase):
 
         bus1.shutdown()
         bus2.shutdown()
+
+
+    @unittest.skipIf(IS_CI, "the timing sensitive behaviour cannot be reproduced reliably on a CI server")
+    def test_removing_bus_tasks(self):
+
+        bus1 = can.interface.Bus(bustype='virtual')
+        bus2 = can.interface.Bus(bustype='virtual')
+        tasks = []
+        for task_i in range(10):
+            msg = can.Message(extended_id=False, arbitration_id=0x123, data=[0, 1, 2, 3, 4, 5, 6, 7])
+            msg.arbitration_id = task_i
+            task = bus1.send_periodic(msg, 0.1, 1)
+            tasks.append(task)
+            self.assertIsInstance(task, can.broadcastmanager.CyclicSendTaskABC)
+
+        assert len(bus1._periodic_tasks) == 10
+
+        for task in tasks:
+            task.stop()
+
+        assert len(bus1._periodic_tasks) == 0
+
+        bus1.shutdown()
+        bus2.shutdown()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/simplecyclic_test.py
+++ b/test/simplecyclic_test.py
@@ -91,15 +91,22 @@ class SimpleCyclicSendTaskTest(unittest.TestCase):
             task = bus.send_periodic(msg, 0.1, 1)
             tasks.append(task)
 
+        assert len(bus._periodic_tasks) == 10
         # stop half the tasks using the task object
         for task in tasks[::2]:
             task.stop()
 
+        assert len(bus._periodic_tasks) == 5
+
         # stop the other half using the bus api
-        bus.stop_all_periodic_tasks()
+        bus.stop_all_periodic_tasks(remove_tasks=False)
 
         for task in tasks:
             assert task.thread.join(5.0) is None, "Task didn't stop before timeout"
+
+        # Tasks stopped via `stop_all_periodic_tasks` with remove_tasks=False should
+        # still be associated with the bus (e.g. for restarting)
+        assert len(bus._periodic_tasks) == 5
 
         bus.shutdown()
 


### PR DESCRIPTION
Competes with #409  because I forgot to look if you were already doing this @christiansandberg !

* adds task management responsibility to the `Bus`. By default tasks created with `bus.send_periodic` will have a reference held by the bus - this means in many cases the user doesn't need to keep the task in scope for their periodic messages to continue being sent. If this behavior isn't desired pass `store_task=False` to the `send_periodic` method.
* the bus now has a `stop_all_periodic_tasks` method
* The socketcan tasks now reuse a bcm socket
