### PR TITLE
Remove shebangs from files in the module

### DIFF
--- a/can/CAN.py
+++ b/can/CAN.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/__init__.py
+++ b/can/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/broadcastmanager.py
+++ b/can/broadcastmanager.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/bus.py
+++ b/can/bus.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/ctypesutil.py
+++ b/can/ctypesutil.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interface.py
+++ b/can/interface.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/ics_neovi/__init__.py
+++ b/can/interfaces/ics_neovi/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/ics_neovi/neovi_bus.py
+++ b/can/interfaces/ics_neovi/neovi_bus.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/iscan.py
+++ b/can/interfaces/iscan.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/ixxat/__init__.py
+++ b/can/interfaces/ixxat/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/ixxat/constants.py
+++ b/can/interfaces/ixxat/constants.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/ixxat/exceptions.py
+++ b/can/interfaces/ixxat/exceptions.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/ixxat/structures.py
+++ b/can/interfaces/ixxat/structures.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/kvaser/__init__.py
+++ b/can/interfaces/kvaser/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/kvaser/canlib.py
+++ b/can/interfaces/kvaser/canlib.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/kvaser/constants.py
+++ b/can/interfaces/kvaser/constants.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/nican.py
+++ b/can/interfaces/nican.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/pcan/__init__.py
+++ b/can/interfaces/pcan/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/pcan/basic.py
+++ b/can/interfaces/pcan/basic.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/serial/__init__.py
+++ b/can/interfaces/serial/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/serial/serial_can.py
+++ b/can/interfaces/serial/serial_can.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/slcan.py
+++ b/can/interfaces/slcan.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/socketcan/__init__.py
+++ b/can/interfaces/socketcan/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/socketcan/constants.py
+++ b/can/interfaces/socketcan/constants.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 import logging
 

--- a/can/interfaces/socketcan/utils.py
+++ b/can/interfaces/socketcan/utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/usb2can/__init__.py
+++ b/can/interfaces/usb2can/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/usb2can/serial_selector.py
+++ b/can/interfaces/usb2can/serial_selector.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/usb2can/usb2canInterface.py
+++ b/can/interfaces/usb2can/usb2canInterface.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/usb2can/usb2canabstractionlayer.py
+++ b/can/interfaces/usb2can/usb2canabstractionlayer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/vector/__init__.py
+++ b/can/interfaces/vector/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/vector/exceptions.py
+++ b/can/interfaces/vector/exceptions.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/vector/vxlapi.py
+++ b/can/interfaces/vector/vxlapi.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/interfaces/virtual.py
+++ b/can/interfaces/virtual.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/io/__init__.py
+++ b/can/io/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/io/canutils.py
+++ b/can/io/canutils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/io/csv.py
+++ b/can/io/csv.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/io/generic.py
+++ b/can/io/generic.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/io/player.py
+++ b/can/io/player.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/io/printer.py
+++ b/can/io/printer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/listener.py
+++ b/can/listener.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/logger.py
+++ b/can/logger.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/message.py
+++ b/can/message.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/notifier.py
+++ b/can/notifier.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/player.py
+++ b/can/player.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/thread_safe_bus.py
+++ b/can/thread_safe_bus.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 from __future__ import print_function, absolute_import

--- a/can/util.py
+++ b/can/util.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 """

--- a/can/viewer.py
+++ b/can/viewer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # coding: utf-8
 #
 # Copyright (C) 2018 Kristian Sloth Lauszus. All rights reserved.


### PR DESCRIPTION
The execution bit is removed from these files when they are installed, rendering the shebangs useless. In most cases, the scripts don't handle `__main__` anyway, which makes the shebang misleading as well.

This should wrap up the discussion in #418.