### PR TITLE
Remove spaces from setup.py version specifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import
 
 from os import listdir
 from os.path import isfile, join
-from sys import version_info
 import re
 import logging
 from setuptools import setup, find_packages
@@ -25,17 +24,17 @@ with open('README.rst', 'r') as f:
 
 # Dependencies
 extras_require = {
-    'serial':   ['pyserial ~= 3.0'],
-    'neovi':    ['python-ics >= 2.12']
+    'serial':   ['pyserial~=3.0'],
+    'neovi':    ['python-ics>=2.12']
 }
 
 tests_require = [
-    'mock ~= 2.0',
-    'nose ~= 1.3',
-    'pytest ~= 3.6',
-    'pytest-timeout ~= 1.2',
-    'pytest-cov ~= 2.5',
-    'codecov ~= 2.0',
+    'mock~=2.0',
+    'nose~=1.3',
+    'pytest~=3.6',
+    'pytest-timeout~=1.2',
+    'pytest-cov~=2.5',
+    'codecov~=2.0',
     'future',
     'six'
 ] + extras_require['serial']
@@ -100,7 +99,7 @@ setup(
     # see https://www.python.org/dev/peps/pep-0345/#version-specifiers
     python_requires=">=2.7,!=3.0,!=3.1,!=3.2,!=3.3",
     install_requires=[
-        'wrapt ~= 1.10', 'typing', 'windows-curses;platform_system=="Windows"',
+        'wrapt~= 1.10', 'typing', 'windows-curses;platform_system=="Windows"',
     ],
     extras_require=extras_require,
 


### PR DESCRIPTION
Suggested fix for #431