### PR TITLE
Make dependency typing only required for python_version < 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
     python_requires=">=2.7,!=3.0,!=3.1,!=3.2,!=3.3",
     install_requires=[
         'wrapt~=1.10',
-        'typing',
+        'typing;python_version<"3.5"',
         'windows-curses;platform_system=="Windows"',
     ],
     extras_require=extras_require,


### PR DESCRIPTION
FIx #451.