### PR TITLE
Use is_extedned_id instead of extended_id in Message constructor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Example usage
                   receive_own_messages=True)
 
     # send a message
-    message = can.Message(arbitration_id=123, extended_id=True,
+    message = can.Message(arbitration_id=123, is_extended_id=True,
                           data=[0x11, 0x22, 0x33])
     bus.send(message, timeout=0.2)
 

--- a/can/interfaces/ics_neovi/neovi_bus.py
+++ b/can/interfaces/ics_neovi/neovi_bus.py
@@ -268,7 +268,7 @@ class NeoViBus(BusABC):
                 arbitration_id=ics_msg.ArbIDOrHeader,
                 data=data,
                 dlc=ics_msg.NumberBytesData,
-                extended_id=bool(
+                is_extended_id=bool(
                     ics_msg.StatusBitField & ics.SPY_STATUS_XTD_FRAME
                 ),
                 is_fd=is_fd,
@@ -289,7 +289,7 @@ class NeoViBus(BusABC):
                 arbitration_id=ics_msg.ArbIDOrHeader,
                 data=ics_msg.Data[:ics_msg.NumberBytesData],
                 dlc=ics_msg.NumberBytesData,
-                extended_id=bool(
+                is_extended_id=bool(
                     ics_msg.StatusBitField & ics.SPY_STATUS_XTD_FRAME
                 ),
                 is_fd=is_fd,

--- a/can/interfaces/iscan.py
+++ b/can/interfaces/iscan.py
@@ -111,7 +111,7 @@ class IscanBus(BusABC):
                 break
 
         msg = Message(arbitration_id=raw_msg.message_id,
-                      extended_id=bool(raw_msg.is_extended),
+                      is_extended_id=bool(raw_msg.is_extended),
                       timestamp=time.time(),                    # Better than nothing...
                       is_remote_frame=bool(raw_msg.remote_req),
                       dlc=raw_msg.data_len,

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -470,7 +470,7 @@ class IXXATBus(BusABC):
         rx_msg = Message(
             timestamp=self._message.dwTime / self._tick_resolution,  # Relative time in s
             is_remote_frame=True if self._message.uMsgInfo.Bits.rtr else False,
-            extended_id=True if self._message.uMsgInfo.Bits.ext else False,
+            is_extended_id=True if self._message.uMsgInfo.Bits.ext else False,
             arbitration_id=self._message.dwMsgId,
             dlc=self._message.uMsgInfo.Bits.dlc,
             data=self._message.abData[:self._message.uMsgInfo.Bits.dlc],

--- a/can/interfaces/kvaser/canlib.py
+++ b/can/interfaces/kvaser/canlib.py
@@ -508,7 +508,7 @@ class KvaserBus(BusABC):
             rx_msg = Message(arbitration_id=arb_id.value,
                              data=data_array[:dlc.value],
                              dlc=dlc.value,
-                             extended_id=is_extended,
+                             is_extended_id=is_extended,
                              is_error_frame=is_error_frame,
                              is_remote_frame=is_remote_frame,
                              is_fd=is_fd,

--- a/can/interfaces/nican.py
+++ b/can/interfaces/nican.py
@@ -245,7 +245,7 @@ class NicanBus(BusABC):
                       channel=self.channel,
                       is_remote_frame=is_remote_frame,
                       is_error_frame=is_error_frame,
-                      extended_id=is_extended,
+                      is_extended_id=is_extended,
                       arbitration_id=arb_id,
                       dlc=dlc,
                       data=raw_msg.data[:dlc])

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -218,7 +218,7 @@ class PcanBus(BusABC):
 
         rx_msg = Message(timestamp=timestamp,
                          arbitration_id=theMsg.ID,
-                         extended_id=bIsExt,
+                         is_extended_id=bIsExt,
                          is_remote_frame=bIsRTR,
                          dlc=dlc,
                          data=theMsg.DATA[:dlc])

--- a/can/interfaces/serial/serial_can.py
+++ b/can/interfaces/serial/serial_can.py
@@ -119,7 +119,7 @@ class SerialBus(BusABC):
             Received message and False (because not filtering as taken place).
 
             .. warning::
-                Flags like extended_id, is_remote_frame and is_error_frame
+                Flags like is_extended_id, is_remote_frame and is_error_frame
                 will not be set over this function, the flags in the return
                 message are the default values.
 

--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -422,7 +422,7 @@ def capture_message(sock, get_channel=False):
     msg = Message(timestamp=timestamp,
                   channel=channel,
                   arbitration_id=arbitration_id,
-                  extended_id=is_extended_frame_format,
+                  is_extended_id=is_extended_frame_format,
                   is_remote_frame=is_remote_transmission_request,
                   is_error_frame=is_error_frame,
                   is_fd=is_fd,

--- a/can/interfaces/usb2can/usb2canInterface.py
+++ b/can/interfaces/usb2can/usb2canInterface.py
@@ -65,7 +65,7 @@ def message_convert_rx(messagerx):
 
     msgrx = Message(timestamp=messagerx.timestamp,
                     is_remote_frame=REMOTE_FRAME,
-                    extended_id=ID_TYPE,
+                    is_extended_id=ID_TYPE,
                     is_error_frame=ERROR_FRAME,
                     arbitration_id=messagerx.id,
                     dlc=messagerx.sizeData,

--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -265,7 +265,7 @@ class VectorBus(BusABC):
                         msg = Message(
                             timestamp=timestamp + self._time_offset,
                             arbitration_id=msg_id & 0x1FFFFFFF,
-                            extended_id=bool(msg_id & vxlapi.XL_CAN_EXT_MSG_ID),
+                            is_extended_id=bool(msg_id & vxlapi.XL_CAN_EXT_MSG_ID),
                             is_remote_frame=bool(flags & vxlapi.XL_CAN_RXMSG_FLAG_RTR),
                             is_error_frame=bool(flags & vxlapi.XL_CAN_RXMSG_FLAG_EF),
                             is_fd=bool(flags & vxlapi.XL_CAN_RXMSG_FLAG_EDL),
@@ -292,7 +292,7 @@ class VectorBus(BusABC):
                         msg = Message(
                             timestamp=timestamp + self._time_offset,
                             arbitration_id=msg_id & 0x1FFFFFFF,
-                            extended_id=bool(msg_id & vxlapi.XL_CAN_EXT_MSG_ID),
+                            is_extended_id=bool(msg_id & vxlapi.XL_CAN_EXT_MSG_ID),
                             is_remote_frame=bool(flags & vxlapi.XL_CAN_MSG_FLAG_REMOTE_FRAME),
                             is_error_frame=bool(flags & vxlapi.XL_CAN_MSG_FLAG_ERROR_FRAME),
                             is_fd=False,

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -85,7 +85,7 @@ class ASCReader(BaseIOHandler):
                 can_id_num, is_extended_id = self._extract_can_id(can_id_str)
                 msg = Message(timestamp=timestamp,
                               arbitration_id=can_id_num & CAN_ID_MASK,
-                              extended_id=is_extended_id,
+                              is_extended_id=is_extended_id,
                               is_remote_frame=True,
                               channel=channel)
                 yield msg
@@ -111,7 +111,7 @@ class ASCReader(BaseIOHandler):
                 yield Message(
                     timestamp=timestamp,
                     arbitration_id=can_id_num & CAN_ID_MASK,
-                    extended_id=is_extended_id,
+                    is_extended_id=is_extended_id,
                     is_remote_frame=False,
                     dlc=dlc,
                     data=frame,

--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -215,7 +215,7 @@ class BLFReader(BaseIOHandler):
                          can_data) = CAN_MSG_STRUCT.unpack_from(data, pos)
                         msg = Message(timestamp=timestamp,
                                       arbitration_id=can_id & 0x1FFFFFFF,
-                                      extended_id=bool(can_id & CAN_MSG_EXT),
+                                      is_extended_id=bool(can_id & CAN_MSG_EXT),
                                       is_remote_frame=bool(flags & REMOTE_FLAG),
                                       dlc=dlc,
                                       data=can_data[:dlc],
@@ -227,7 +227,7 @@ class BLFReader(BaseIOHandler):
                         length = dlc2len(dlc)
                         msg = Message(timestamp=timestamp,
                                       arbitration_id=can_id & 0x1FFFFFFF,
-                                      extended_id=bool(can_id & CAN_MSG_EXT),
+                                      is_extended_id=bool(can_id & CAN_MSG_EXT),
                                       is_remote_frame=bool(flags & REMOTE_FLAG),
                                       is_fd=bool(fd_flags & EDL),
                                       bitrate_switch=bool(fd_flags & BRS),
@@ -241,7 +241,7 @@ class BLFReader(BaseIOHandler):
                          can_data) = CAN_ERROR_EXT_STRUCT.unpack_from(data, pos)
                         msg = Message(timestamp=timestamp,
                                       is_error_frame=True,
-                                      extended_id=bool(can_id & CAN_MSG_EXT),
+                                      is_extended_id=bool(can_id & CAN_MSG_EXT),
                                       arbitration_id=can_id & 0x1FFFFFFF,
                                       dlc=dlc,
                                       data=can_data[:dlc],

--- a/can/io/canutils.py
+++ b/can/io/canutils.py
@@ -81,7 +81,7 @@ class CanutilsLogReader(BaseIOHandler):
                 msg = Message(timestamp=timestamp, is_error_frame=True)
             else:
                 msg = Message(timestamp=timestamp, arbitration_id=canId & 0x1FFFFFFF,
-                              extended_id=isExtended, is_remote_frame=isRemoteFrame,
+                              is_extended_id=isExtended, is_remote_frame=isRemoteFrame,
                               dlc=dlc, data=dataBin, channel=channel)
             yield msg
 

--- a/can/io/csv.py
+++ b/can/io/csv.py
@@ -99,7 +99,7 @@ class CSVReader(BaseIOHandler):
             yield Message(
                 timestamp=float(timestamp),
                 is_remote_frame=(remote == '1'),
-                extended_id=(extended == '1'),
+                is_extended_id=(extended == '1'),
                 is_error_frame=(error == '1'),
                 arbitration_id=int(arbitration_id, base=16),
                 dlc=int(dlc),

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -64,7 +64,7 @@ class SqliteReader(BaseIOHandler):
         return Message(
             timestamp=timestamp,
             is_remote_frame=bool(is_remote),
-            extended_id=bool(is_extended),
+            is_extended_id=bool(is_extended),
             is_error_frame=bool(is_error),
             arbitration_id=can_id,
             dlc=dlc,

--- a/can/message.py
+++ b/can/message.py
@@ -82,7 +82,7 @@ class Message(object):
                  is_remote_frame=False, is_error_frame=False, channel=None,
                  dlc=None, data=None,
                  is_fd=False, bitrate_switch=False, error_state_indicator=False,
-                 extended_id=True,
+                 extended_id=True, # deprecated in 3.x, removed in 4.x
                  check=False):
         """
         To create a message object, simply provide any of the below attributes
@@ -221,7 +221,7 @@ class Message(object):
         new = Message(
             timestamp=self.timestamp,
             arbitration_id=self.arbitration_id,
-            extended_id=self.is_extended_id,
+            is_extended_id=self.is_extended_id,
             is_remote_frame=self.is_remote_frame,
             is_error_frame=self.is_error_frame,
             channel=self.channel,
@@ -238,7 +238,7 @@ class Message(object):
         new = Message(
             timestamp=self.timestamp,
             arbitration_id=self.arbitration_id,
-            extended_id=self.is_extended_id,
+            is_extended_id=self.is_extended_id,
             is_remote_frame=self.is_remote_frame,
             is_error_frame=self.is_error_frame,
             channel=deepcopy(self.channel, memo),

--- a/doc/interfaces/socketcan.rst
+++ b/doc/interfaces/socketcan.rst
@@ -140,7 +140,7 @@ To spam a bus:
         """:param id: Spam the bus with messages including the data id."""
         bus = can.interface.Bus(channel=channel, bustype=bustype)
         for i in range(10):
-            msg = can.Message(arbitration_id=0xc0ffee, data=[id, i, 0, 1, 3, 1, 4, 1], extended_id=False)
+            msg = can.Message(arbitration_id=0xc0ffee, data=[id, i, 0, 1, 3, 1, 4, 1], is_extended_id=False)
             bus.send(msg)
         # Issue #3: Need to keep running to ensure the writing threads stay alive. ?
         time.sleep(1)

--- a/doc/message.rst
+++ b/doc/message.rst
@@ -43,7 +43,7 @@ Message
         (either 2\ :sup:`11` - 1 for 11-bit IDs, or
         2\ :sup:`29` - 1 for 29-bit identifiers).
 
-            >>> print(Message(extended_id=False, arbitration_id=100))
+            >>> print(Message(is_extended_id=False, arbitration_id=100))
             Timestamp:        0.000000        ID: 0064    S        DLC: 0
 
 
@@ -105,9 +105,9 @@ Message
         This flag controls the size of the :attr:`~can.Message.arbitration_id` field.
         Previously this was exposed as `id_type`.
 
-        >>> print(Message(extended_id=False))
+        >>> print(Message(is_extended_id=False))
         Timestamp:        0.000000        ID: 0000    S        DLC: 0
-        >>> print(Message(extended_id=True))
+        >>> print(Message(is_extended_id=True))
         Timestamp:        0.000000    ID: 00000000    X        DLC: 0
 
 

--- a/examples/cyclic.py
+++ b/examples/cyclic.py
@@ -26,7 +26,7 @@ def simple_periodic_send(bus):
     Sleeps for 2 seconds then stops the task.
     """
     print("Starting to send a message every 200ms for 2s")
-    msg = can.Message(arbitration_id=0x123, data=[1, 2, 3, 4, 5, 6], extended_id=False)
+    msg = can.Message(arbitration_id=0x123, data=[1, 2, 3, 4, 5, 6], is_extended_id=False)
     task = bus.send_periodic(msg, 0.20)
     assert isinstance(task, can.CyclicSendTaskABC)
     time.sleep(2)
@@ -36,7 +36,7 @@ def simple_periodic_send(bus):
 
 def limited_periodic_send(bus):
     print("Starting to send a message every 200ms for 1s")
-    msg = can.Message(arbitration_id=0x12345678, data=[0, 0, 0, 0, 0, 0], extended_id=True)
+    msg = can.Message(arbitration_id=0x12345678, data=[0, 0, 0, 0, 0, 0], is_extended_id=True)
     task = bus.send_periodic(msg, 0.20, 1, store_task=False)
     if not isinstance(task, can.LimitedDurationCyclicSendTaskABC):
         print("This interface doesn't seem to support a ")
@@ -107,7 +107,7 @@ def test_periodic_send_with_modifying_data(bus):
 
 if __name__ == "__main__":
 
-    reset_msg = can.Message(arbitration_id=0x00, data=[0, 0, 0, 0, 0, 0], extended_id=False)
+    reset_msg = can.Message(arbitration_id=0x00, data=[0, 0, 0, 0, 0, 0], is_extended_id=False)
 
     for interface, channel in [
         ('socketcan', 'vcan0'),

--- a/examples/send_one.py
+++ b/examples/send_one.py
@@ -24,7 +24,7 @@ def send_one():
 
     msg = can.Message(arbitration_id=0xc0ffee,
                       data=[0, 25, 0, 1, 3, 1, 4, 1],
-                      extended_id=True)
+                      is_extended_id=True)
 
     try:
         bus.send(msg)

--- a/examples/vcan_filtered.py
+++ b/examples/vcan_filtered.py
@@ -17,8 +17,8 @@ if __name__ == '__main__':
     can_filters = [{"can_id": 1, "can_mask": 0xf, "extended": True}]
     bus.set_filters(can_filters)
     notifier = can.Notifier(bus, [can.Printer()])
-    bus.send(can.Message(arbitration_id=1, extended_id=True))
-    bus.send(can.Message(arbitration_id=2, extended_id=True))
-    bus.send(can.Message(arbitration_id=1, extended_id=False))
+    bus.send(can.Message(arbitration_id=1, is_extended_id=True))
+    bus.send(can.Message(arbitration_id=2, is_extended_id=True))
+    bus.send(can.Message(arbitration_id=1, is_extended_id=False))
 
     time.sleep(10)

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -93,26 +93,26 @@ class Back2BackTestCase(unittest.TestCase):
                         'But measured {}'.format(delta_time))
 
     def test_standard_message(self):
-        msg = can.Message(extended_id=False,
+        msg = can.Message(is_extended_id=False,
                           arbitration_id=0x100,
                           data=[1, 2, 3, 4, 5, 6, 7, 8])
         self._send_and_receive(msg)
 
     def test_extended_message(self):
-        msg = can.Message(extended_id=True,
+        msg = can.Message(is_extended_id=True,
                           arbitration_id=0x123456,
                           data=[10, 11, 12, 13, 14, 15, 16, 17])
         self._send_and_receive(msg)
 
     def test_remote_message(self):
-        msg = can.Message(extended_id=False,
+        msg = can.Message(is_extended_id=False,
                           arbitration_id=0x200,
                           is_remote_frame=True,
                           dlc=4)
         self._send_and_receive(msg)
 
     def test_dlc_less_than_eight(self):
-        msg = can.Message(extended_id=False,
+        msg = can.Message(is_extended_id=False,
                           arbitration_id=0x300,
                           data=[4, 5, 6])
         self._send_and_receive(msg)
@@ -120,7 +120,7 @@ class Back2BackTestCase(unittest.TestCase):
     @unittest.skipUnless(TEST_CAN_FD, "Don't test CAN-FD")
     def test_fd_message(self):
         msg = can.Message(is_fd=True,
-                          extended_id=True,
+                          is_extended_id=True,
                           arbitration_id=0x56789,
                           data=[0xff] * 64)
         self._send_and_receive(msg)
@@ -129,7 +129,7 @@ class Back2BackTestCase(unittest.TestCase):
     def test_fd_message_with_brs(self):
         msg = can.Message(is_fd=True,
                           bitrate_switch=True,
-                          extended_id=True,
+                          is_extended_id=True,
                           arbitration_id=0x98765,
                           data=[0xff] * 48)
         self._send_and_receive(msg)
@@ -190,7 +190,7 @@ class TestThreadSafeBus(Back2BackTestCase):
 
         message = can.Message(
             arbitration_id=0x123,
-            extended_id=True,
+            is_extended_id=True,
             timestamp=121334.365,
             data=[254, 255, 1, 2]
         )

--- a/test/contextmanager_test.py
+++ b/test/contextmanager_test.py
@@ -13,7 +13,7 @@ class ContextManagerTest(unittest.TestCase):
 
     def setUp(self):
         data = [0, 1, 2, 3, 4, 5, 6, 7]
-        self.msg_send = can.Message(extended_id=False, arbitration_id=0x100, data=data)
+        self.msg_send = can.Message(is_extended_id=False, arbitration_id=0x100, data=data)
 
     def test_open_buses(self):
         with can.Bus(interface='virtual') as bus_send, can.Bus(interface='virtual') as bus_recv:

--- a/test/data/example_data.py
+++ b/test/data/example_data.py
@@ -40,11 +40,11 @@ TEST_MESSAGES_BASE = [
     ),
     Message(
         # no data
-        arbitration_id=0xAB, extended_id=False
+        arbitration_id=0xAB, is_extended_id=False
     ),
     Message(
         # no data
-        arbitration_id=0x42, extended_id=True
+        arbitration_id=0x42, is_extended_id=True
     ),
     Message(
         # no data
@@ -75,27 +75,27 @@ TEST_MESSAGES_BASE = [
         channel="awesome_channel",
     ),
     Message(
-        arbitration_id=0xABCDEF, extended_id=True,
+        arbitration_id=0xABCDEF, is_extended_id=True,
         timestamp=TEST_TIME,
         data=[1, 2, 3, 4, 5, 6, 7, 8]
     ),
     Message(
-        arbitration_id=0x123, extended_id=False,
+        arbitration_id=0x123, is_extended_id=False,
         timestamp=TEST_TIME + 42.42,
         data=[0xff, 0xff]
     ),
     Message(
-        arbitration_id=0xDADADA, extended_id=True,
+        arbitration_id=0xDADADA, is_extended_id=True,
         timestamp=TEST_TIME + .165,
         data=[1, 2, 3, 4, 5, 6, 7, 8]
     ),
     Message(
-        arbitration_id=0x123, extended_id=False,
+        arbitration_id=0x123, is_extended_id=False,
         timestamp=TEST_TIME + .365,
         data=[254, 255]
     ),
     Message(
-        arbitration_id=0x768, extended_id=False,
+        arbitration_id=0x768, is_extended_id=False,
         timestamp=TEST_TIME + 3.165
     ),
 ]
@@ -104,21 +104,21 @@ TEST_MESSAGES_BASE = sort_messages(TEST_MESSAGES_BASE)
 
 TEST_MESSAGES_REMOTE_FRAMES = [
     Message(
-        arbitration_id=0xDADADA, extended_id=True, is_remote_frame=True,
+        arbitration_id=0xDADADA, is_extended_id=True, is_remote_frame=True,
         timestamp=TEST_TIME + .165,
         data=[1, 2, 3, 4, 5, 6, 7, 8]
     ),
     Message(
-        arbitration_id=0x123, extended_id=False, is_remote_frame=True,
+        arbitration_id=0x123, is_extended_id=False, is_remote_frame=True,
         timestamp=TEST_TIME + .365,
         data=[254, 255]
     ),
     Message(
-        arbitration_id=0x768, extended_id=False, is_remote_frame=True,
+        arbitration_id=0x768, is_extended_id=False, is_remote_frame=True,
         timestamp=TEST_TIME + 3.165
     ),
     Message(
-        arbitration_id=0xABCDEF, extended_id=True, is_remote_frame=True,
+        arbitration_id=0xABCDEF, is_extended_id=True, is_remote_frame=True,
         timestamp=TEST_TIME + 7858.67
     ),
 ]
@@ -164,4 +164,4 @@ def generate_message(arbitration_id):
     and a non-extended ID.
     """
     data = bytearray([random.randrange(0, 2 ** 8 - 1) for _ in range(8)])
-    return Message(arbitration_id=arbitration_id, data=data, extended_id=False, timestamp=TEST_TIME)
+    return Message(arbitration_id=arbitration_id, data=data, is_extended_id=False, timestamp=TEST_TIME)

--- a/test/logformats_test.py
+++ b/test/logformats_test.py
@@ -352,12 +352,12 @@ class TestBlfFileFormat(ReaderWriterTest):
         expected = [
             can.Message(
                 timestamp=1.0,
-                extended_id=False,
+                is_extended_id=False,
                 arbitration_id=0x64,
                 data=[0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8]),
             can.Message(
                 timestamp=73.0,
-                extended_id=True,
+                is_extended_id=True,
                 arbitration_id=0x1FFFFFFF,
                 is_error_frame=True,)
         ]

--- a/test/network_test.py
+++ b/test/network_test.py
@@ -55,7 +55,7 @@ class ControllerAreaNetworkTestCase(unittest.TestCase):
                 arbitration_id=self.ids[i],
                 is_remote_frame=self.remote_flags[i],
                 is_error_frame=self.error_flags[i],
-                extended_id=self.extended_flags[i],
+                is_extended_id=self.extended_flags[i],
                 data=self.data[i]
             )
             #logging.debug("writing message: {}".format(m))

--- a/test/simplecyclic_test.py
+++ b/test/simplecyclic_test.py
@@ -24,7 +24,7 @@ class SimpleCyclicSendTaskTest(unittest.TestCase, ComparingMessagesTestCase):
 
     @unittest.skipIf(IS_CI, "the timing sensitive behaviour cannot be reproduced reliably on a CI server")
     def test_cycle_time(self):
-        msg = can.Message(extended_id=False, arbitration_id=0x123, data=[0,1,2,3,4,5,6,7])
+        msg = can.Message(is_extended_id=False, arbitration_id=0x123, data=[0,1,2,3,4,5,6,7])
         bus1 = can.interface.Bus(bustype='virtual')
         bus2 = can.interface.Bus(bustype='virtual')
         task = bus1.send_periodic(msg, 0.01, 1)
@@ -46,7 +46,7 @@ class SimpleCyclicSendTaskTest(unittest.TestCase, ComparingMessagesTestCase):
         bus = can.interface.Bus(bustype='virtual')
         tasks = []
         for task_i in range(10):
-            msg = can.Message(extended_id=False, arbitration_id=0x123, data=[0, 1, 2, 3, 4, 5, 6, 7])
+            msg = can.Message(is_extended_id=False, arbitration_id=0x123, data=[0, 1, 2, 3, 4, 5, 6, 7])
             msg.arbitration_id = task_i
             task = bus.send_periodic(msg, 0.1, 1)
             tasks.append(task)
@@ -65,7 +65,7 @@ class SimpleCyclicSendTaskTest(unittest.TestCase, ComparingMessagesTestCase):
         bus = can.interface.Bus(bustype='virtual', receive_own_messages=True)
         tasks = []
         for task_i in range(3):
-            msg = can.Message(extended_id=False, arbitration_id=0x123, data=[0, 1, 2, 3, 4, 5, 6, 7])
+            msg = can.Message(is_extended_id=False, arbitration_id=0x123, data=[0, 1, 2, 3, 4, 5, 6, 7])
             msg.arbitration_id = task_i
             task = bus.send_periodic(msg, 0.1, 10, store_task=False)
             tasks.append(task)
@@ -91,7 +91,7 @@ class SimpleCyclicSendTaskTest(unittest.TestCase, ComparingMessagesTestCase):
         bus = can.interface.Bus(bustype='virtual')
         tasks = []
         for task_i in range(10):
-            msg = can.Message(extended_id=False, arbitration_id=0x123, data=[0, 1, 2, 3, 4, 5, 6, 7])
+            msg = can.Message(is_extended_id=False, arbitration_id=0x123, data=[0, 1, 2, 3, 4, 5, 6, 7])
             msg.arbitration_id = task_i
             task = bus.send_periodic(msg, 0.1, 1)
             tasks.append(task)

--- a/test/test_kvaser.py
+++ b/test/test_kvaser.py
@@ -100,7 +100,7 @@ class KvaserTest(unittest.TestCase):
         msg = can.Message(
             arbitration_id=0xc0ffee,
             data=[0, 25, 0, 1, 3, 1, 4],
-            extended_id=True)
+            is_extended_id=True)
 
         self.bus.send(msg)
 
@@ -113,7 +113,7 @@ class KvaserTest(unittest.TestCase):
         msg = can.Message(
             arbitration_id=0x321,
             data=[50, 51],
-            extended_id=False)
+            is_extended_id=False)
 
         self.bus.send(msg)
 
@@ -130,7 +130,7 @@ class KvaserTest(unittest.TestCase):
         self.msg_in_cue = can.Message(
             arbitration_id=0xc0ffef,
             data=[1, 2, 3, 4, 5, 6, 7, 8],
-            extended_id=True)
+            is_extended_id=True)
 
         now = time.time()
         msg = self.bus.recv()
@@ -144,7 +144,7 @@ class KvaserTest(unittest.TestCase):
         self.msg_in_cue = can.Message(
             arbitration_id=0x123,
             data=[100, 101],
-            extended_id=False)
+            is_extended_id=False)
 
         msg = self.bus.recv()
         self.assertEqual(msg.arbitration_id, 0x123)

--- a/test/test_message_filtering.py
+++ b/test/test_message_filtering.py
@@ -14,8 +14,8 @@ from can import Bus, Message
 from .data.example_data import TEST_ALL_MESSAGES
 
 
-EXAMPLE_MSG = Message(arbitration_id=0x123, extended_id=True)
-HIGHEST_MSG = Message(arbitration_id=0x1FFFFFFF, extended_id=True)
+EXAMPLE_MSG = Message(arbitration_id=0x123, is_extended_id=True)
+HIGHEST_MSG = Message(arbitration_id=0x1FFFFFFF, is_extended_id=True)
 
 MATCH_EXAMPLE = [{
     "can_id": 0x123,

--- a/test/test_viewer.py
+++ b/test/test_viewer.py
@@ -140,31 +140,31 @@ class CanViewerTest(unittest.TestCase):
     def test_send(self):
         # CANopen EMCY
         data = [1, 2, 3, 4, 5, 6, 7]  # Wrong length
-        msg = can.Message(arbitration_id=0x080 + 1, data=data, extended_id=False)
+        msg = can.Message(arbitration_id=0x080 + 1, data=data, is_extended_id=False)
         self.can_viewer.bus.send(msg)
 
         data = [1, 2, 3, 4, 5, 6, 7, 8]
-        msg = can.Message(arbitration_id=0x080 + 1, data=data, extended_id=False)
+        msg = can.Message(arbitration_id=0x080 + 1, data=data, is_extended_id=False)
         self.can_viewer.bus.send(msg)
 
         # CANopen HEARTBEAT
         data = [0x05]  # Operational
-        msg = can.Message(arbitration_id=0x700 + 0x7F, data=data, extended_id=False)
+        msg = can.Message(arbitration_id=0x700 + 0x7F, data=data, is_extended_id=False)
         self.can_viewer.bus.send(msg)
 
         # Send non-CANopen message
         data = [1, 2, 3, 4, 5, 6, 7, 8]
-        msg = can.Message(arbitration_id=0x101, data=data, extended_id=False)
+        msg = can.Message(arbitration_id=0x101, data=data, is_extended_id=False)
         self.can_viewer.bus.send(msg)
 
         # Send the same command, but with another data length
         data = [1, 2, 3, 4, 5, 6]
-        msg = can.Message(arbitration_id=0x101, data=data, extended_id=False)
+        msg = can.Message(arbitration_id=0x101, data=data, is_extended_id=False)
         self.can_viewer.bus.send(msg)
 
         # Message with extended id
         data = [1, 2, 3, 4, 5, 6, 7, 8]
-        msg = can.Message(arbitration_id=0x123456, data=data, extended_id=True)
+        msg = can.Message(arbitration_id=0x123456, data=data, is_extended_id=True)
         self.can_viewer.bus.send(msg)
         # self.assertTupleEqual(self.can_viewer.parse_canopen_message(msg), (None, None))
 

--- a/test/zero_dlc_test.py
+++ b/test/zero_dlc_test.py
@@ -19,7 +19,7 @@ class ZeroDLCTest(unittest.TestCase):
         bus_send = can.interface.Bus(bustype='virtual')
         bus_recv = can.interface.Bus(bustype='virtual')
         data = [0, 1, 2, 3, 4, 5, 6, 7]
-        msg_send = can.Message(extended_id=False, arbitration_id=0x100, data=data)
+        msg_send = can.Message(is_extended_id=False, arbitration_id=0x100, data=data)
 
         bus_send.send(msg_send)
         msg_recv = bus_recv.recv()
@@ -38,7 +38,7 @@ class ZeroDLCTest(unittest.TestCase):
     def test_recv_zero_dlc(self):
         bus_send = can.interface.Bus(bustype='virtual')
         bus_recv = can.interface.Bus(bustype='virtual')
-        msg_send = can.Message(extended_id=False, arbitration_id=0x100, data=[])
+        msg_send = can.Message(is_extended_id=False, arbitration_id=0x100, data=[])
 
         bus_send.send(msg_send)
         msg_recv = bus_recv.recv()


### PR DESCRIPTION
This needs to be done before printing a warning when `extended_id` is used.

Part of #424.