### PR TITLE
fix rendering of BusABC docstring

### DIFF
--- a/can/bus.py
+++ b/can/bus.py
@@ -368,6 +368,7 @@ class BusABC(object):
     def state(self):
         """
         Return the current state of the hardware
+
         :return: ACTIVE, PASSIVE or ERROR
         :rtype: NamedTuple
         """
@@ -377,6 +378,7 @@ class BusABC(object):
     def state(self, new_state):
         """
         Set the new state of the hardware
+
         :param new_state: BusState.ACTIVE, BusState.PASSIVE or BusState.ERROR
         """
         raise NotImplementedError("Property is not implemented.")


### PR DESCRIPTION
This is just a minor thing, but the rendering in the docstring of `state` of `BusABC` is broken.