### PR TITLE
Fix Kvaser CANLIB CAN FD data rate setting

### DIFF
--- a/can/interfaces/kvaser/canlib.py
+++ b/can/interfaces/kvaser/canlib.py
@@ -396,7 +396,7 @@ class KvaserBus(BusABC):
             elif not data_bitrate:
                 # Use same bitrate for arbitration and data phase
                 data_bitrate = bitrate
-            canSetBusParamsFd(self._read_handle, bitrate, tseg1, tseg2, sjw)
+            canSetBusParamsFd(self._read_handle, data_bitrate, tseg1, tseg2, sjw)
         else:
             if 'tseg1' not in config and bitrate in BITRATE_OBJS:
                 bitrate = BITRATE_OBJS[bitrate]

--- a/test/test_kvaser.py
+++ b/test/test_kvaser.py
@@ -28,6 +28,7 @@ class KvaserTest(unittest.TestCase):
         canlib.canIoCtl = Mock(return_value=0)
         canlib.kvReadTimer = Mock()
         canlib.canSetBusParams = Mock()
+        canlib.canSetBusParamsFd = Mock()
         canlib.canBusOn = Mock()
         canlib.canBusOff = Mock()
         canlib.canClose = Mock()
@@ -159,6 +160,36 @@ class KvaserTest(unittest.TestCase):
             {'interface': 'kvaser', 'channel': 1}
         ]
         self.assertListEqual(configs, expected)
+
+    def test_canfd_default_data_bitrate(self):
+        canlib.canSetBusParams.reset_mock()
+        canlib.canSetBusParamsFd.reset_mock()
+        can.Bus(channel=0, bustype='kvaser', fd=True)
+        canlib.canSetBusParams.assert_called_once_with(
+            0, constants.canFD_BITRATE_500K_80P, 0, 0, 0, 0, 0)
+        canlib.canSetBusParamsFd.assert_called_once_with(
+            0, constants.canFD_BITRATE_500K_80P, 0, 0, 0)
+
+    def test_canfd_nondefault_data_bitrate(self):
+        canlib.canSetBusParams.reset_mock()
+        canlib.canSetBusParamsFd.reset_mock()
+        data_bitrate = 2000000
+        can.Bus(channel=0, bustype='kvaser', fd=True, data_bitrate=data_bitrate)
+        bitrate_constant = canlib.BITRATE_FD[data_bitrate]
+        canlib.canSetBusParams.assert_called_once_with(
+            0, constants.canFD_BITRATE_500K_80P, 0, 0, 0, 0, 0)
+        canlib.canSetBusParamsFd.assert_called_once_with(
+            0, bitrate_constant, 0, 0, 0)
+
+    def test_canfd_custom_data_bitrate(self):
+        canlib.canSetBusParams.reset_mock()
+        canlib.canSetBusParamsFd.reset_mock()
+        data_bitrate = 123456
+        can.Bus(channel=0, bustype='kvaser', fd=True, data_bitrate=data_bitrate)
+        canlib.canSetBusParams.assert_called_once_with(
+            0, constants.canFD_BITRATE_500K_80P, 0, 0, 0, 0, 0)
+        canlib.canSetBusParamsFd.assert_called_once_with(
+            0, data_bitrate, 0, 0, 0)
 
     @staticmethod
     def canGetNumberOfChannels(count):


### PR DESCRIPTION
I have been evaluating CAN FD using python-can and a Kvaser Leaf Pro HS v2, which supports CAN FD. I found that python-can wasn't setting the data bit rate correctly (as observed with a logic analyser), although it was able to send the longer CAN FD frames at the arbitration bit rate. This change appears to fix the incorrect data bit rate issue, and adds some testing around interpretation of the data bit rate in the can.Bus constructor for Kvaser devices.