### PR TITLE
Import name deepcopy for __deepcopy__ method

### DIFF
--- a/can/message.py
+++ b/can/message.py
@@ -11,7 +11,7 @@ This module contains the implementation of :class:`can.Message`.
 from __future__ import absolute_import, division
         
 import warnings
-
+from copy import deepcopy
 
 class Message(object):
     """


### PR DESCRIPTION
Calling copy.deepcopy on message class raise NameError: name 'deepcopy' is not defined