### PR TITLE
Message class changes

### DIFF
--- a/can/message.py
+++ b/can/message.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import, division
 
 import warnings
 from copy import deepcopy
+from math import isinf, isnan
 
 
 class Message(object):
@@ -136,7 +137,10 @@ class Message(object):
             self.dlc = dlc
 
         if check:
-            self._check()
+            try:
+                self._check()
+            except AssertionError as error:
+                raise ValueError(error.message)
 
     def __str__(self):
         field_strings = ["Timestamp: {0:>15.6f}".format(self.timestamp)]
@@ -266,6 +270,8 @@ class Message(object):
         """
 
         assert 0.0 <= self.timestamp, "the timestamp may not be negative"
+        assert not isinf(self.timestamp), "the timestamp may not be infinite"
+        assert not isnan(self.timestamp), "the timestamp may not be NaN"
 
         assert not (self.is_remote_frame and self.is_error_frame), \
             "a message cannot be a remote and an error frame at the sane time"

--- a/can/message.py
+++ b/can/message.py
@@ -119,7 +119,7 @@ class Message(object):
         self.bitrate_switch = bitrate_switch
         self.error_state_indicator = error_state_indicator
 
-        if data is None or is_remote_frame:
+        if data is None:
             self.data = bytearray()
         elif isinstance(data, bytearray):
             self.data = data
@@ -268,6 +268,9 @@ class Message(object):
 
         assert not (self.is_remote_frame and self.is_error_frame), \
             "a message cannot be a remote and an error frame at the sane time"
+
+        assert self.data is None or not self.is_remote_frame, \
+            "remote frames may not carry any data"
 
         assert 0 <= self.arbitration_id, "arbitration IDs may not be negative"
 

--- a/can/message.py
+++ b/can/message.py
@@ -9,9 +9,10 @@ This module contains the implementation of :class:`can.Message`.
 """
 
 from __future__ import absolute_import, division
-        
+
 import warnings
 from copy import deepcopy
+
 
 class Message(object):
     """
@@ -53,7 +54,7 @@ class Message(object):
         # can be removed in 4.0
         # this method is only called if the attribute was not found elsewhere, like in __slots__
         try:
-            warnings.warn("Custom attributes of messages are deprecated and will be removed in the next major version", DeprecationWarning)
+            warnings.warn("Custom attributes of messages are deprecated and will be removed in 4.0", DeprecationWarning)
             return self._dict[key]
         except KeyError:
             raise AttributeError("'message' object has no attribute '{}'".format(key))
@@ -63,26 +64,26 @@ class Message(object):
         try:
             super(Message, self).__setattr__(key, value)
         except AttributeError:
-            warnings.warn("Custom attributes of messages are deprecated and will be removed in the next major version", DeprecationWarning)
+            warnings.warn("Custom attributes of messages are deprecated and will be removed in 4.0", DeprecationWarning)
             self._dict[key] = value
 
     @property
     def id_type(self):
         # TODO remove in 4.0
-        warnings.warn("Message.id_type is deprecated, use is_extended_id", DeprecationWarning)
+        warnings.warn("Message.id_type is deprecated and will be removed in 4.0, use is_extended_id instead", DeprecationWarning)
         return self.is_extended_id
 
     @id_type.setter
     def id_type(self, value):
         # TODO remove in 4.0
-        warnings.warn("Message.id_type is deprecated, use is_extended_id", DeprecationWarning)
+        warnings.warn("Message.id_type is deprecated and will be removed in 4.0, use is_extended_id instead", DeprecationWarning)
         self.is_extended_id = value
 
     def __init__(self, timestamp=0.0, arbitration_id=0, is_extended_id=None,
                  is_remote_frame=False, is_error_frame=False, channel=None,
                  dlc=None, data=None,
                  is_fd=False, bitrate_switch=False, error_state_indicator=False,
-                 extended_id=True, # deprecated in 3.x, removed in 4.x
+                 extended_id=None, # deprecated in 3.x, TODO remove in 4.x
                  check=False):
         """
         To create a message object, simply provide any of the below attributes
@@ -100,10 +101,15 @@ class Message(object):
 
         self.timestamp = timestamp
         self.arbitration_id = arbitration_id
+
+        if extended_id is not None:
+            # TODO remove in 4.0
+            warnings.warn("The extended_id parameter is deprecated and will be removed in 4.0, use is_extended_id instead", DeprecationWarning)
+
         if is_extended_id is not None:
             self.is_extended_id = is_extended_id
         else:
-            self.is_extended_id = extended_id
+            self.is_extended_id = True if extended_id is None else extended_id
 
         self.is_remote_frame = is_remote_frame
         self.is_error_frame = is_error_frame

--- a/can/message.py
+++ b/can/message.py
@@ -119,7 +119,7 @@ class Message(object):
         self.bitrate_switch = bitrate_switch
         self.error_state_indicator = error_state_indicator
 
-        if data is None:
+        if data is None or is_remote_frame:
             self.data = bytearray()
         elif isinstance(data, bytearray):
             self.data = data

--- a/can/message.py
+++ b/can/message.py
@@ -299,7 +299,7 @@ class Message(object):
         # see https://github.com/hardbyte/python-can/pull/413 for a discussion
         # on why a delta of 1.0e-6 was chosen
         return (
-            # check for identity first
+            # check for identity first and finish fast
             self is other or
             # then check for equality by value
             (

--- a/can/message.py
+++ b/can/message.py
@@ -140,7 +140,7 @@ class Message(object):
             try:
                 self._check()
             except AssertionError as error:
-                raise ValueError(error.message)
+                raise ValueError(str(error))
 
     def __str__(self):
         field_strings = ["Timestamp: {0:>15.6f}".format(self.timestamp)]

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ tests_require = [
     'pytest-cov~=2.5',
     'codecov~=2.0',
     'future',
-    'six'
+    'six',
+    'hypothesis'
 ] + extras_require['serial']
 
 extras_require['test'] = tests_require

--- a/test/data/example_data.py
+++ b/test/data/example_data.py
@@ -30,7 +30,7 @@ TEST_TIME = 1483389946.197
 
 
 # List of messages of different types that can be used in tests
-TEST_MESSAGES_BASE = [
+TEST_MESSAGES_BASE = sort_messages([
     Message(
         # empty
     ),
@@ -98,11 +98,10 @@ TEST_MESSAGES_BASE = [
         arbitration_id=0x768, is_extended_id=False,
         timestamp=TEST_TIME + 3.165
     ),
-]
-TEST_MESSAGES_BASE = sort_messages(TEST_MESSAGES_BASE)
+])
 
 
-TEST_MESSAGES_REMOTE_FRAMES = [
+TEST_MESSAGES_REMOTE_FRAMES = sort_messages([
     Message(
         arbitration_id=0xDADADA, is_extended_id=True, is_remote_frame=True,
         timestamp=TEST_TIME + .165,
@@ -119,11 +118,10 @@ TEST_MESSAGES_REMOTE_FRAMES = [
         arbitration_id=0xABCDEF, is_extended_id=True, is_remote_frame=True,
         timestamp=TEST_TIME + 7858.67
     ),
-]
-TEST_MESSAGES_REMOTE_FRAMES = sort_messages(TEST_MESSAGES_REMOTE_FRAMES)
+])
 
 
-TEST_MESSAGES_ERROR_FRAMES = [
+TEST_MESSAGES_ERROR_FRAMES = sort_messages([
     Message(
         is_error_frame=True
     ),
@@ -135,8 +133,7 @@ TEST_MESSAGES_ERROR_FRAMES = [
         is_error_frame=True,
         timestamp=TEST_TIME + 17.157
     )
-]
-TEST_MESSAGES_ERROR_FRAMES = sort_messages(TEST_MESSAGES_ERROR_FRAMES)
+])
 
 
 TEST_ALL_MESSAGES = sort_messages(TEST_MESSAGES_BASE + TEST_MESSAGES_REMOTE_FRAMES + \

--- a/test/data/example_data.py
+++ b/test/data/example_data.py
@@ -106,12 +106,10 @@ TEST_MESSAGES_REMOTE_FRAMES = [
     Message(
         arbitration_id=0xDADADA, is_extended_id=True, is_remote_frame=True,
         timestamp=TEST_TIME + .165,
-        data=[1, 2, 3, 4, 5, 6, 7, 8]
     ),
     Message(
         arbitration_id=0x123, is_extended_id=False, is_remote_frame=True,
         timestamp=TEST_TIME + .365,
-        data=[254, 255]
     ),
     Message(
         arbitration_id=0x768, is_extended_id=False, is_remote_frame=True,

--- a/test/message_helper.py
+++ b/test/message_helper.py
@@ -1,13 +1,21 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+"""
+This module contains a helper for writing test cases that need to compare messages.
+"""
+
 from __future__ import absolute_import, print_function
 
 from copy import copy
 
 
 class ComparingMessagesTestCase(object):
-    """Must be extended by a class also extending a unittest.TestCase.
+    """
+    Must be extended by a class also extending a unittest.TestCase.
+
+    .. note:: This class does not extend unittest.TestCase so it does not get
+              run as a test itself.
     """
 
     def __init__(self, allowed_timestamp_delta=0.0, preserves_channel=True):

--- a/test/notifier_test.py
+++ b/test/notifier_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
+
 import unittest
 import time
 try:

--- a/test/test_message_class.py
+++ b/test/test_message_class.py
@@ -6,7 +6,7 @@ import sys
 from math import isinf, isnan
 from copy import copy, deepcopy
 
-from hypothesis import given, settings
+from hypothesis import given, settings, reproduce_failure
 import hypothesis.strategies as st
 
 from can import Message
@@ -15,30 +15,33 @@ from can import Message
 class TestMessageClass(unittest.TestCase):
     """
     This test tries many inputs to the message class constructor and then sanity checks
-    all methods and ensures that nothing crashes. It also checks whether Message.check()
+    all methods and ensures that nothing crashes. It also checks whether Message._check()
     allows all valid can frames.
     """
 
     @given(
         timestamp=st.floats(min_value=0.0),
-        arbitration_id=st.integers(min_value=0, max_value=0x20000000-1),
+        arbitration_id=st.integers(),
         is_extended_id=st.booleans(),
         is_remote_frame=st.booleans(),
         is_error_frame=st.booleans(),
-        channel=st.one_of(st.characters(), st.integers()),
+        channel=st.one_of(st.text(), st.integers()),
         dlc=st.integers(min_value=0, max_value=8),
-        data=st.binary(min_size=0, max_size=8),
+        data=st.one_of(st.binary(min_size=0, max_size=8), st.none()),
         is_fd=st.booleans(),
         bitrate_switch=st.booleans(),
         error_state_indicator=st.booleans()
     )
-    @settings(max_examples=1000, deadline=10)
+    @settings(max_examples=1000, deadline=50)
     def test_methods(self, **kwargs):
         is_valid = not (
-            len(kwargs['data']) != kwargs['dlc'] or
+            (not kwargs['is_remote_frame'] and (len(kwargs['data'] or []) != kwargs['dlc'])) or
             (kwargs['arbitration_id'] >= 0x800 and not kwargs['is_extended_id']) or
+            kwargs['arbitration_id'] >= 0x20000000 or
+            kwargs['arbitration_id'] < 0 or
             (kwargs['is_remote_frame'] and kwargs['is_error_frame']) or
-            ((kwargs['bitrate_switch'] or kwargs['error_state_indicator']) and not kwargs['is_fd']),
+            (kwargs['is_remote_frame'] and len(kwargs['data'] or []) > 0) or
+            ((kwargs['bitrate_switch'] or kwargs['error_state_indicator']) and not kwargs['is_fd']) or
             isnan(kwargs['timestamp']) or
             isinf(kwargs['timestamp'])
         )
@@ -47,7 +50,7 @@ class TestMessageClass(unittest.TestCase):
         self.assertGreater(len(str(message)), 0)
         self.assertGreater(len(message.__repr__()), 0)
         if is_valid:
-            self.assertEqual(len(message), kwargs['dlc'])
+            self.assertEqual(len(message), kwargs['dlc'])#, "dlc of message is {}".format(message.dlc))
         self.assertTrue(bool(message))
         self.assertGreater(len("{}".format(message)), 0)
         with self.assertRaises(Exception):
@@ -61,7 +64,9 @@ class TestMessageClass(unittest.TestCase):
             normal_copy = copy(message)
             deep_copy = deepcopy(message)
             for other in (normal_copy, deep_copy, message):
+                self.assertTrue(message.equals(other, timestamp_delta=None))
                 self.assertTrue(message.equals(other))
+                self.assertTrue(message.equals(other, timestamp_delta=0))
 
 
 if __name__ == '__main__':

--- a/test/test_message_class.py
+++ b/test/test_message_class.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import unittest
+import sys
+from math import isinf, isnan
+from copy import copy, deepcopy
+
+from hypothesis import given, settings
+import hypothesis.strategies as st
+
+from can import Message
+
+
+class TestMessageClass(unittest.TestCase):
+
+    @given(
+        timestamp=st.floats(min_value=0.0),
+        arbitration_id=st.integers(min_value=0, max_value=0x20000000-1),
+        is_extended_id=st.booleans(),
+        is_remote_frame=st.booleans(),
+        is_error_frame=st.booleans(),
+        channel=st.one_of(st.characters(), st.integers()),
+        dlc=st.integers(min_value=0, max_value=8),
+        data=st.binary(min_size=0, max_size=8),
+        is_fd=st.booleans(),
+        bitrate_switch=st.booleans(),
+        error_state_indicator=st.booleans()
+    )
+    @settings(max_examples=1000, deadline=10)
+    def test_methods(self, **kwargs):
+        is_valid = not (
+            len(kwargs['data']) != kwargs['dlc'] or
+            (kwargs['arbitration_id'] >= 0x800 and not kwargs['is_extended_id']) or
+            (kwargs['is_remote_frame'] and kwargs['is_error_frame']) or
+            ((kwargs['bitrate_switch'] or kwargs['error_state_indicator']) and not kwargs['is_fd']),
+            isnan(kwargs['timestamp']) or
+            isinf(kwargs['timestamp'])
+        )
+
+        message = Message(check=is_valid, **kwargs)
+        self.assertGreater(len(str(message)), 0)
+        self.assertGreater(len(message.__repr__()), 0)
+        if is_valid:
+            self.assertEqual(len(message), kwargs['dlc'])
+        self.assertTrue(bool(message))
+        self.assertGreater(len("{}".format(message)), 0)
+        with self.assertRaises(Exception):
+            _ = "{some_spec}".format(message)
+        if sys.version_info.major > 2:
+            self.assertEqual(bytes(message), kwargs['data'])
+
+        # check copies and equalities
+        if is_valid:
+            self.assertEqual(message, message)        
+            normal_copy = copy(message)
+            deep_copy = deepcopy(message)
+            for other in (normal_copy, deep_copy, message):
+                self.assertTrue(message.equals(other), str(other))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_message_class.py
+++ b/test/test_message_class.py
@@ -32,7 +32,7 @@ class TestMessageClass(unittest.TestCase):
         bitrate_switch=st.booleans(),
         error_state_indicator=st.booleans()
     )
-    @settings(max_examples=2000, deadline=50)
+    @settings(max_examples=2000)
     def test_methods(self, **kwargs):
         is_valid = not (
             (not kwargs['is_remote_frame'] and (len(kwargs['data'] or []) != kwargs['dlc'])) or
@@ -46,8 +46,12 @@ class TestMessageClass(unittest.TestCase):
             isinf(kwargs['timestamp'])
         )
 
-        # this should return normally and not throw an assertion error
+        # this should return normally and not throw an exception
         message = Message(check=is_valid, **kwargs)
+
+        if kwargs['data'] is None or kwargs['is_remote_frame']:
+            kwargs['data'] = bytearray()
+
         if not is_valid and not kwargs['is_remote_frame']:
             with self.assertRaises(ValueError):
                 Message(check=True, **kwargs)
@@ -61,8 +65,8 @@ class TestMessageClass(unittest.TestCase):
         _ = "{}".format(message)
         with self.assertRaises(Exception):
             _ = "{somespec}".format(message)
-        if sys.version_info.major > 2 and not kwargs['is_remote_frame']:
-            self.assertEqual(bytes(message), kwargs['data'])
+        if sys.version_info.major > 2:
+            self.assertEqual(bytearray(bytes(message)), kwargs['data'])
 
         # check copies and equalities
         if is_valid:

--- a/test/test_message_class.py
+++ b/test/test_message_class.py
@@ -13,6 +13,11 @@ from can import Message
 
 
 class TestMessageClass(unittest.TestCase):
+    """
+    This test tries many inputs to the message class constructor and then sanity checks
+    all methods and ensures that nothing crashes. It also checks whether Message.check()
+    allows all valid can frames.
+    """
 
     @given(
         timestamp=st.floats(min_value=0.0),
@@ -56,7 +61,7 @@ class TestMessageClass(unittest.TestCase):
             normal_copy = copy(message)
             deep_copy = deepcopy(message)
             for other in (normal_copy, deep_copy, message):
-                self.assertTrue(message.equals(other), str(other))
+                self.assertTrue(message.equals(other))
 
 
 if __name__ == '__main__':

--- a/test/test_message_class.py
+++ b/test/test_message_class.py
@@ -32,7 +32,7 @@ class TestMessageClass(unittest.TestCase):
         bitrate_switch=st.booleans(),
         error_state_indicator=st.booleans()
     )
-    @settings(max_examples=1000, deadline=50)
+    @settings(max_examples=2000, deadline=50)
     def test_methods(self, **kwargs):
         is_valid = not (
             (not kwargs['is_remote_frame'] and (len(kwargs['data'] or []) != kwargs['dlc'])) or
@@ -46,16 +46,22 @@ class TestMessageClass(unittest.TestCase):
             isinf(kwargs['timestamp'])
         )
 
+        # this should return normally and not throw an assertion error
         message = Message(check=is_valid, **kwargs)
+        if not is_valid and not kwargs['is_remote_frame']:
+            with self.assertRaises(ValueError):
+                Message(check=True, **kwargs)
+
         self.assertGreater(len(str(message)), 0)
         self.assertGreater(len(message.__repr__()), 0)
         if is_valid:
-            self.assertEqual(len(message), kwargs['dlc'])#, "dlc of message is {}".format(message.dlc))
+            self.assertEqual(len(message), kwargs['dlc'])
         self.assertTrue(bool(message))
         self.assertGreater(len("{}".format(message)), 0)
+        _ = "{}".format(message)
         with self.assertRaises(Exception):
-            _ = "{some_spec}".format(message)
-        if sys.version_info.major > 2:
+            _ = "{somespec}".format(message)
+        if sys.version_info.major > 2 and not kwargs['is_remote_frame']:
             self.assertEqual(bytes(message), kwargs['data'])
 
         # check copies and equalities


### PR DESCRIPTION
This adds a deprecation warning to `can.Message.extended_id` as discussed in #424.

Further, this PR

- specifies when specific deprecated members of `can.Message` will be removed
- changes `len(some_message)` to return the DLC instead on `len(self.data)`, so the method also works on remote frames
- makes `can.Message(..., check=True)` to actually raise a `ValueError` and not an `AssertionError` on invalid parameters, as was documented previously; and also make it run when assertions are disabled
- adds small improvements and fixes to `can.Message`, like Unicode errors being avoided
- adds a `hypothesis` test for `can.Message`
- adds minor cleanups to `test/*`