### PR TITLE
Fully initialize usb2can Bus interface object.

### DIFF
--- a/can/interfaces/usb2can/usb2canInterface.py
+++ b/can/interfaces/usb2can/usb2canInterface.py
@@ -119,6 +119,8 @@ class Usb2canBus(BusABC):
 
         self.handle = self.can.open(connector.encode('utf-8'), enable_flags)
 
+        super(Usb2canBus, self).__init__(channel=channel, *args, **kwargs)
+
     def send(self, msg, timeout=None):
         tx = message_convert_tx(msg)
         if timeout:

--- a/doc/interfaces/usb2can.rst
+++ b/doc/interfaces/usb2can.rst
@@ -26,6 +26,7 @@ WINDOWS INSTALL
     1. To install on Windows download the USB2CAN Windows driver.  It is compatible with XP, Vista, Win7, Win8/8.1. (Written against driver version v1.0.2.1)
     2. Install the appropriate version of `pywin32 <https://sourceforge.net/projects/pywin32/>`_ (win32com)
     3. Download the USB2CAN CANAL DLL from the USB2CAN website.  Place this in either the same directory you are running usb2can.py from or your DLL folder in your python install.
+       Note that only a 32-bit version is currently available, so this only works in a 32-bit Python environment.
         (Written against CANAL DLL version v1.0.6)
 
 Interface Layout


### PR DESCRIPTION
Add the missing parent class initialization to fix #465.

Tested under a 32-bit Python3 environment in Windows 7.