### PR TITLE
Improve USB2CAN interface

### DIFF
--- a/can/interfaces/iscan.py
+++ b/can/interfaces/iscan.py
@@ -147,6 +147,7 @@ class IscanError(CanError):
         10: "Thread already started",
         11: "Buffer overrun",
         12: "Device not initialized",
+        15: "Found the device, but it is being used by another process",
         16: "Bus error",
         17: "Bus off",
         18: "Error passive",

--- a/can/interfaces/usb2can/serial_selector.py
+++ b/can/interfaces/usb2can/serial_selector.py
@@ -33,10 +33,13 @@ def find_serial_devices(serial_matcher="ED"):
     """
     Finds a list of USB devices where the serial number (partially) matches the given string.
 
+    :param str serial_matcher (optional):
+        only device IDs starting with this string are returned
+
     :rtype: List[str]
     """
     objWMIService = win32com.client.Dispatch("WbemScripting.SWbemLocator")
     objSWbemServices = objWMIService.ConnectServer(".", "root\cimv2")
     items = objSWbemServices.ExecQuery("SELECT * FROM Win32_USBControllerDevice")
-    ids = (item.Dependent[-8:] for item in items)
+    ids = (item.Dependent.strip('"')[-8:] for item in items)
     return [e for e in ids if e.startswith(serial_matcher)]

--- a/can/interfaces/usb2can/serial_selector.py
+++ b/can/interfaces/usb2can/serial_selector.py
@@ -38,10 +38,5 @@ def find_serial_devices(serial_matcher="ED"):
     objWMIService = win32com.client.Dispatch("WbemScripting.SWbemLocator")
     objSWbemServices = objWMIService.ConnectServer(".", "root\cimv2")
     items = objSWbemServices.ExecQuery("SELECT * FROM Win32_USBControllerDevice")
-    ids = map(lambda item: item.Dependent, items)
-
-    return [
-        string[len(string) - 9:len(string) - 1]
-        for string in ids
-        if serial_matcher in string
-    ]
+    ids = (item.Dependent[-8:] for item in items)
+    return [el for el in ids if serial_matcher in el]

--- a/can/interfaces/usb2can/serial_selector.py
+++ b/can/interfaces/usb2can/serial_selector.py
@@ -3,6 +3,8 @@
 """
 """
 
+from __future__ import division, print_function, absolute_import
+
 import logging
 
 try:
@@ -27,14 +29,19 @@ def WMIDateStringToDate(dtmDate):
     return strDateTime
 
 
-def serial():
-    strComputer = '.'
-    objWMIService = win32com.client.Dispatch("WbemScripting.SWbemLocator")
-    objSWbemServices = objWMIService.ConnectServer(strComputer, "root\cimv2")
-    colItems = objSWbemServices.ExecQuery("SELECT * FROM Win32_USBControllerDevice")
+def find_serial_devices(serial_matcher="ED"):
+    """
+    Finds a list of serial devices.
 
-    for objItem in colItems:
-        string = objItem.Dependent
-        # find based on beginning of serial
-        if 'ED' in string:
-            return string[len(string) - 9:len(string) - 1]
+    :rtype: List[str]
+    """
+    objWMIService = win32com.client.Dispatch("WbemScripting.SWbemLocator")
+    objSWbemServices = objWMIService.ConnectServer(".", "root\cimv2")
+    items = objSWbemServices.ExecQuery("SELECT * FROM Win32_USBControllerDevice")
+    ids = map(lambda item: item.Dependent, items)
+
+    return [
+        string[len(string) - 9:len(string) - 1]
+        for string in ids
+        if serial_matcher in string
+    ]

--- a/can/interfaces/usb2can/serial_selector.py
+++ b/can/interfaces/usb2can/serial_selector.py
@@ -31,7 +31,7 @@ def WMIDateStringToDate(dtmDate):
 
 def find_serial_devices(serial_matcher="ED"):
     """
-    Finds a list of serial devices.
+    Finds a list of USB devices where the serial number (partially) matches the given string.
 
     :rtype: List[str]
     """
@@ -39,4 +39,4 @@ def find_serial_devices(serial_matcher="ED"):
     objSWbemServices = objWMIService.ConnectServer(".", "root\cimv2")
     items = objSWbemServices.ExecQuery("SELECT * FROM Win32_USBControllerDevice")
     ids = (item.Dependent[-8:] for item in items)
-    return [el for el in ids if serial_matcher in el]
+    return [e for e in ids if e.startswith(serial_matcher)]

--- a/can/interfaces/usb2can/usb2canInterface.py
+++ b/can/interfaces/usb2can/usb2canInterface.py
@@ -17,16 +17,6 @@ from .serial_selector import find_serial_devices
 log = logging.getLogger('can.usb2can')
 
 
-def format_connection_string(deviceID, baudrate='500'):
-    """Set up the connection string for the device.
-
-    >>> config = deviceID + '; ' + baudrate
-
-    :rtype: str
-    """
-    return "%s; %s" % (deviceID, baudrate)
-
-
 def message_convert_tx(msg):
     messagetx = CanalMsg()
 
@@ -120,7 +110,7 @@ class Usb2canBus(BusABC):
 
         self.channel_info = "USB2CAN device {}".format(device_id)
 
-        connector = format_connection_string(device_id, baudrate)
+        connector = "%s; %s" % (device_id, baudrate)
         # we need to convert this into bytes, since the underlying DLL cannot
         # handle non-ASCII configuration strings
         self.handle = self.can.open(connector.encode('utf-8', 'ignore'), flags)

--- a/can/interfaces/usb2can/usb2canInterface.py
+++ b/can/interfaces/usb2can/usb2canInterface.py
@@ -109,8 +109,6 @@ class Usb2canBus(BusABC):
         self.channel_info = "USB2CAN device {}".format(device_id)
 
         connector = "{}; {}".format(device_id, baudrate)
-        # we need to convert this into bytes, since the underlying DLL cannot
-        # handle non-ASCII configuration strings
         self.handle = self.can.open(connector, flags)
 
         super(Usb2canBus, self).__init__(channel=channel, dll=dll, flags=flags,

--- a/can/interfaces/usb2can/usb2canInterface.py
+++ b/can/interfaces/usb2can/usb2canInterface.py
@@ -1,24 +1,17 @@
 # coding: utf-8
 
 """
-This interface is for windows only, otherwise use socketCAN.
+This interface is for Windows only, otherwise use socketCAN.
 """
 
-from __future__ import absolute_import, division
+from __future__ import division, print_function, absolute_import
 
 import logging
+from ctypes import byref
 
-from can import BusABC, Message
+from can import BusABC, Message, CanError
 from .usb2canabstractionlayer import *
-
-bootTimeEpoch = 0
-try:
-    import uptime
-    import datetime
-
-    bootTimeEpoch = (uptime.boottime() - datetime.datetime.utcfromtimestamp(0)).total_seconds()
-except:
-    bootTimeEpoch = 0
+from .serial_selector import find_serial_devices
 
 # Set up logging
 log = logging.getLogger('can.usb2can')
@@ -27,7 +20,7 @@ log = logging.getLogger('can.usb2can')
 def format_connection_string(deviceID, baudrate='500'):
     """setup the string for the device
 
-    config = deviceID + '; ' + baudrate
+    >>> config = deviceID + '; ' + baudrate
     """
     return "%s; %s" % (deviceID, baudrate)
 
@@ -35,7 +28,7 @@ def format_connection_string(deviceID, baudrate='500'):
 def message_convert_tx(msg):
     messagetx = CanalMsg()
 
-    length = len(msg.data)
+    length = msg.dlc
     messagetx.sizeData = length
 
     messagetx.id = msg.arbitration_id
@@ -69,37 +62,40 @@ def message_convert_rx(messagerx):
                     is_error_frame=ERROR_FRAME,
                     arbitration_id=messagerx.id,
                     dlc=messagerx.sizeData,
-                    data=messagerx.data[:messagerx.sizeData]
-                    )
+                    data=messagerx.data[:messagerx.sizeData])
 
     return msgrx
 
 
 class Usb2canBus(BusABC):
     """Interface to a USB2CAN Bus.
+    
+    This interface only works on Windows.
+    Please use socketcan on Linux.
 
     :param str channel:
         The device's serial number. If not provided, Windows Management Instrumentation
-        will be used to identify the first such device. The *kwarg* `serial` may also be
-        used.
+        will be used to identify the first such device.
 
-    :param int bitrate:
+    :param int bitrate (optional):
         Bitrate of channel in bit/s. Values will be limited to a maximum of 1000 Kb/s.
         Default is 500 Kbs
 
-    :param int flags:
+    :param int flags (optional):
         Flags to directly pass to open function of the usb2can abstraction layer.
+
+    :param str dll (optional):
+        Path to the DLL with the CANAL API to load
+        Defaults to 'usb2can.dll'
+
     """
 
-    def __init__(self, channel, *args, **kwargs):
+    def __init__(self, channel, dll='usb2can.dll', flags=0x00000008,
+                 bitrate=500000, *args, **kwargs):
 
-        self.can = Usb2CanAbstractionLayer()
+        self.can = Usb2CanAbstractionLayer(dll)
 
-        # set flags on the connection
-        if 'flags' in kwargs:
-            enable_flags = kwargs["flags"]
-        else:
-            enable_flags = 0x00000008
+        self.channel_info = "USB2CAN device {}".format(channel)
 
         # code to get the serial number of the device
         if 'serial' in kwargs:
@@ -107,26 +103,31 @@ class Usb2canBus(BusABC):
         elif channel is not None:
             deviceID = channel
         else:
-            from can.interfaces.usb2can.serial_selector import serial
-            deviceID = serial()
+            devices = find_serial_devices()
+            if not devices:
+                raise CanError("could not find any serial device")
+            deviceID = devices[0]
 
-        # get baudrate in b/s from bitrate or use default
-        bitrate = kwargs.get("bitrate", 500000)
-        # convert to kb/s (eg:500000 bitrate must be 500), max rate is 1000 kb/s
-        baudrate = min(1000, int(bitrate/1000))
+        # convert to kb/s and cap: max rate is 1000 kb/s
+        baudrate = min(int(bitrate // 1000), 1000)
 
         connector = format_connection_string(deviceID, baudrate)
+        self.handle = self.can.open(connector.encode('utf-8'), flags)
 
-        self.handle = self.can.open(connector.encode('utf-8'), enable_flags)
-
-        super(Usb2canBus, self).__init__(channel=channel, *args, **kwargs)
+        super(Usb2canBus, self).__init__(channel=channel, dll=dll, flags=flags,
+                                         bitrate=bitrate, *args, **kwargs)
 
     def send(self, msg, timeout=None):
         tx = message_convert_tx(msg)
+
         if timeout:
-            self.can.blocking_send(self.handle, byref(tx), int(timeout * 1000))
+            status = self.can.blocking_send(self.handle, byref(tx), int(timeout * 1000))
         else:
-            self.can.send(self.handle, byref(tx))
+            status = self.can.send(self.handle, byref(tx))
+
+        if status != CANAL_STATUS_OK:
+            raise CanError("could not send message: status == {}".format(status))
+
 
     def _recv_internal(self, timeout):
 
@@ -139,10 +140,9 @@ class Usb2canBus(BusABC):
             time = 0 if timeout is None else int(timeout * 1000)
             status = self.can.blocking_receive(self.handle, byref(messagerx), time)
 
-        if status == 0:
+        if status == CANAL_STATUS_OK:
             rx = message_convert_rx(messagerx)
-        elif status == 19 or status == 32:
-            # CANAL_ERROR_RCV_EMPTY or CANAL_ERROR_TIMEOUT
+        elif status == CANAL_ERROR_RCV_EMPTY or status == CANAL_ERROR_TIMEOUT:
             rx = None
         else:
             log.error('Canal Error %s', status)
@@ -151,6 +151,27 @@ class Usb2canBus(BusABC):
         return rx, False
 
     def shutdown(self):
-        """Shut down the device safely"""
-        # TODO handle error
+        """
+        Shuts down connection to the device safely.
+
+        :raise cam.CanError: is closing the connection did not work
+        """
         status = self.can.close(self.handle)
+
+        if status != CANAL_STATUS_OK:
+            raise CanError("could not shut down bus: status == {}".format(status))
+
+    @staticmethod
+    def _detect_available_configs(serial_matcher=None):
+        """
+        Uses the Windows Management Instrumentation to identify serial devices.
+
+        :param str serial_matcher (optional):
+            search string for automatic detection of the device serial
+        """
+        if serial_matcher:
+            channels = find_serial_devices(serial_matcher)
+        else:
+            channels = find_serial_devices()
+
+        return [{'interface': 'usb2can', 'channel': c} for c in channels]

--- a/can/interfaces/usb2can/usb2canabstractionlayer.py
+++ b/can/interfaces/usb2can/usb2canabstractionlayer.py
@@ -90,7 +90,8 @@ class Usb2CanAbstractionLayer:
         :returns: Nothing
         """
         try:
-            # unicode is not supported
+            # we need to convert this into bytes, since the underlying DLL cannot
+            # handle non-ASCII configuration strings
             config_ascii = configuration.encode('ascii', 'ignore')
             result = self.__m_dllBasic.CanalOpen(config_ascii, flags)
         except Exception as ex:

--- a/can/interfaces/usb2can/usb2canabstractionlayer.py
+++ b/can/interfaces/usb2can/usb2canabstractionlayer.py
@@ -80,17 +80,24 @@ class Usb2CanAbstractionLayer:
             log.warning('DLL failed to load at path: {}'.format(dll))
 
     def open(self, configuration, flags):
+        """
+        Opens a CAN connection.
+
+        :param bytes configuration: the configuration as ASCII bytes
+                                    (or simply as a str on Python 2)
+
+        :raises can.CanError: if any error occured
+        :returns: Nothing
+        """
         try:
             # unicode is not supported
-            configuration = configuration.encode('ascii', 'ignore')
             result = self.__m_dllBasic.CanalOpen(configuration, flags)
             if result != CANAL_STATUS_OK:
-                raise can.CanError("CanalOpen failed, configure string: " + configuration)
-
-            return res
-        except:
-            log.warning('Failed to open')
-            raise
+                raise can.CanError('CanalOpen() failed, configuration: "{}", return code: {}'
+                                   .format(configuration, result))
+        except Exception as ex:
+            raise can.CanError('CanalOpen() failed, configuration: "{}", error: {}'
+                               .format(configuration, ex))
 
     def close(self, handle):
         try:

--- a/can/interfaces/usb2can/usb2canabstractionlayer.py
+++ b/can/interfaces/usb2can/usb2canabstractionlayer.py
@@ -81,10 +81,11 @@ class Usb2CanAbstractionLayer:
 
     def open(self, configuration, flags):
         """
-        Opens a CAN connection.
+        Opens a CAN connection using `CanalOpen()`.
 
         :param bytes configuration: the configuration as ASCII bytes
                                     (or simply as a str on Python 2)
+        :param int flags: the flags to be set
 
         :raises can.CanError: if any error occured
         :returns: Nothing

--- a/doc/interfaces/usb2can.rst
+++ b/doc/interfaces/usb2can.rst
@@ -27,7 +27,7 @@ WINDOWS INSTALL
     2. Install the appropriate version of `pywin32 <https://sourceforge.net/projects/pywin32/>`_ (win32com)
     3. Download the USB2CAN CANAL DLL from the USB2CAN website.  Place this in either the same directory you are running usb2can.py from or your DLL folder in your python install.
        Note that only a 32-bit version is currently available, so this only works in a 32-bit Python environment.
-        (Written against CANAL DLL version v1.0.6)
+       (Written against CANAL DLL version v1.0.6)
 
 Interface Layout
 ----------------


### PR DESCRIPTION
This basically replaces #245 and instead of creating a new interface, applies the changes to `usb2can`.

New features:
- slightly better error handling
- multiple serial devices can be found
- support for the `_detect_available_configs()` API