### PR TITLE
Remove support for Python 3.4 + update testing dependencies

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,16 +2,14 @@ environment:
   matrix:
 
     # For Python versions available on Appveyor, see
-    # http://www.appveyor.com/docs/installed-software#python
-    # Python 3.0-3.3 have reached EOL
+    # https://www.appveyor.com/docs/windows-images-software/#python
+    # Python pre-2.7 and 3.0-3.4 have reached EOL
 
     - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 
 python:
-  # CPython; versions 3.0-3.3 have reached EOL
+  # CPython; versions pre-2.7 and 3.0-3.4 have reached EOL
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7-dev" # TODO: change to "3.7" once it is supported by travis-ci

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Python developers; providing common abstractions to
 different hardware devices, and a suite of utilities for sending and receiving
 messages on a can bus.
 
-The library supports Python 2.7, Python 3.4+ as well as PyPy 2 & 3 and runs on Mac, Linux and Windows.
+The library supports Python 2.7, Python 3.5+ as well as PyPy 2 & 3 and runs on Mac, Linux and Windows.
 
 
 Features

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,10 @@ extras_require = {
 
 tests_require = [
     'mock~=2.0',
-    'nose~=1.3',
-    'pytest~=3.6',
-    'pytest-timeout~=1.2',
-    'pytest-cov~=2.5',
+    'nose2~=0.8',
+    'pytest~=4.3',
+    'pytest-timeout~=1.3',
+    'pytest-cov~=2.6',
     'codecov~=2.0',
     'future',
     'six',
@@ -53,7 +53,6 @@ setup(
         # a list of all available ones: https://pypi.org/classifiers/
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
@@ -98,7 +97,7 @@ setup(
 
     # Installation
     # see https://www.python.org/dev/peps/pep-0345/#version-specifiers
-    python_requires=">=2.7,!=3.0,!=3.1,!=3.2,!=3.3",
+    python_requires=">=2.7,!=3.0,!=3.1,!=3.2,!=3.3,!=3.4",
     install_requires=[
         'wrapt~=1.10',
         'typing;python_version<"3.5"',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ extras_require = {
 
 tests_require = [
     'mock~=2.0',
-    'nose2~=0.8',
     'pytest~=4.3',
     'pytest-timeout~=1.3',
     'pytest-cov~=2.6',
@@ -79,7 +78,7 @@ setup(
 
     # Code
     version=version,
-    packages=find_packages(exclude=["test", "test.*"]),
+    packages=find_packages(exclude=["test", "doc", "scripts", "examples"]),
     scripts=list(filter(isfile, (join("scripts/", f) for f in listdir("scripts/")))),
 
     # Author
@@ -91,21 +90,19 @@ setup(
 
     # Package data
     package_data={
-        "": ["CONTRIBUTORS.txt", "LICENSE.txt", "CHANGELOG.txt"],
-        "doc": ["*.*"]
+        "": ["README.rst", "CONTRIBUTORS.txt", "LICENSE.txt", "CHANGELOG.txt"],
+        "doc": ["*.*"],
+        "examples": ["*.py"]
     },
 
     # Installation
     # see https://www.python.org/dev/peps/pep-0345/#version-specifiers
-    python_requires=">=2.7,!=3.0,!=3.1,!=3.2,!=3.3,!=3.4",
+    python_requires=">=2.7",
     install_requires=[
         'wrapt~=1.10',
         'typing;python_version<"3.5"',
         'windows-curses;platform_system=="Windows"',
     ],
     extras_require=extras_require,
-
-    # Testing
-    test_suite="nose.collector",
-    tests_require=tests_require,
+    tests_require=tests_require
 )


### PR DESCRIPTION
This removes support for Python 3.4, since [it will reach EOL on 2019-03-16](https://devguide.python.org/#status-of-python-branches) (=next week).

It also updates the testing tools to their current versions.