### PR TITLE
Turn BusState into an enum

### DIFF
--- a/can/bus.py
+++ b/can/bus.py
@@ -11,12 +11,19 @@ import logging
 import threading
 from time import time
 from collections import namedtuple
+from aenum import Enum, auto
 
 from .broadcastmanager import ThreadBasedCyclicSendTask
 
 LOG = logging.getLogger(__name__)
 
-BusState = namedtuple('BusState', 'ACTIVE, PASSIVE, ERROR')
+
+class BusState(Enum):
+    """The state in which a :class:`can.BusABC` can be."""
+
+    ACTIVE = auto()
+    PASSIVE = auto()
+    ERROR = auto()
 
 
 class BusABC(object):
@@ -152,7 +159,7 @@ class BusABC(object):
             for transmit queue to be ready depending on driver implementation.
             If timeout is exceeded, an exception will be raised.
             Might not be supported by all interfaces.
-            None blocks indefinitly.
+            None blocks indefinitely.
 
         :raises can.CanError:
             if the message could not be sent
@@ -369,8 +376,7 @@ class BusABC(object):
         """
         Return the current state of the hardware
 
-        :return: ACTIVE, PASSIVE or ERROR
-        :rtype: NamedTuple
+        :type: can.BusState
         """
         return BusState.ACTIVE
 
@@ -379,7 +385,7 @@ class BusABC(object):
         """
         Set the new state of the hardware
 
-        :param new_state: BusState.ACTIVE, BusState.PASSIVE or BusState.ERROR
+        :type: can.BusState
         """
         raise NotImplementedError("Property is not implemented.")
 

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -97,7 +97,7 @@ class PcanBus(BusABC):
         self.m_objPCANBasic = PCANBasic()
         self.m_PcanHandle = globals()[channel]
 
-        if state is BusState.ACTIVE or BusState.PASSIVE:
+        if state is BusState.ACTIVE or state is BusState.PASSIVE:
             self._state = state
         else:
             raise ArgumentError("BusState must be Active or Passive")
@@ -280,7 +280,7 @@ class PcanBus(BusABC):
         if new_state is BusState.ACTIVE:
             self.m_objPCANBasic.SetValue(self.m_PcanHandle, PCAN_LISTEN_ONLY, PCAN_PARAMETER_OFF)
 
-        if new_state is BusState.PASSIVE:
+        elif new_state is BusState.PASSIVE:
             # When this mode is set, the CAN controller does not take part on active events (eg. transmit CAN messages)
             # but stays in a passive mode (CAN monitor), in which it can analyse the traffic on the CAN bus used by a
             # PCAN channel. See also the Philips Data Sheet "SJA1000 Stand-alone CAN controller".
@@ -289,6 +289,6 @@ class PcanBus(BusABC):
 
 class PcanError(CanError):
     """
-    TODO: add docs
+    A generic error on a PCAN bus.
     """
     pass

--- a/can/interfaces/systec/ucanbus.py
+++ b/can/interfaces/systec/ucanbus.py
@@ -104,7 +104,7 @@ class UcanBus(BusABC):
             raise ValueError("Invalid bitrate {}".format(bitrate))
 
         state = config.get('state', BusState.ACTIVE)
-        if state is BusState.ACTIVE or BusState.PASSIVE:
+        if state is BusState.ACTIVE or state is BusState.PASSIVE:
             self._state = state
         else:
             raise ValueError("BusState must be Active or Passive")
@@ -247,11 +247,11 @@ class UcanBus(BusABC):
 
     @state.setter
     def state(self, new_state):
-        if self._state != BusState.ERROR and (new_state == BusState.ACTIVE or new_state == BusState.PASSIVE):
+        if self._state is not BusState.ERROR and (new_state is BusState.ACTIVE or new_state is BusState.PASSIVE):
             # deinitialize CAN channel
             self._ucan.shutdown(self.channel, False)
             # set mode
-            if new_state == BusState.ACTIVE:
+            if new_state is BusState.ACTIVE:
                 self._params["mode"] &= ~Mode.MODE_LISTEN_ONLY
             else:
                 self._params["mode"] |= Mode.MODE_LISTEN_ONLY

--- a/can/interfaces/systec/ucanbus.py
+++ b/can/interfaces/systec/ucanbus.py
@@ -105,7 +105,7 @@ class UcanBus(BusABC):
 
         state = kwargs.get('state', BusState.ACTIVE)
         if state is BusState.ACTIVE or state is BusState.PASSIVE:
-            self.state = state
+            self._state = state
         else:
             raise ValueError("BusState must be Active or Passive")
 
@@ -248,7 +248,7 @@ class UcanBus(BusABC):
     @state.setter
     def state(self, new_state):
         if self._state is not BusState.ERROR and (new_state is BusState.ACTIVE or new_state is BusState.PASSIVE):
-            # deinitialize CAN channel
+            # close the CAN channel
             self._ucan.shutdown(self.channel, False)
             # set mode
             if new_state is BusState.ACTIVE:

--- a/can/logger.py
+++ b/can/logger.py
@@ -57,10 +57,10 @@ def main():
     parser.add_argument('-b', '--bitrate', type=int,
                         help='''Bitrate to use for the CAN bus.''')
 
-    group = parser.add_mutually_exclusive_group(required=False)
-    group.add_argument('--active', help="Start the bus as active, this is applied the default.",
+    state_group = parser.add_mutually_exclusive_group(required=False)
+    state_group.add_argument('--active', help="Start the bus as active, this is applied by default.",
                        action='store_true')
-    group.add_argument('--passive', help="Start the bus as passive.",
+    state_group.add_argument('--passive', help="Start the bus as passive.",
                        action='store_true')
 
     # print help message when no arguments wre given
@@ -98,8 +98,7 @@ def main():
 
     if results.active:
         bus.state = BusState.ACTIVE
-
-    if results.passive:
+    elif results.passive:
         bus.state = BusState.PASSIVE
 
     print('Connected to {}: {}'.format(bus.__class__.__name__, bus.channel_info))

--- a/examples/receive_all.py
+++ b/examples/receive_all.py
@@ -12,8 +12,7 @@ def receive_all():
     #bus = can.interface.Bus(bustype='ixxat', channel=0, bitrate=250000)
     #bus = can.interface.Bus(bustype='vector', app_name='CANalyzer', channel=0, bitrate=250000)
 
-    bus.state = BusState.ACTIVE
-    #bus.state = BusState.PASSIVE
+    bus.state = BusState.ACTIVE  # or BusState.PASSIVE
 
     try:
         while True:

--- a/setup.py
+++ b/setup.py
@@ -101,8 +101,8 @@ setup(
     python_requires=">=2.7,!=3.0,!=3.1,!=3.2,!=3.3",
     install_requires=[
         'wrapt~=1.10',
+        'aenum',
         'typing;python_version<"3.5"',
-        'aenum;python_version<"3.6"',
         'windows-curses;platform_system=="Windows"',
     ],
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ setup(
     install_requires=[
         'wrapt~=1.10',
         'typing;python_version<"3.5"',
+        'aenum;python_version<"3.6"',
         'windows-curses;platform_system=="Windows"',
     ],
     extras_require=extras_require,


### PR DESCRIPTION
Requires the `aenum` library on Python < 3.6. The `enum34` library was not used since it does not provide auto-assigned values.

Contains some small fixes/improvements to related code parts.

Closes #519.

@hardbyte you may add your other changes to this PR as well