### PR TITLE
Fix non-functional USB2CAN interface backend

### DIFF
--- a/can/interfaces/usb2can/usb2canabstractionlayer.py
+++ b/can/interfaces/usb2can/usb2canabstractionlayer.py
@@ -87,7 +87,7 @@ class Usb2CanAbstractionLayer:
         :param int flags: the flags to be set
 
         :raises can.CanError: if any error occurred
-        :returns: Nothing
+        :returns: Valid handle for CANAL API functions on success
         """
         try:
             # we need to convert this into bytes, since the underlying DLL cannot
@@ -105,6 +105,8 @@ class Usb2CanAbstractionLayer:
             if result <= 0:
                 raise can.CanError('CanalOpen() failed, configuration: "{}", return code: {}'
                                    .format(configuration, result))
+            else:
+                return result
 
     def close(self, handle):
         try:


### PR DESCRIPTION
During the refactorization and cleanup in #511, something slipped the review process.  I only got to testing on hardware with an actual CAN bus connected today and nothing worked.

Apparently the returned handle from `CanalOpen()` needs to be saved in a backend-local `.handle` member for all other API functions to use.  With all the confusion about CANAL API return values, the return statement for this got removed by accident.