### PR TITLE
implemented FD for Pcan

### DIFF
--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -13,6 +13,7 @@ import time
 import can
 from can import CanError, Message, BusABC
 from can.bus import BusState
+from can.util import len2dlc, dlc2len
 from .basic import *
 
 boottimeEpoch = 0
@@ -65,6 +66,9 @@ pcan_bitrate_objs = {1000000 : PCAN_BAUD_1M,
                         5000 : PCAN_BAUD_5K}
 
 
+pcan_fd_parameter_list = ['nom_brp', 'nom_tseg1', 'nom_tseg2', 'nom_sjw', 'data_brp', 'data_tseg1', 'data_tseg2', 'data_sjw']
+
+
 class PcanBus(BusABC):
 
     def __init__(self, channel='PCAN_USBBUS1', state=BusState.ACTIVE, bitrate=500000, *args, **kwargs):
@@ -85,9 +89,80 @@ class PcanBus(BusABC):
         :param int bitrate:
             Bitrate of channel in bit/s.
             Default is 500 kbit/s.
+            Ignored if using CanFD.
+
+        :param bool fd:
+            Should the Bus be initialized in CAN-FD mode.
+
+        :param int f_clock:
+            Clock rate in Hz.
+            Any of the following:
+            20000000, 24000000, 30000000, 40000000, 60000000, 80000000.
+            Ignored if not using CAN-FD.
+            Pass either f_clock or f_clock_mhz.
+
+        :param int f_clock_mhz:
+            Clock rate in MHz.
+            Any of the following:
+            20, 24, 30, 40, 60, 80.
+            Ignored if not using CAN-FD.
+            Pass either f_clock or f_clock_mhz.
+
+        :param int nom_brp:
+            Clock prescaler for nominal time quantum.
+            In the range (1..1024)
+            Ignored if not using CAN-FD.
+
+        :param int nom_tseg1:
+            Time segment 1 for nominal bit rate,
+            that is, the number of quanta from (but not including)
+            the Sync Segment to the sampling point.
+            In the range (1..256).
+            Ignored if not using CAN-FD.
+
+        :param int nom_tseg2:
+            Time segment 2 for nominal bit rate,
+            that is, the number of quanta from the sampling
+            point to the end of the bit.
+            In the range (1..128).
+            Ignored if not using CAN-FD.
+
+        :param int nom_sjw:
+            Synchronization Jump Width for nominal bit rate.
+            Decides the maximum number of time quanta
+            that the controller can resynchronize every bit.
+            In the range (1..128).
+            Ignored if not using CAN-FD.
+
+        :param int data_brp:
+            Clock prescaler for fast data time quantum.
+            In the range (1..1024)
+            Ignored if not using CAN-FD.
+
+        :param int data_tseg1:
+            Time segment 1 for fast data bit rate,
+            that is, the number of quanta from (but not including)
+            the Sync Segment to the sampling point.
+            In the range (1..32).
+            Ignored if not using CAN-FD.
+
+        :param int data_tseg2:
+            Time segment 2 for fast data bit rate,
+            that is, the number of quanta from the sampling
+            point to the end of the bit.
+            In the range (1..16).
+            Ignored if not using CAN-FD.
+
+        :param int data_sjw:
+            Synchronization Jump Width for fast data bit rate.
+            Decides the maximum number of time quanta
+            that the controller can resynchronize every bit.
+            In the range (1..16).
+            Ignored if not using CAN-FD.
 
         """
         self.channel_info = channel
+        self.fd = kwargs.get('fd', False)
         pcan_bitrate = pcan_bitrate_objs.get(bitrate, PCAN_BAUD_500K)
 
         hwtype = PCAN_TYPE_ISA
@@ -102,7 +177,22 @@ class PcanBus(BusABC):
         else:
             raise ArgumentError("BusState must be Active or Passive")
 
-        result = self.m_objPCANBasic.Initialize(self.m_PcanHandle, pcan_bitrate, hwtype, ioport, interrupt)
+
+        if self.fd:
+            f_clock_val = kwargs.get('f_clock', None)
+            if f_clock_val is None:
+                f_clock = "{}={}".format('f_clock_mhz', kwargs.get('f_clock_mhz', None))
+            else:
+                f_clock = "{}={}".format('f_clock', kwargs.get('f_clock', None))
+            
+            fd_parameters_values = [f_clock] + ["{}={}".format(key, kwargs.get(key, None)) for key in pcan_fd_parameter_list if kwargs.get(key, None) is not None]
+
+            self.fd_bitrate = ' ,'.join(fd_parameters_values).encode("ascii")
+
+
+            result = self.m_objPCANBasic.InitializeFD(self.m_PcanHandle, self.fd_bitrate)
+        else:
+            result = self.m_objPCANBasic.Initialize(self.m_PcanHandle, pcan_bitrate, hwtype, ioport, interrupt)
 
         if result != PCAN_ERROR_OK:
             raise PcanError(self._get_formatted_error(result))
@@ -187,7 +277,10 @@ class PcanBus(BusABC):
 
         result = None
         while result is None:
-            result = self.m_objPCANBasic.Read(self.m_PcanHandle)
+            if self.fd:
+                result = self.m_objPCANBasic.ReadFD(self.m_PcanHandle)
+            else:
+                result = self.m_objPCANBasic.Read(self.m_PcanHandle)
             if result[0] == PCAN_ERROR_QRCVEMPTY:
                 if HAS_EVENTS:
                     result = None
@@ -210,50 +303,94 @@ class PcanBus(BusABC):
 
         #log.debug("Received a message")
 
-        bIsRTR = (theMsg.MSGTYPE & PCAN_MESSAGE_RTR.value) == PCAN_MESSAGE_RTR.value
-        bIsExt = (theMsg.MSGTYPE & PCAN_MESSAGE_EXTENDED.value) == PCAN_MESSAGE_EXTENDED.value
+        is_extended_id = (theMsg.MSGTYPE & PCAN_MESSAGE_EXTENDED.value) == PCAN_MESSAGE_EXTENDED.value
+        is_remote_frame = (theMsg.MSGTYPE & PCAN_MESSAGE_RTR.value) == PCAN_MESSAGE_RTR.value
+        is_fd = (theMsg.MSGTYPE & PCAN_MESSAGE_FD.value) == PCAN_MESSAGE_FD.value
+        bitrate_switch = (theMsg.MSGTYPE & PCAN_MESSAGE_BRS.value) == PCAN_MESSAGE_BRS.value
+        error_state_indicator = (theMsg.MSGTYPE & PCAN_MESSAGE_ESI.value) == PCAN_MESSAGE_ESI.value
+        is_error_frame = (theMsg.MSGTYPE & PCAN_MESSAGE_ERRFRAME.value) == PCAN_MESSAGE_ERRFRAME.value
 
-        dlc = theMsg.LEN
-        timestamp = boottimeEpoch + ((itsTimeStamp.micros + 1000 * itsTimeStamp.millis + 0x100000000 * 1000 * itsTimeStamp.millis_overflow) / (1000.0 * 1000.0))
+
+        if self.fd:
+            dlc = dlc2len(theMsg.DLC)
+            timestamp = boottimeEpoch + (itsTimeStamp.value / (1000.0 * 1000.0))
+        else:
+            dlc = theMsg.LEN
+            timestamp = boottimeEpoch + ((itsTimeStamp.micros + 1000 * itsTimeStamp.millis + 0x100000000 * 1000 * itsTimeStamp.millis_overflow) / (1000.0 * 1000.0))
+
 
         rx_msg = Message(timestamp=timestamp,
                          arbitration_id=theMsg.ID,
-                         is_extended_id=bIsExt,
-                         is_remote_frame=bIsRTR,
+                         is_extended_id=is_extended_id,
+                         is_remote_frame=is_remote_frame,
+                         is_error_frame=is_error_frame,
                          dlc=dlc,
-                         data=theMsg.DATA[:dlc])
+                         data=theMsg.DATA[:dlc],
+                         is_fd=is_fd,
+                         bitrate_switch=bitrate_switch,
+                         error_state_indicator=error_state_indicator)
 
         return rx_msg, False
 
     def send(self, msg, timeout=None):
-        if msg.is_extended_id:
-            msgType = PCAN_MESSAGE_EXTENDED
-        else:
-            msgType = PCAN_MESSAGE_STANDARD
-
-        # create a TPCANMsg message structure
-        if platform.system() == 'Darwin':
-            CANMsg = TPCANMsgMac()
-        else:
-            CANMsg = TPCANMsg()
-
-        # configure the message. ID, Length of data, message type and data
-        CANMsg.ID = msg.arbitration_id
-        CANMsg.LEN = msg.dlc
-        CANMsg.MSGTYPE = msgType
-
-        # if a remote frame will be sent, data bytes are not important.
+        msgType = PCAN_MESSAGE_EXTENDED.value if msg.is_extended_id else PCAN_MESSAGE_STANDARD.value
         if msg.is_remote_frame:
-            CANMsg.MSGTYPE = msgType.value | PCAN_MESSAGE_RTR.value
-        else:
+            msgType |= PCAN_MESSAGE_RTR.value
+        if msg.is_error_frame:
+            msgType |= PCAN_MESSAGE_ERRFRAME.value
+        if msg.is_fd:
+            msgType |= PCAN_MESSAGE_FD.value
+        if msg.bitrate_switch:
+            msgType |= PCAN_MESSAGE_BRS.value
+        if msg.error_state_indicator:
+            msgType |= PCAN_MESSAGE_ESI.value
+
+        if self.fd:
+            # create a TPCANMsg message structure
+            if platform.system() == 'Darwin':
+                CANMsg = TPCANMsgFDMac()
+            else:
+                CANMsg = TPCANMsgFD()
+            
+            # configure the message. ID, Length of data, message type and data
+            CANMsg.ID = msg.arbitration_id
+            CANMsg.DLC = len2dlc(msg.dlc)
+            CANMsg.MSGTYPE = msgType
+
             # copy data
-            for i in range(CANMsg.LEN):
+            for i in range(msg.dlc):
                 CANMsg.DATA[i] = msg.data[i]
 
-        log.debug("Data: %s", msg.data)
-        log.debug("Type: %s", type(msg.data))
+            log.debug("Data: %s", msg.data)
+            log.debug("Type: %s", type(msg.data))
 
-        result = self.m_objPCANBasic.Write(self.m_PcanHandle, CANMsg)
+            result = self.m_objPCANBasic.WriteFD(self.m_PcanHandle, CANMsg)
+
+        else:
+            # create a TPCANMsg message structure
+            if platform.system() == 'Darwin':
+                CANMsg = TPCANMsgMac()
+            else:
+                CANMsg = TPCANMsg()
+
+            # configure the message. ID, Length of data, message type and data
+            CANMsg.ID = msg.arbitration_id
+            CANMsg.LEN = msg.dlc
+            CANMsg.MSGTYPE = msgType
+
+            # if a remote frame will be sent, data bytes are not important.
+            if msg.is_remote_frame:
+                CANMsg.MSGTYPE = msgType.value | PCAN_MESSAGE_RTR.value
+            else:
+                # copy data
+                for i in range(CANMsg.LEN):
+                    CANMsg.DATA[i] = msg.data[i]
+
+            log.debug("Data: %s", msg.data)
+            log.debug("Type: %s", type(msg.data))
+
+            result = self.m_objPCANBasic.Write(self.m_PcanHandle, CANMsg)
+
         if result != PCAN_ERROR_OK:
             raise PcanError("Failed to send: " + self._get_formatted_error(result))
 


### PR DESCRIPTION
I have implemented FD support for PCAN (solving #507).
This code has been tested manually on PCAN-FD hardware.

Points to be discussed:

1. Parameters for the bit rate are passed as keyword args.
Should this be switched to be a single string? (this is what the Pcan API accepts).
The benefit to switching would be a simpler interface.
2. Messages with a non standard message size are padded right now with zeros.
Should we allow for an option to configure the padding?
What should the default padding be?