### PR TITLE
Fixed simplecyclic test

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -26,3 +26,4 @@ Shaoyu Meng <shaoyu@life-foundry.com>
 Alexander Mueller<XelaRellum@web.de>
 Jan Goeteyn
 "ykzheng" <wishdo@gmail.com>
+Lear Corporation

--- a/test/simplecyclic_test.py
+++ b/test/simplecyclic_test.py
@@ -37,8 +37,18 @@ class SimpleCyclicSendTaskTest(unittest.TestCase, ComparingMessagesTestCase):
                         '100 +/- 20 messages should have been transmitted. But queue contained {}'.format(size))
         last_msg = bus2.recv()
         next_last_msg = bus2.recv()
+        # Check consecutive messages are spaced properly in time and have
+        # the same id/data
         self.assertMessageEqual(last_msg, next_last_msg)
 
+
+        # Check the message id/data sent is the same as message received
+        # Set timestamp and channel to match recv'd because we don't care
+        # and they are not initialized by the can.Message constructor.
+        msg.timestamp = last_msg.timestamp
+        msg.channel = last_msg.channel
+        self.assertMessageEqual(msg, last_msg)
+	
         bus1.shutdown()
         bus2.shutdown()
 

--- a/test/simplecyclic_test.py
+++ b/test/simplecyclic_test.py
@@ -20,7 +20,7 @@ class SimpleCyclicSendTaskTest(unittest.TestCase, ComparingMessagesTestCase):
 
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)
-        ComparingMessagesTestCase.__init__(self, allowed_timestamp_delta=None, preserves_channel=True)
+        ComparingMessagesTestCase.__init__(self, allowed_timestamp_delta=0.016, preserves_channel=True)
 
     @unittest.skipIf(IS_CI, "the timing sensitive behaviour cannot be reproduced reliably on a CI server")
     def test_cycle_time(self):
@@ -36,7 +36,8 @@ class SimpleCyclicSendTaskTest(unittest.TestCase, ComparingMessagesTestCase):
         self.assertTrue(80 <= size <= 120,
                         '100 +/- 20 messages should have been transmitted. But queue contained {}'.format(size))
         last_msg = bus2.recv()
-        self.assertMessageEqual(last_msg, msg)
+        next_last_msg = bus2.recv()
+        self.assertMessageEqual(last_msg, next_last_msg)
 
         bus1.shutdown()
         bus2.shutdown()


### PR DESCRIPTION
Originally, the testcase would fail because timestamps would not match.
This was due to a Can.Message being initialized had a timestamp
value of 0, while a recv'd message had a virtual timestamp. When compared
they never matched.

Modified testcase now allows for some variation (0.016 s) in the timestamp
for a 0.01 s periodic message and compares the last message with the next
last message.