### PR TITLE
Fixes BusState.PASSIVE from config file for PCAN

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -26,3 +26,4 @@ Shaoyu Meng <shaoyu@life-foundry.com>
 Alexander Mueller<XelaRellum@web.de>
 Jan Goeteyn
 "ykzheng" <wishdo@gmail.com>
+Lear Corporation

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -98,7 +98,7 @@ class PcanBus(BusABC):
         self.m_PcanHandle = globals()[channel]
 
         if state is BusState.ACTIVE or BusState.PASSIVE:
-            self._state = state
+            self.state = state
         else:
             raise ArgumentError("BusState must be Active or Passive")
 


### PR DESCRIPTION
Before, the config value "BusState" was not being actually sent to the PEAK hardware
due to the state setter not being invoked. Instead, the private _state variable
was being written to directly.

Now, the setter is being invoked and the state is being properly sent
to the PEAK hardware.