### PR TITLE
Direct setup.py test to use pytest. (Addresses Issue #544)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [bdist_wheel]
 universal = 1
 
+[aliases]
+test=pytest
+
 [metadata]
 license_file = LICENSE.txt
 

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setup(
         'typing;python_version<"3.5"',
         'windows-curses;platform_system=="Windows"',
     ],
+    setup_requires=["pytest-runner"],
     extras_require=extras_require,
     tests_require=tests_require
 )


### PR DESCRIPTION
See Issue #544. 

I was seeing issues in the develop branch when trying execute "setup.py test" to pass testcases before submitting a pull request.

This change directs "setup.py test" to use pytest instead of unittest.