### PR TITLE
Add availability to set can custom speed in slcan backend

### DIFF
--- a/can/interfaces/slcan.py
+++ b/can/interfaces/slcan.py
@@ -50,7 +50,7 @@ class slcanBus(BusABC):
     LINE_TERMINATOR = b'\r'
 
     def __init__(self, channel, ttyBaudrate=115200, bitrate=None,
-                 sleep_after_open=_SLEEP_AFTER_SERIAL_OPEN,
+                 btr=None, sleep_after_open=_SLEEP_AFTER_SERIAL_OPEN,
                  rtscts=False, **kwargs):
         """
         :param str channel:
@@ -60,6 +60,8 @@ class slcanBus(BusABC):
             baudrate of underlying serial or usb device
         :param int bitrate:
             Bitrate in bit/s
+        :param str btr:
+            BTR register value to set custom can speed (overrides bitrate)
         :param float poll_interval:
             Poll interval in seconds when reading messages
         :param float sleep_after_open:
@@ -81,12 +83,19 @@ class slcanBus(BusABC):
 
         time.sleep(sleep_after_open)
 
+        if bitrate is not None and btr is not None:
+            raise ValueError("Bitrate and btr mutually exclusive.")
+
         if bitrate is not None:
             self.close()
             if bitrate in self._BITRATES:
                 self.write(self._BITRATES[bitrate])
             else:
                 raise ValueError("Invalid bitrate, choose one of " + (', '.join(self._BITRATES)) + '.')
+
+        if btr is not None:
+            self.close()
+            self.write("s" + btr)
 
         self.open()
 

--- a/can/interfaces/slcan.py
+++ b/can/interfaces/slcan.py
@@ -53,6 +53,8 @@ class slcanBus(BusABC):
                  btr=None, sleep_after_open=_SLEEP_AFTER_SERIAL_OPEN,
                  rtscts=False, **kwargs):
         """
+        :raise ValueError: if both *bitrate* and *btr* are set
+
         :param str channel:
             port of underlying serial or usb device (e.g. /dev/ttyUSB0, COM8, ...)
             Must not be empty.
@@ -61,7 +63,7 @@ class slcanBus(BusABC):
         :param int bitrate:
             Bitrate in bit/s
         :param str btr:
-            BTR register value to set custom can speed (overrides bitrate)
+            BTR register value to set custom can speed
         :param float poll_interval:
             Poll interval in seconds when reading messages
         :param float sleep_after_open:


### PR DESCRIPTION
According the documentation, there are availability to set custom can speed instead use predefined speed values. I have add this future to slcan backend.