### PR TITLE
Fix broken execution of tests on some Windows environments

### DIFF
--- a/test/logformats_test.py
+++ b/test/logformats_test.py
@@ -43,9 +43,12 @@ class ReaderWriterTest(unittest.TestCase, ComparingMessagesTestCase):
     """Tests a pair of writer and reader by writing all data first and
     then reading all data and checking if they could be reconstructed
     correctly. Optionally writes some comments as well.
-    """
 
-    __test__ = False
+    .. note::
+        This class is prevented from being executed as a test
+        case itself by a *del* statement in at the end of the file.
+        (Source: `*Wojciech B.* on StackOverlfow <https://stackoverflow.com/a/22836015/3753684>`_)
+    """
 
     __metaclass__ = ABCMeta
 
@@ -318,8 +321,6 @@ class ReaderWriterTest(unittest.TestCase, ComparingMessagesTestCase):
 class TestAscFileFormat(ReaderWriterTest):
     """Tests can.ASCWriter and can.ASCReader"""
 
-    __test__ = True
-
     def _setup_instance(self):
         super(TestAscFileFormat, self)._setup_instance_helper(
             can.ASCWriter, can.ASCReader,
@@ -331,8 +332,6 @@ class TestAscFileFormat(ReaderWriterTest):
 
 class TestBlfFileFormat(ReaderWriterTest):
     """Tests can.BLFWriter and can.BLFReader"""
-
-    __test__ = True
 
     def _setup_instance(self):
         super(TestBlfFileFormat, self)._setup_instance_helper(
@@ -368,8 +367,6 @@ class TestBlfFileFormat(ReaderWriterTest):
 class TestCanutilsFileFormat(ReaderWriterTest):
     """Tests can.CanutilsLogWriter and can.CanutilsLogReader"""
 
-    __test__ = True
-
     def _setup_instance(self):
         super(TestCanutilsFileFormat, self)._setup_instance_helper(
             can.CanutilsLogWriter, can.CanutilsLogReader,
@@ -382,8 +379,6 @@ class TestCanutilsFileFormat(ReaderWriterTest):
 class TestCsvFileFormat(ReaderWriterTest):
     """Tests can.ASCWriter and can.ASCReader"""
 
-    __test__ = True
-
     def _setup_instance(self):
         super(TestCsvFileFormat, self)._setup_instance_helper(
             can.CSVWriter, can.CSVReader,
@@ -395,8 +390,6 @@ class TestCsvFileFormat(ReaderWriterTest):
 
 class TestSqliteDatabaseFormat(ReaderWriterTest):
     """Tests can.SqliteWriter and can.SqliteReader"""
-
-    __test__ = True
 
     def _setup_instance(self):
         super(TestSqliteDatabaseFormat, self)._setup_instance_helper(
@@ -451,6 +444,10 @@ class TestPrinter(unittest.TestCase):
             with can.Printer(temp_file) as printer:
                 for message in self.messages:
                     printer(message)
+
+
+# this excludes the base class from being executed as a test case itself
+del(ReaderWriterTest)
 
 
 if __name__ == '__main__':

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -15,18 +15,16 @@ from abc import ABCMeta, abstractmethod
 
 from .config import *
 
+
 class CanScriptTest(unittest.TestCase):
+
+    __metaclass__ = ABCMeta
 
     @classmethod
     def setUpClass(cls):
         # clean up the argument list so the call to the main() functions
         # in test_does_not_crash() succeeds
         sys.argv = sys.argv[:1]
-
-    #: this is overridden by the subclasses
-    __test__ = False
-
-    __metaclass__ = ABCMeta
 
     def test_do_commands_exist(self):
         """This test calls each scripts once and verifies that the help
@@ -54,8 +52,7 @@ class CanScriptTest(unittest.TestCase):
         # test main method
         with self.assertRaises(SystemExit) as cm:
             module.main()
-            self.assertEqual(cm.exception.code, errno.EINVAL,
-                    'Calling main failed:\n{}'.format(command, e.output))
+        self.assertEqual(cm.exception.code, errno.EINVAL)
 
     @abstractmethod
     def _commands(self):
@@ -73,8 +70,6 @@ class CanScriptTest(unittest.TestCase):
 
 class TestLoggerScript(CanScriptTest):
 
-    __test__ = True
-
     def _commands(self):
         commands = [
             "python -m can.logger --help",
@@ -91,8 +86,6 @@ class TestLoggerScript(CanScriptTest):
 
 class TestPlayerScript(CanScriptTest):
 
-    __test__ = True
-
     def _commands(self):
         commands = [
             "python -m can.player --help",
@@ -108,6 +101,10 @@ class TestPlayerScript(CanScriptTest):
 
 
 # TODO add #390
+
+
+# this excludes the base class from being executed as a test case itself
+del(CanScriptTest)
 
 
 if __name__ == '__main__':

--- a/test/test_socketcan_helpers.py
+++ b/test/test_socketcan_helpers.py
@@ -36,7 +36,7 @@ class TestSocketCanHelpers(unittest.TestCase):
         result = list(find_available_interfaces())
         self.assertGreaterEqual(len(result), 0)
         for entry in result:
-            self.assertRegex(entry, r"v?can\d+")
+            self.assertRegexpMatches(entry, r"v?can\d+")
         if IS_CI:
             self.assertGreaterEqual(len(result), 1)
             self.assertIn("vcan0", result)

--- a/test/test_socketcan_helpers.py
+++ b/test/test_socketcan_helpers.py
@@ -36,7 +36,7 @@ class TestSocketCanHelpers(unittest.TestCase):
         result = list(find_available_interfaces())
         self.assertGreaterEqual(len(result), 0)
         for entry in result:
-            self.assertRegexpMatches(entry, r"v?can\d+")
+            self.assertRegex(entry, r"v?can\d+")
         if IS_CI:
             self.assertGreaterEqual(len(result), 1)
             self.assertIn("vcan0", result)


### PR DESCRIPTION
This fixes the non-standard usage of `__test__ = False` to exclude the base class from execution and uses a simple `del` statement instead. The `__test__` attribute was a Nose idiom (though supposedly supported by pytest 🤷‍♂️). But as we don't use Nose any more, this seems to be the better way!

Fixes #544. (@bhass1 could you verify this, since you can reproduce the error nicely?)