### PR TITLE
Update Travis CI to use Xenial for most jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ script:
       # Run the tests
       python setup.py test
       # Upload the coverage to codecov.io
-      if [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]]; then codecov fi
+      if [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]]; then codecov; fi
     fi
 
 # Have travis deploy tagged commits to PyPi

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
       python -m sphinx -an doc build
     else
       # Run the tests
-      python setup.py test
+      python setup.py test && # (preserve the error code semantics)
       # Upload the coverage to codecov.io
       if [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]]; then codecov; fi
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,12 +65,12 @@ script:
       # Build the docs with Sphinx
       #   -a Write all files
       #   -n nitpicky
-      python -m sphinx -an doc build;
+      python -m sphinx -an doc build
     else
       # Run the tests
       python setup.py test
       # Upload the coverage to codecov.io
-      codecov;
+      if [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]]; then codecov fi
     fi
 
 # Have travis deploy tagged commits to PyPi

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,8 @@ matrix:
   allow_failures:
     # we allow all dev & nighly builds to fail, since these python versions might
     # still be very unstable
-    - python:
-        - 3.8-dev
-        - nightly
+    - python: 3.8-dev
+    - python: nightly
 
 install:
   - if [[ "$TEST_SOCKETCAN" ]]; then sudo bash test/open_vcan.sh ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  # CPython; versions pre-2.7 and 3.0-3.4 have reached EOL
+  # CPython; versions pre-2.7 and 3.0-3.5 have reached EOL
   - "2.7"
   - "3.6"
   - "3.7"
@@ -29,8 +29,16 @@ dist: xenial
 sudo: required
 
 matrix:
-  # see "os: ..." above
   include:
+    # building the docs
+    - python: "3.7"
+      env: BUILD_ONLY_DOCS=TRUE
+    # testing socketcan on Trusty
+    - os: linux
+      dist: trusty
+      python: "3.6"
+      env: TEST_SOCKETCAN=TRUE
+    # testing on macOS; see "os: ..." above
     - os: osx
       osx_image: xcode8.3
       python: "3.6-dev"
@@ -42,22 +50,28 @@ matrix:
       python: "nightly"
 
   allow_failures:
-    # allow all nighly builds to fail, since these python versions might be unstable
-    - python: "nightly"
     # we do not allow dev builds to fail, since these builds are considered stable enough
+    # we allow all nighly builds to fail, since these python versions might be unstable
+    - python: "nightly"
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo bash test/open_vcan.sh ; fi
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then travis_retry pip install -r doc/doc-requirements.txt; fi
+  - if [[ "$TEST_SOCKETCAN" ]]; then sudo bash test/open_vcan.sh ; fi
+  - if [[ "$BUILD_ONLY_DOCS" ]]; then travis_retry pip install -r doc/doc-requirements.txt; fi
   - travis_retry pip install .[test]
 
 script:
-  - pytest
-  - codecov
-  # Build Docs with Sphinx
-  # -a Write all files
-  # -n nitpicky
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then python -m sphinx -an doc build; fi
+  - |
+    if [[ "$BUILD_ONLY_DOCS" ]]; then
+      # Build the docs with Sphinx
+      #   -a Write all files
+      #   -n nitpicky
+      python -m sphinx -an doc build;
+    else
+      # Run the tests
+      python setup.py test
+      # Upload the coverage to codecov.io
+      codecov;
+    fi
 
 # Have travis deploy tagged commits to PyPi
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ python:
   - "2.7"
   - "3.6"
   - "3.7"
-  - "nightly"
+  - 3.8-dev
+  - nightly
   # PyPy:
-  - "pypy" # Python 2.7
-  - "pypy3.5" # Python 3.5
+  - pypy # Python 2.7
+  - pypy3.5 # Python 3.5
 
 os:
   - linux   # Linux is officially supported and we test the library under
@@ -33,7 +34,7 @@ matrix:
     # building the docs
     - python: "3.7"
       env: BUILD_ONLY_DOCS=TRUE
-    # testing socketcan on Trusty
+    # testing socketcan on Trusty & Python 3.6, since it is not available on Xenial
     - os: linux
       dist: trusty
       python: "3.6"
@@ -41,18 +42,20 @@ matrix:
     # testing on macOS; see "os: ..." above
     - os: osx
       osx_image: xcode8.3
-      python: "3.6-dev"
+      python: 3.6-dev
     - os: osx
       osx_image: xcode8.3
-      python: "3.7-dev"
+      python: 3.7-dev
     - os: osx
       osx_image: xcode8.3
-      python: "nightly"
+      python: nightly
 
   allow_failures:
-    # we do not allow dev builds to fail, since these builds are considered stable enough
-    # we allow all nighly builds to fail, since these python versions might be unstable
-    - python: "nightly"
+    # we allow all dev & nighly builds to fail, since these python versions might
+    # still be very unstable
+    - python:
+        - 3.8-dev
+        - nightly
 
 install:
   - if [[ "$TEST_SOCKETCAN" ]]; then sudo bash test/open_vcan.sh ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ os:
 
 # Linux setup
 dist: xenial
-sudo: required
 
 matrix:
   include:
@@ -38,6 +37,7 @@ matrix:
     - os: linux
       dist: trusty
       python: "3.6"
+      sudo: required
       env: TEST_SOCKETCAN=TRUE
     # testing on macOS; see "os: ..." above
     - os: osx
@@ -70,9 +70,13 @@ script:
       python -m sphinx -an doc build
     else
       # Run the tests
-      python setup.py test && # (preserve the error code semantics)
+      python setup.py test
+      # preserve the error code
+      RETURN_CODE=$?
       # Upload the coverage to codecov.io
-      if [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]]; then codecov; fi
+      codecov
+      # set error code
+      (exit $RETURN_CODE);
     fi
 
 # Have travis deploy tagged commits to PyPi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7-dev" # TODO: change to "3.7" once it is supported by travis-ci
+  - "3.7"
   - "nightly"
   # PyPy:
   - "pypy" # Python 2.7
@@ -27,7 +27,7 @@ os:
 # - windows # Windows is not supported at all by Travis CI as of Feb. 2018
 
 # Linux setup
-dist: trusty
+dist: xenial
 sudo: required
 
 matrix:

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     url="https://github.com/hardbyte/python-can",
     description="Controller Area Network interface module for Python",
     long_description=long_description,
-    classifiers=(
+    classifiers=[
         # a list of all available ones: https://pypi.org/classifiers/
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
@@ -74,7 +74,7 @@ setup(
         "Topic :: System :: Networking",
         "Topic :: System :: Hardware :: Hardware Drivers",
         "Topic :: Utilities"
-    ),
+    ],
 
     # Code
     version=version,

--- a/test/config.py
+++ b/test/config.py
@@ -12,21 +12,24 @@ import platform
 from os import environ as environment
 
 
+def env(name): # type: bool
+    return environment.get(name, '').lower() in ("yes", "true", "t", "1")
+
+
 # ############################## Continuos integration
 
 # see here for the environment variables that are set on the CI servers:
 #   - https://docs.travis-ci.com/user/environment-variables/
 #   - https://www.appveyor.com/docs/environment-variables/
 
-IS_TRAVIS = environment.get('TRAVIS', '').lower() == 'true'
-IS_APPVEYOR = environment.get('APPVEYOR', '').lower() == 'true'
+IS_TRAVIS = env('TRAVIS')
+IS_APPVEYOR = env('APPVEYOR')
 
-IS_CI = IS_TRAVIS or IS_APPVEYOR or \
-        environment.get('CI', '').lower() == 'true' or \
-        environment.get('CONTINUOUS_INTEGRATION', '').lower() == 'true'
+IS_CI = IS_TRAVIS or IS_APPVEYOR or env('CI') or env('CONTINUOUS_INTEGRATION')
 
 if IS_APPVEYOR and IS_TRAVIS:
     raise EnvironmentError("IS_APPVEYOR and IS_TRAVIS cannot be both True at the same time")
+
 
 # ############################## Platforms
 
@@ -42,11 +45,10 @@ if (IS_WINDOWS and IS_LINUX) or (IS_LINUX and IS_OSX) or (IS_WINDOWS and IS_OSX)
         "can be True at the same time " +
         '(platform.system() == "{}")'.format(platform.system())
     )
-elif not IS_WINDOWS and not IS_LINUX and not IS_OSX:
-    raise EnvironmentError("one of IS_WINDOWS, IS_LINUX, IS_OSX has to be True")
+
 
 # ############################## What tests to run
 
 TEST_CAN_FD = True
 
-TEST_INTERFACE_SOCKETCAN = IS_CI and IS_LINUX
+TEST_INTERFACE_SOCKETCAN = IS_LINUX and env('TEST_SOCKETCAN')

--- a/test/test_detect_available_configs.py
+++ b/test/test_detect_available_configs.py
@@ -15,7 +15,7 @@ if sys.version_info.major > 2:
 
 from can import detect_available_configs
 
-from .config import IS_LINUX, IS_CI
+from .config import IS_LINUX, IS_CI, TEST_INTERFACE_SOCKETCAN
 
 
 class TestDetectAvailableConfigs(unittest.TestCase):
@@ -45,13 +45,13 @@ class TestDetectAvailableConfigs(unittest.TestCase):
         for config in configs:
             self.assertEqual(config['interface'], 'socketcan')
 
-    @unittest.skipUnless(IS_LINUX and IS_CI, "socketcan is only available on Linux")
+    @unittest.skipUnless(TEST_INTERFACE_SOCKETCAN, "socketcan is not tested")
     def test_socketcan_on_ci_server(self):
         configs = detect_available_configs(interfaces='socketcan')
         self.assertGreaterEqual(len(configs), 1)
         self.assertIn('vcan0', [config['channel'] for config in configs])
 
-    # see TestSocketCanHelpers.test_find_available_interfaces()
+    # see TestSocketCanHelpers.test_find_available_interfaces() too
 
 
 if __name__ == '__main__':

--- a/test/test_socketcan_helpers.py
+++ b/test/test_socketcan_helpers.py
@@ -37,7 +37,7 @@ class TestSocketCanHelpers(unittest.TestCase):
         self.assertGreaterEqual(len(result), 0)
         for entry in result:
             self.assertRegexpMatches(entry, r"v?can\d+")
-        if IS_CI:
+        if TEST_INTERFACE_SOCKETCAN:
             self.assertGreaterEqual(len(result), 1)
             self.assertIn("vcan0", result)
 


### PR DESCRIPTION
- Moves Travis from Trusty to Xenial for most jobs (except OSX jobs & testing socketcan, see below)
- testing socketcan remains as a test on Python 3.6 only on Trusty
- Makes building the docs run in a separate job
- Fixes various smaller problems with skipping socketcan tests outside of Travis CI
- Fixes: `Warning: 'classifiers' should be a list, got type 'tuple'` on Python 3.8a ("nightly")