### PR TITLE
Various spelling corrections in the generated docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Features
 - many different loggers and readers supporting playback: ASC (CANalyzer format), BLF (Binary Logging Format by Vector), CSV, SQLite and Canutils log
 - efficient in-kernel or in-hardware filtering of messages on supported interfaces
 - bus configuration reading from file or environment variables
-- CLI tools for working with CAN busses (see the `docs <https://python-can.readthedocs.io/en/stable/scripts.html>`__)
+- CLI tools for working with CAN buses (see the `docs <https://python-can.readthedocs.io/en/stable/scripts.html>`__)
 - more
 
 

--- a/can/interfaces/virtual.py
+++ b/can/interfaces/virtual.py
@@ -121,7 +121,7 @@ class VirtualBus(BusABC):
         .. note::
 
             This method will run into problems if thousands of
-            autodetected busses are used at once.
+            autodetected buses are used at once.
 
         """
         with channels_lock:

--- a/can/io/csv.py
+++ b/can/io/csv.py
@@ -78,7 +78,7 @@ class CSVReader(BaseIOHandler):
     format as described there. Assumes that there is a header
     and thus skips the first line.
 
-    Any line seperator is accepted.
+    Any line separator is accepted.
     """
 
     def __init__(self, file):

--- a/can/io/printer.py
+++ b/can/io/printer.py
@@ -17,7 +17,7 @@ log = logging.getLogger('can.io.printer')
 class Printer(BaseIOHandler, Listener):
     """
     The Printer class is a subclass of :class:`~can.Listener` which simply prints
-    any messages it receives to the terminal (stdout). A message is tunred into a
+    any messages it receives to the terminal (stdout). A message is turned into a
     string using :meth:`~can.Message.__str__`.
 
     :attr bool write_to_file: `True` iff this instance prints to a file instead of

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -20,7 +20,7 @@ from .generic import BaseIOHandler
 
 log = logging.getLogger('can.io.sqlite')
 
-if sys.version_info.major < 3:	
+if sys.version_info.major < 3:
     # legacy fallback for Python 2
     memoryview = buffer
 
@@ -58,7 +58,7 @@ class SqliteReader(BaseIOHandler):
         for frame_data in self._cursor.execute("SELECT * FROM {}".format(self.table_name)):
             yield SqliteReader._assemble_message(frame_data)
 
-    @staticmethod 
+    @staticmethod
     def _assemble_message(frame_data):
         timestamp, can_id, is_extended, is_remote, is_error, dlc, data = frame_data
         return Message(
@@ -103,7 +103,7 @@ class SqliteWriter(BaseIOHandler, BufferedReader):
     :meth:`~can.SqliteWriter.stop()` may take a while.
 
     :attr str table_name: the name of the database table used for storing the messages
-    :attr int num_frames: the number of frames actally writtem to the database, this
+    :attr int num_frames: the number of frames actually written to the database, this
                           excludes messages that are still buffered
     :attr float last_write: the last time a message war actually written to the database,
                             as given by ``time.time()``

--- a/can/notifier.py
+++ b/can/notifier.py
@@ -20,7 +20,7 @@ class Notifier(object):
     def __init__(self, bus, listeners, timeout=1.0, loop=None):
         """Manages the distribution of :class:`can.Message` instances to listeners.
 
-        Supports multiple busses and listeners.
+        Supports multiple buses and listeners.
 
         .. Note::
 
@@ -127,7 +127,7 @@ class Notifier(object):
                 listener.on_error(exc)
 
     def add_listener(self, listener):
-        """Add new Listener to the notification list. 
+        """Add new Listener to the notification list.
         If it is already present, it will be called two times
         each time a message arrives.
 

--- a/doc/interfaces/ixxat.rst
+++ b/doc/interfaces/ixxat.rst
@@ -46,7 +46,7 @@ module, while the following parameters are optional and are interpreted by IXXAT
 Internals
 ---------
 
-The IXXAT :class:`~can.BusABC` object is a farly straightforward interface
+The IXXAT :class:`~can.BusABC` object is a fairly straightforward interface
 to the IXXAT VCI library. It can open a specific device ID or use the
 first one found.
 

--- a/doc/interfaces/nican.rst
+++ b/doc/interfaces/nican.rst
@@ -12,7 +12,7 @@ This interface adds support for CAN controllers by `National Instruments`_.
 
 .. warning::
 
-    CAN filtering has not been tested throughly and may not work as expected.
+    CAN filtering has not been tested thoroughly and may not work as expected.
 
 
 Bus

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 
 """
-This module tests two virtual busses attached to each other.
+This module tests two virtual buses attached to each other.
 """
 
 from __future__ import absolute_import, print_function
@@ -10,7 +10,7 @@ from __future__ import absolute_import, print_function
 import sys
 import unittest
 from time import sleep
-from multiprocessing.dummy import Pool as ThreadPool 
+from multiprocessing.dummy import Pool as ThreadPool
 
 import pytest
 import random
@@ -90,7 +90,7 @@ class Back2BackTestCase(unittest.TestCase):
         recv_msg2 = self.bus1.recv(self.TIMEOUT)
         delta_time = recv_msg2.timestamp - recv_msg1.timestamp
         self.assertTrue(1.75 <= delta_time <= 2.25,
-                        'Time difference should have been 2s +/- 250ms.' 
+                        'Time difference should have been 2s +/- 250ms.'
                         'But measured {}'.format(delta_time))
 
     def test_standard_message(self):


### PR DESCRIPTION
When reading through the documentation, I noticed these minor spelling mistakes that I've taken the liberty to fix in this PR.

* 'farly' -> 'fairly'
* 'throughly' -> 'thoroughly'
* 'actally' -> 'actually'
* 'tunred' -> 'turned'
* 'seperator' -> 'separator'
* 'busses' -> 'buses'