### PR TITLE
Add support for multiple Cyclic Messages in Task

### DIFF
--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -191,7 +191,7 @@ def build_bcm_tx_delete_header(can_id, flags):
 
 
 def build_bcm_transmit_header(
-    can_id, count, initial_period, subsequent_period, msg_flags
+    can_id, count, initial_period, subsequent_period, msg_flags, nframes=1
 ):
     opcode = CAN_BCM_TX_SETUP
 
@@ -209,7 +209,6 @@ def build_bcm_transmit_header(
 
     ival1_seconds, ival1_usec = split_time(initial_period)
     ival2_seconds, ival2_usec = split_time(subsequent_period)
-    nframes = 1
 
     return build_bcm_header(
         opcode,
@@ -224,8 +223,8 @@ def build_bcm_transmit_header(
     )
 
 
-def build_bcm_update_header(can_id, msg_flags):
-    return build_bcm_header(CAN_BCM_TX_SETUP, msg_flags, 0, 0, 0, 0, 0, can_id, 1)
+def build_bcm_update_header(can_id, msg_flags, nframes=1):
+    return build_bcm_header(CAN_BCM_TX_SETUP, msg_flags, 0, 0, 0, 0, 0, can_id, nframes)
 
 
 def dissect_can_frame(frame):
@@ -288,7 +287,7 @@ class CyclicSendTask(
     LimitedDurationCyclicSendTaskABC, ModifiableCyclicTaskABC, RestartableCyclicTaskABC
 ):
     """
-    A socketcan cyclic send task supports:
+    A SocketCAN cyclic send task supports:
 
         - setting of a task duration
         - modifying the data
@@ -296,24 +295,32 @@ class CyclicSendTask(
 
     """
 
-    def __init__(self, bcm_socket, message, period, duration=None):
+    def __init__(self, bcm_socket, messages, period, duration=None):
         """
-        :param bcm_socket: An open bcm socket on the desired CAN channel.
-        :param can.Message message: The message to be sent periodically.
-        :param float period: The rate in seconds at which to send the message.
-        :param float duration: Approximate duration in seconds to send the message.
+        :param bcm_socket: An open BCM socket on the desired CAN channel.
+        :param Union[Sequence[can.Message], can.Message] messages:
+            The messages to be sent periodically.
+        :param float period:
+            The rate in seconds at which to send the messages.
+        :param float duration:
+            Approximate duration in seconds to send the messages for.
         """
-        super().__init__(message, period, duration)
+        # The following are assigned by LimitedDurationCyclicSendTaskABC:
+        #   - self.messages
+        #   - self.period
+        #   - self.duration
+        super().__init__(messages, period, duration)
+
         self.bcm_socket = bcm_socket
-        self.duration = duration
-        self._tx_setup(message)
-        self.message = message
+        self._tx_setup(self.messages)
 
-    def _tx_setup(self, message):
-
+    def _tx_setup(self, messages):
         # Create a low level packed frame to pass to the kernel
-        self.can_id_with_flags = _add_flags_to_can_id(message)
-        self.flags = CAN_FD_FRAME if message.is_fd else 0
+        header = bytearray()
+        body = bytearray()
+        self.can_id_with_flags = _add_flags_to_can_id(messages[0])
+        self.flags = CAN_FD_FRAME if messages[0].is_fd else 0
+
         if self.duration:
             count = int(self.duration / self.period)
             ival1 = self.period
@@ -322,12 +329,19 @@ class CyclicSendTask(
             count = 0
             ival1 = 0
             ival2 = self.period
+
         header = build_bcm_transmit_header(
-            self.can_id_with_flags, count, ival1, ival2, self.flags
+            self.can_id_with_flags,
+            count,
+            ival1,
+            ival2,
+            self.flags,
+            nframes=len(messages),
         )
-        frame = build_can_frame(message)
+        for message in messages:
+            body += build_can_frame(message)
         log.debug("Sending BCM command")
-        send_bcm(self.bcm_socket, header + frame)
+        send_bcm(self.bcm_socket, header + body)
 
     def stop(self):
         """Send a TX_DELETE message to cancel this task.
@@ -341,22 +355,35 @@ class CyclicSendTask(
         stopframe = build_bcm_tx_delete_header(self.can_id_with_flags, self.flags)
         send_bcm(self.bcm_socket, stopframe)
 
-    def modify_data(self, message):
-        """Update the contents of this periodically sent message.
+    def modify_data(self, messages):
+        """Update the contents of the periodically sent messages.
 
-        Note the Message must have the same :attr:`~can.Message.arbitration_id`
-        like the first message.
+        Note: The messages must all have the same
+        :attr:`~can.Message.arbitration_id` like the first message.
+
+        Note: The number of new cyclic messages to be sent must be equal to the
+        original number of messages originally specified for this task.
+
+        :param Union[Sequence[can.Message], can.Message] messages:
+            The messages with the new :attr:`can.Message.data`.
         """
-        assert (
-            message.arbitration_id == self.can_id
-        ), "You cannot modify the can identifier"
-        self.message = message
-        header = build_bcm_update_header(self.can_id_with_flags, self.flags)
-        frame = build_can_frame(message)
-        send_bcm(self.bcm_socket, header + frame)
+        messages = self._check_and_convert_messages(messages)
+        self._check_modified_messages(messages)
+
+        self.messages = messages
+
+        header = bytearray()
+        body = bytearray()
+        header = build_bcm_update_header(
+            can_id=self.can_id_with_flags, msg_flags=self.flags, nframes=len(messages)
+        )
+        for message in messages:
+            body += build_can_frame(message)
+        log.debug("Sending BCM command")
+        send_bcm(self.bcm_socket, header + body)
 
     def start(self):
-        self._tx_setup(self.message)
+        self._tx_setup(self.messages)
 
 
 class MultiRateCyclicSendTask(CyclicSendTask):
@@ -365,17 +392,25 @@ class MultiRateCyclicSendTask(CyclicSendTask):
 
     """
 
-    def __init__(self, channel, message, count, initial_period, subsequent_period):
-        super().__init__(channel, message, subsequent_period)
+    def __init__(self, channel, messages, count, initial_period, subsequent_period):
+        super().__init__(channel, messages, subsequent_period)
 
         # Create a low level packed frame to pass to the kernel
-        frame = build_can_frame(message)
         header = build_bcm_transmit_header(
-            self.can_id_with_flags, count, initial_period, subsequent_period, self.flags
+            self.can_id_with_flags,
+            count,
+            initial_period,
+            subsequent_period,
+            self.flags,
+            nframes=len(messages),
         )
 
+        body = bytearray()
+        for message in messages:
+            body += build_can_frame(message)
+
         log.info("Sending BCM TX_SETUP command")
-        send_bcm(self.bcm_socket, header + frame)
+        send_bcm(self.bcm_socket, header + body)
 
 
 def create_socket():
@@ -599,17 +634,17 @@ class SocketcanBus(BusABC):
             raise can.CanError("Failed to transmit: %s" % exc)
         return sent
 
-    def _send_periodic_internal(self, msg, period, duration=None):
-        """Start sending a message at a given period on this bus.
+    def _send_periodic_internal(self, msgs, period, duration=None):
+        """Start sending messages at a given period on this bus.
 
-        The kernel's broadcast manager will be used.
+        The kernel's Broadcast Manager SocketCAN API will be used.
 
-        :param can.Message msg:
-            Message to transmit
+        :param Union[Sequence[can.Message], can.Message] messages:
+            The messages to be sent periodically
         :param float period:
-            Period in seconds between each message
+            The rate in seconds at which to send the messages.
         :param float duration:
-            The duration to keep sending this message at given rate. If
+            Approximate duration in seconds to continue sending messages. If
             no duration is provided, the task will continue indefinitely.
 
         :return:
@@ -619,14 +654,19 @@ class SocketcanBus(BusABC):
 
         .. note::
 
-            Note the duration before the message stops being sent may not
+            Note the duration before the messages stop being sent may not
             be exactly the same as the duration specified by the user. In
             general the message will be sent at the given rate until at
             least *duration* seconds.
 
         """
-        bcm_socket = self._get_bcm_socket(msg.channel or self.channel)
-        task = CyclicSendTask(bcm_socket, msg, period, duration)
+        msgs = LimitedDurationCyclicSendTaskABC._check_and_convert_messages(msgs)
+
+        bcm_socket = self._get_bcm_socket(msgs[0].channel or self.channel)
+        # TODO: The SocketCAN BCM interface treats all cyclic tasks sharing an
+        # Arbitration ID as the same Cyclic group. We should probably warn the
+        # user instead of overwriting the old group?
+        task = CyclicSendTask(bcm_socket, msgs, period, duration)
         return task
 
     def _get_bcm_socket(self, channel):

--- a/examples/cyclic_multiple.py
+++ b/examples/cyclic_multiple.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+"""
+This example exercises the periodic task's multiple message sending capabilities
+
+Expects a vcan0 interface:
+
+    python3 -m examples.cyclic_multiple
+
+"""
+
+from __future__ import print_function
+
+import logging
+import time
+
+import can
+
+logging.basicConfig(level=logging.INFO)
+
+
+def cyclic_multiple_send(bus):
+    """
+    Sends periodic messages every 1 s with no explicit timeout
+    Sleeps for 10 seconds then stops the task.
+    """
+    print("Starting to send a message every 1 s for 10 s")
+    messages = []
+
+    messages.append(
+        can.Message(
+            arbitration_id=0x401,
+            data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+            is_extended_id=False,
+        )
+    )
+    messages.append(
+        can.Message(
+            arbitration_id=0x401,
+            data=[0x22, 0x22, 0x22, 0x22, 0x22, 0x22],
+            is_extended_id=False,
+        )
+    )
+    messages.append(
+        can.Message(
+            arbitration_id=0x401,
+            data=[0x33, 0x33, 0x33, 0x33, 0x33, 0x33],
+            is_extended_id=False,
+        )
+    )
+    messages.append(
+        can.Message(
+            arbitration_id=0x401,
+            data=[0x44, 0x44, 0x44, 0x44, 0x44, 0x44],
+            is_extended_id=False,
+        )
+    )
+    messages.append(
+        can.Message(
+            arbitration_id=0x401,
+            data=[0x55, 0x55, 0x55, 0x55, 0x55, 0x55],
+            is_extended_id=False,
+        )
+    )
+    task = bus.send_periodic(messages, 1)
+    assert isinstance(task, can.CyclicSendTaskABC)
+    time.sleep(10)
+    task.stop()
+    print("stopped cyclic send")
+
+
+def cyclic_multiple_send_modify(bus):
+    """
+    Sends initial set of 3 Messages containing Odd data sent every 1 s with
+    no explicit timeout. Sleeps for 8 s.
+
+    Then the set is updated to 3 Messages containing Even data.
+    Sleeps for 10 s.
+    """
+    messages_odd = []
+    messages_odd.append(
+        can.Message(
+            arbitration_id=0x401,
+            data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+            is_extended_id=False,
+        )
+    )
+    messages_odd.append(
+        can.Message(
+            arbitration_id=0x401,
+            data=[0x33, 0x33, 0x33, 0x33, 0x33, 0x33],
+            is_extended_id=False,
+        )
+    )
+    messages_odd.append(
+        can.Message(
+            arbitration_id=0x401,
+            data=[0x55, 0x55, 0x55, 0x55, 0x55, 0x55],
+            is_extended_id=False,
+        )
+    )
+    messages_even = []
+    messages_even.append(
+        can.Message(
+            arbitration_id=0x401,
+            data=[0x22, 0x22, 0x22, 0x22, 0x22, 0x22],
+            is_extended_id=False,
+        )
+    )
+    messages_even.append(
+        can.Message(
+            arbitration_id=0x401,
+            data=[0x44, 0x44, 0x44, 0x44, 0x44, 0x44],
+            is_extended_id=False,
+        )
+    )
+    messages_even.append(
+        can.Message(
+            arbitration_id=0x401,
+            data=[0x66, 0x66, 0x66, 0x66, 0x66, 0x66],
+            is_extended_id=False,
+        )
+    )
+    print("Starting to send a message with odd every 1 s for 8 s with odd data")
+    task = bus.send_periodic(messages_odd, 1)
+    assert isinstance(task, can.CyclicSendTaskABC)
+    time.sleep(8)
+    print("Starting to send a message with even data every 1 s for 10 s with even data")
+    task.modify_data(messages_even)
+    time.sleep(10)
+    print("stopped cyclic modify send")
+
+
+if __name__ == "__main__":
+    for interface, channel in [("socketcan", "vcan0")]:
+        print("Carrying out cyclic multiple tests with {} interface".format(interface))
+
+        bus = can.Bus(interface=interface, channel=channel, bitrate=500000)
+
+        cyclic_multiple_send(bus)
+
+        cyclic_multiple_send_modify(bus)
+
+        bus.shutdown()
+
+    time.sleep(2)

--- a/test/test_socketcan_cyclic_multiple.py
+++ b/test/test_socketcan_cyclic_multiple.py
@@ -1,0 +1,507 @@
+"""
+This module tests multiple message cyclic send tasks.
+"""
+import unittest
+
+import time
+import can
+
+from .config import TEST_INTERFACE_SOCKETCAN
+
+
+@unittest.skipUnless(TEST_INTERFACE_SOCKETCAN, "skip testing of socketcan")
+class SocketCanCyclicMultiple(unittest.TestCase):
+    BITRATE = 500000
+    TIMEOUT = 0.1
+
+    INTERFACE_1 = "socketcan"
+    CHANNEL_1 = "vcan0"
+    INTERFACE_2 = "socketcan"
+    CHANNEL_2 = "vcan0"
+
+    PERIOD = 1.0
+
+    DELTA = 0.01
+
+    def _find_start_index(self, tx_messages, message):
+        """
+        :param tx_messages:
+            The list of messages that were passed to the periodic backend
+        :param message:
+            The message whose data we wish to match and align to
+
+        :returns: start index in the tx_messages
+        """
+        start_index = -1
+        for index, tx_message in enumerate(tx_messages):
+            if tx_message.data == message.data:
+                start_index = index
+                break
+        return start_index
+
+    def setUp(self):
+        self._send_bus = can.Bus(
+            interface=self.INTERFACE_1, channel=self.CHANNEL_1, bitrate=self.BITRATE
+        )
+        self._recv_bus = can.Bus(
+            interface=self.INTERFACE_2, channel=self.CHANNEL_2, bitrate=self.BITRATE
+        )
+
+    def tearDown(self):
+        self._send_bus.shutdown()
+        self._recv_bus.shutdown()
+
+    def test_cyclic_initializer_list(self):
+        messages = []
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+                is_extended_id=False,
+            )
+        )
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x22, 0x22, 0x22, 0x22, 0x22, 0x22],
+                is_extended_id=False,
+            )
+        )
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x33, 0x33, 0x33, 0x33, 0x33, 0x33],
+                is_extended_id=False,
+            )
+        )
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x44, 0x44, 0x44, 0x44, 0x44, 0x44],
+                is_extended_id=False,
+            )
+        )
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x55, 0x55, 0x55, 0x55, 0x55, 0x55],
+                is_extended_id=False,
+            )
+        )
+
+        task = self._send_bus.send_periodic(messages, self.PERIOD)
+        self.assertIsInstance(task, can.broadcastmanager.CyclicSendTaskABC)
+
+        results = []
+        for _ in range(len(messages) * 2):
+            result = self._recv_bus.recv(self.PERIOD * 2)
+            if result:
+                results.append(result)
+
+        task.stop()
+
+        # Find starting index for each
+        start_index = self._find_start_index(messages, results[0])
+        self.assertTrue(start_index != -1)
+
+        # Now go through the partitioned results and assert that they're equal
+        for rx_index, rx_message in enumerate(results):
+            tx_message = messages[start_index]
+
+            self.assertIsNotNone(rx_message)
+            self.assertEqual(tx_message.arbitration_id, rx_message.arbitration_id)
+            self.assertEqual(tx_message.dlc, rx_message.dlc)
+            self.assertEqual(tx_message.data, rx_message.data)
+            self.assertEqual(tx_message.is_extended_id, rx_message.is_extended_id)
+            self.assertEqual(tx_message.is_remote_frame, rx_message.is_remote_frame)
+            self.assertEqual(tx_message.is_error_frame, rx_message.is_error_frame)
+            self.assertEqual(tx_message.is_fd, rx_message.is_fd)
+
+            start_index = (start_index + 1) % len(messages)
+
+    def test_cyclic_initializer_tuple(self):
+        messages = []
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+                is_extended_id=False,
+            )
+        )
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x22, 0x22, 0x22, 0x22, 0x22, 0x22],
+                is_extended_id=False,
+            )
+        )
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x33, 0x33, 0x33, 0x33, 0x33, 0x33],
+                is_extended_id=False,
+            )
+        )
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x44, 0x44, 0x44, 0x44, 0x44, 0x44],
+                is_extended_id=False,
+            )
+        )
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x55, 0x55, 0x55, 0x55, 0x55, 0x55],
+                is_extended_id=False,
+            )
+        )
+        messages = tuple(messages)
+
+        self.assertIsInstance(messages, tuple)
+
+        task = self._send_bus.send_periodic(messages, self.PERIOD)
+        self.assertIsInstance(task, can.broadcastmanager.CyclicSendTaskABC)
+
+        results = []
+        for _ in range(len(messages) * 2):
+            result = self._recv_bus.recv(self.PERIOD * 2)
+            if result:
+                results.append(result)
+
+        task.stop()
+
+        # Find starting index for each
+        start_index = self._find_start_index(messages, results[0])
+        self.assertTrue(start_index != -1)
+
+        # Now go through the partitioned results and assert that they're equal
+        for rx_index, rx_message in enumerate(results):
+            tx_message = messages[start_index]
+
+            self.assertIsNotNone(rx_message)
+            self.assertEqual(tx_message.arbitration_id, rx_message.arbitration_id)
+            self.assertEqual(tx_message.dlc, rx_message.dlc)
+            self.assertEqual(tx_message.data, rx_message.data)
+            self.assertEqual(tx_message.is_extended_id, rx_message.is_extended_id)
+            self.assertEqual(tx_message.is_remote_frame, rx_message.is_remote_frame)
+            self.assertEqual(tx_message.is_error_frame, rx_message.is_error_frame)
+            self.assertEqual(tx_message.is_fd, rx_message.is_fd)
+
+            start_index = (start_index + 1) % len(messages)
+
+    def test_cyclic_initializer_message(self):
+        message = can.Message(
+            arbitration_id=0x401,
+            data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+            is_extended_id=False,
+        )
+
+        task = self._send_bus.send_periodic(message, self.PERIOD)
+        self.assertIsInstance(task, can.broadcastmanager.CyclicSendTaskABC)
+
+        # Take advantage of kernel's queueing mechanisms
+        time.sleep(4 * self.PERIOD)
+        task.stop()
+
+        for _ in range(4):
+            tx_message = message
+            rx_message = self._recv_bus.recv(self.TIMEOUT)
+
+            self.assertIsNotNone(rx_message)
+            self.assertEqual(tx_message.arbitration_id, rx_message.arbitration_id)
+            self.assertEqual(tx_message.dlc, rx_message.dlc)
+            self.assertEqual(tx_message.data, rx_message.data)
+            self.assertEqual(tx_message.is_extended_id, rx_message.is_extended_id)
+            self.assertEqual(tx_message.is_remote_frame, rx_message.is_remote_frame)
+            self.assertEqual(tx_message.is_error_frame, rx_message.is_error_frame)
+            self.assertEqual(tx_message.is_fd, rx_message.is_fd)
+
+    def test_cyclic_initializer_invalid_none(self):
+        with self.assertRaises(ValueError):
+            task = self._send_bus.send_periodic(None, self.PERIOD)
+
+    def test_cyclic_initializer_invalid_empty_list(self):
+        with self.assertRaises(ValueError):
+            task = self._send_bus.send_periodic([], self.PERIOD)
+
+    def test_cyclic_initializer_different_arbitration_ids(self):
+        messages = []
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+                is_extended_id=False,
+            )
+        )
+        messages.append(
+            can.Message(
+                arbitration_id=0x3E1,
+                data=[0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE],
+                is_extended_id=False,
+            )
+        )
+        with self.assertRaises(ValueError):
+            task = self._send_bus.send_periodic(messages, self.PERIOD)
+
+    def test_modify_data_list(self):
+        messages_odd = []
+        messages_odd.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+                is_extended_id=False,
+            )
+        )
+        messages_odd.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x33, 0x33, 0x33, 0x33, 0x33, 0x33],
+                is_extended_id=False,
+            )
+        )
+        messages_odd.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x55, 0x55, 0x55, 0x55, 0x55, 0x55],
+                is_extended_id=False,
+            )
+        )
+        messages_even = []
+        messages_even.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x22, 0x22, 0x22, 0x22, 0x22, 0x22],
+                is_extended_id=False,
+            )
+        )
+        messages_even.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x44, 0x44, 0x44, 0x44, 0x44, 0x44],
+                is_extended_id=False,
+            )
+        )
+        messages_even.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x66, 0x66, 0x66, 0x66, 0x66, 0x66],
+                is_extended_id=False,
+            )
+        )
+
+        task = self._send_bus.send_periodic(messages_odd, self.PERIOD)
+        self.assertIsInstance(task, can.broadcastmanager.ModifiableCyclicTaskABC)
+
+        results_odd = []
+        results_even = []
+        for _ in range(len(messages_odd) * 2):
+            result = self._recv_bus.recv(self.PERIOD * 2)
+            if result:
+                results_odd.append(result)
+
+        task.modify_data(messages_even)
+        for _ in range(len(messages_even) * 2):
+            result = self._recv_bus.recv(self.PERIOD * 2)
+            if result:
+                results_even.append(result)
+
+        task.stop()
+
+        # Make sure we received some messages
+        self.assertTrue(len(results_even) != 0)
+        self.assertTrue(len(results_odd) != 0)
+
+        # Find starting index for each
+        start_index_even = self._find_start_index(messages_even, results_even[0])
+        self.assertTrue(start_index_even != -1)
+
+        start_index_odd = self._find_start_index(messages_odd, results_odd[0])
+        self.assertTrue(start_index_odd != -1)
+
+        # Now go through the partitioned results and assert that they're equal
+        for rx_index, rx_message in enumerate(results_even):
+            tx_message = messages_even[start_index_even]
+
+            self.assertEqual(tx_message.arbitration_id, rx_message.arbitration_id)
+            self.assertEqual(tx_message.dlc, rx_message.dlc)
+            self.assertEqual(tx_message.data, rx_message.data)
+            self.assertEqual(tx_message.is_extended_id, rx_message.is_extended_id)
+            self.assertEqual(tx_message.is_remote_frame, rx_message.is_remote_frame)
+            self.assertEqual(tx_message.is_error_frame, rx_message.is_error_frame)
+            self.assertEqual(tx_message.is_fd, rx_message.is_fd)
+
+            start_index_even = (start_index_even + 1) % len(messages_even)
+
+            if rx_index != 0:
+                prev_rx_message = results_even[rx_index - 1]
+                # Assert timestamps are within the expected period
+                self.assertTrue(
+                    abs(
+                        (rx_message.timestamp - prev_rx_message.timestamp) - self.PERIOD
+                    )
+                    <= self.DELTA
+                )
+
+        for rx_index, rx_message in enumerate(results_odd):
+            tx_message = messages_odd[start_index_odd]
+
+            self.assertEqual(tx_message.arbitration_id, rx_message.arbitration_id)
+            self.assertEqual(tx_message.dlc, rx_message.dlc)
+            self.assertEqual(tx_message.data, rx_message.data)
+            self.assertEqual(tx_message.is_extended_id, rx_message.is_extended_id)
+            self.assertEqual(tx_message.is_remote_frame, rx_message.is_remote_frame)
+            self.assertEqual(tx_message.is_error_frame, rx_message.is_error_frame)
+            self.assertEqual(tx_message.is_fd, rx_message.is_fd)
+
+            start_index_odd = (start_index_odd + 1) % len(messages_odd)
+
+            if rx_index != 0:
+                prev_rx_message = results_odd[rx_index - 1]
+                # Assert timestamps are within the expected period
+                self.assertTrue(
+                    abs(
+                        (rx_message.timestamp - prev_rx_message.timestamp) - self.PERIOD
+                    )
+                    <= self.DELTA
+                )
+
+    def test_modify_data_message(self):
+        message_odd = can.Message(
+            arbitration_id=0x401,
+            data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+            is_extended_id=False,
+        )
+        message_even = can.Message(
+            arbitration_id=0x401,
+            data=[0x22, 0x22, 0x22, 0x22, 0x22, 0x22],
+            is_extended_id=False,
+        )
+        task = self._send_bus.send_periodic(message_odd, self.PERIOD)
+        self.assertIsInstance(task, can.broadcastmanager.ModifiableCyclicTaskABC)
+
+        results_odd = []
+        results_even = []
+        for _ in range(1 * 4):
+            result = self._recv_bus.recv(self.PERIOD * 2)
+            if result:
+                results_odd.append(result)
+
+        task.modify_data(message_even)
+        for _ in range(1 * 4):
+            result = self._recv_bus.recv(self.PERIOD * 2)
+            if result:
+                results_even.append(result)
+
+        task.stop()
+
+        # Now go through the partitioned results and assert that they're equal
+        for rx_index, rx_message in enumerate(results_even):
+            tx_message = message_even
+
+            self.assertEqual(tx_message.arbitration_id, rx_message.arbitration_id)
+            self.assertEqual(tx_message.dlc, rx_message.dlc)
+            self.assertEqual(tx_message.data, rx_message.data)
+            self.assertEqual(tx_message.is_extended_id, rx_message.is_extended_id)
+            self.assertEqual(tx_message.is_remote_frame, rx_message.is_remote_frame)
+            self.assertEqual(tx_message.is_error_frame, rx_message.is_error_frame)
+            self.assertEqual(tx_message.is_fd, rx_message.is_fd)
+
+            if rx_index != 0:
+                prev_rx_message = results_even[rx_index - 1]
+                # Assert timestamps are within the expected period
+                self.assertTrue(
+                    abs(
+                        (rx_message.timestamp - prev_rx_message.timestamp) - self.PERIOD
+                    )
+                    <= self.DELTA
+                )
+
+        for rx_index, rx_message in enumerate(results_odd):
+            tx_message = message_odd
+
+            self.assertEqual(tx_message.arbitration_id, rx_message.arbitration_id)
+            self.assertEqual(tx_message.dlc, rx_message.dlc)
+            self.assertEqual(tx_message.data, rx_message.data)
+            self.assertEqual(tx_message.is_extended_id, rx_message.is_extended_id)
+            self.assertEqual(tx_message.is_remote_frame, rx_message.is_remote_frame)
+            self.assertEqual(tx_message.is_error_frame, rx_message.is_error_frame)
+            self.assertEqual(tx_message.is_fd, rx_message.is_fd)
+
+            if rx_index != 0:
+                prev_rx_message = results_odd[rx_index - 1]
+                # Assert timestamps are within the expected period
+                self.assertTrue(
+                    abs(
+                        (rx_message.timestamp - prev_rx_message.timestamp) - self.PERIOD
+                    )
+                    <= self.DELTA
+                )
+
+    def test_modify_data_invalid(self):
+        message = can.Message(
+            arbitration_id=0x401,
+            data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+            is_extended_id=False,
+        )
+        task = self._send_bus.send_periodic(message, self.PERIOD)
+        self.assertIsInstance(task, can.broadcastmanager.ModifiableCyclicTaskABC)
+
+        time.sleep(2 * self.PERIOD)
+
+        with self.assertRaises(ValueError):
+            task.modify_data(None)
+
+    def test_modify_data_unequal_lengths(self):
+        message = can.Message(
+            arbitration_id=0x401,
+            data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+            is_extended_id=False,
+        )
+        new_messages = []
+        new_messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+                is_extended_id=False,
+            )
+        )
+        new_messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x22, 0x22, 0x22, 0x22, 0x22, 0x22],
+                is_extended_id=False,
+            )
+        )
+
+        task = self._send_bus.send_periodic(message, self.PERIOD)
+        self.assertIsInstance(task, can.broadcastmanager.ModifiableCyclicTaskABC)
+
+        time.sleep(2 * self.PERIOD)
+
+        with self.assertRaises(ValueError):
+            task.modify_data(new_messages)
+
+    def test_modify_data_different_arbitration_id_than_original(self):
+        old_message = can.Message(
+            arbitration_id=0x401,
+            data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+            is_extended_id=False,
+        )
+        new_message = can.Message(
+            arbitration_id=0x3E1,
+            data=[0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE],
+            is_extended_id=False,
+        )
+
+        task = self._send_bus.send_periodic(old_message, self.PERIOD)
+        self.assertIsInstance(task, can.broadcastmanager.ModifiableCyclicTaskABC)
+
+        time.sleep(2 * self.PERIOD)
+
+        with self.assertRaises(ValueError):
+            task.modify_data(new_message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds support for multiple Cyclic Messages in a Cyclic Task. The
default implementation is also changed to provide support for this, by
iterating over the list of Cyclic Messages.

The SocketCAN interface takes advantage of the Linux BCM APIs to do so,
while the IXXAT interface maintains its original behaviour.

This also introduces a new example that illustrates how to use Cyclic
Messages, backed by the SocketCAN interface.

Fixes #606