### PR TITLE
Add wrongly removed statement back to codebase

### DIFF
--- a/can/interfaces/kvaser/canlib.py
+++ b/can/interfaces/kvaser/canlib.py
@@ -424,7 +424,8 @@ class KvaserBus(BusABC):
         self.single_handle = single_handle
 
         num_channels = ctypes.c_int(0)
-        # log.debug("Res: %d", canGetNumberOfChannels(ctypes.byref(num_channels)))
+        canGetNumberOfChannels(ctypes.byref(num_channels))
+        # log.debug("canGetNumberOfChannels(): %d", canGetNumberOfChannels(ctypes.byref(num_channels)))
         num_channels = int(num_channels.value)
         log.info("Found %d available channels", num_channels)
         for idx in range(num_channels):

--- a/can/interfaces/kvaser/canlib.py
+++ b/can/interfaces/kvaser/canlib.py
@@ -425,7 +425,6 @@ class KvaserBus(BusABC):
 
         num_channels = ctypes.c_int(0)
         canGetNumberOfChannels(ctypes.byref(num_channels))
-        # log.debug("canGetNumberOfChannels(): %d", canGetNumberOfChannels(ctypes.byref(num_channels)))
         num_channels = int(num_channels.value)
         log.info("Found %d available channels", num_channels)
         for idx in range(num_channels):


### PR DESCRIPTION
This was removed in the process of making the linter happy. But it is required since it changes `num_channels`.

@christiansandberg this fixes the problem found by you