### PR TITLE
Remove Travis builds of Python 3.7 & nightly on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,14 +63,6 @@ jobs:
       os: osx
       osx_image: xcode8.3
       python: 3.6-dev
-    - stage: test
-      os: osx
-      osx_image: xcode8.3
-      python: 3.7-dev
-    - stage: test
-      os: osx
-      osx_image: xcode8.3
-      python: nightly
 
     - stage: documentation
       name: "Sphinx Build"


### PR DESCRIPTION
It is unsupported and causes problems. See [here](https://github.com/hardbyte/python-can/pull/554#issuecomment-500453610).