### PR TITLE
Update Readme: 4.x is currently developed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,13 +44,13 @@ messages on a can bus.
 The library currently supports Python 3.6+ as well as PyPy 3 and runs
 on Mac, Linux and Windows.
 
-==================  ===========
-Library Version      Python
-------------------  -----------
-  2.x                 2.6+, 3.4+
-  3.x                 2.7+, 3.5+
-  4.x                 3.6+
-==================  ===========
+=============================  ===========
+Library Version                Python
+-----------------------------  -----------
+  2.x                          2.6+, 3.4+
+  3.x                          2.7+, 3.5+
+  4.x *(currently on devlop)*  3.6+
+=============================  ===========
 
 
 Features


### PR DESCRIPTION
Make it clearer that 4.x is the version currently developed, maybe more people will stop using the develop branch on Python < 3.6.