### PR TITLE
More flexible configuration context handling and allow CAN_CONFIG env var

### DIFF
--- a/can/util.py
+++ b/can/util.py
@@ -4,6 +4,7 @@
 Utilities and configuration file parsing.
 """
 
+import json
 import os
 import os.path
 import platform
@@ -65,6 +66,7 @@ def load_environment_config(context=None):
     * CAN_INTERFACE
     * CAN_CHANNEL
     * CAN_BITRATE
+    * CAN_CONFIG
 
     if context is supplied, "_{context}" is appended to the environment
     variable name we will look at. For example if context="ABC":
@@ -72,6 +74,7 @@ def load_environment_config(context=None):
     * CAN_INTERFACE_ABC
     * CAN_CHANNEL_ABC
     * CAN_BITRATE_ABC
+    * CAN_CONFIG_ABC
 
     """
     mapper = {
@@ -79,12 +82,18 @@ def load_environment_config(context=None):
         "channel": "CAN_CHANNEL",
         "bitrate": "CAN_BITRATE",
     }
-    config = dict()
+
+    context_suffix = "_{}".format(context) if context else ""
+
+    config = {}
+
+    can_config_key = "CAN_CONFIG" + context_suffix
+    if can_config_key in os.environ:
+        config = json.loads(os.environ.get(can_config_key))
+
     for key, val in mapper.items():
-        if context is not None:
-            val = val + "_{}".format(context)
         if val in os.environ:
-            config[key] = os.environ.get(val)
+            config[key] = os.environ.get(val + context_suffix)
 
     return config
 

--- a/can/util.py
+++ b/can/util.py
@@ -153,7 +153,9 @@ def load_config(path=None, config=None, context=None):
     config_sources = [
         given_config,
         can.rc,
-        lambda _context: load_environment_config(_context),
+        lambda _context: load_environment_config(  # pylint: disable=unnecessary-lambda
+            _context
+        ),
         lambda _context: load_environment_config(),
         lambda _context: load_file_config(path, _context),
         lambda _context: load_file_config(path),

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -92,6 +92,13 @@ Configuration can be pulled from these environmental variables:
     * CAN_INTERFACE
     * CAN_CHANNEL
     * CAN_BITRATE
+    * CAN_CONFIG
+
+The ``CAN_CONFIG`` environment variable allows to set any bus configuration using JSON.
+
+For example:
+
+``CAN_INTERFACE=socketcan CAN_CONFIG={"receive_own_messages": true, "fd": true}``
 
 
 Interface Names

--- a/test/test_load_file_config.py
+++ b/test/test_load_file_config.py
@@ -45,15 +45,16 @@ class LoadFileConfigTest(unittest.TestCase):
     def test_config_file_with_default_and_section(self):
         tmp_config = self._gen_configration_file(["default", "one"])
 
-        default = can.util.load_file_config(path=tmp_config)
-        self.assertEqual(default, self.configuration["default"])
+        config = can.util.load_file_config(path=tmp_config)
+        self.assertEqual(config, self.configuration["default"])
 
-        one = can.util.load_file_config(path=tmp_config, section="one")
-        self.assertEqual(one, self.configuration["one"])
+        config.update(can.util.load_file_config(path=tmp_config, section="one"))
+        self.assertEqual(config, self.configuration["one"])
 
     def test_config_file_with_section_only(self):
         tmp_config = self._gen_configration_file(["one"])
-        config = can.util.load_file_config(path=tmp_config, section="one")
+        config = can.util.load_file_config(path=tmp_config)
+        config.update(can.util.load_file_config(path=tmp_config, section="one"))
         self.assertEqual(config, self.configuration["one"])
 
     def test_config_file_with_section_and_key_in_default(self):
@@ -61,13 +62,15 @@ class LoadFileConfigTest(unittest.TestCase):
         expected.update(self.configuration["two"])
 
         tmp_config = self._gen_configration_file(["default", "two"])
-        config = can.util.load_file_config(path=tmp_config, section="two")
+        config = can.util.load_file_config(path=tmp_config)
+        config.update(can.util.load_file_config(path=tmp_config, section="two"))
         self.assertEqual(config, expected)
 
     def test_config_file_with_section_missing_interface(self):
         expected = self.configuration["two"].copy()
         tmp_config = self._gen_configration_file(["two"])
-        config = can.util.load_file_config(path=tmp_config, section="two")
+        config = can.util.load_file_config(path=tmp_config)
+        config.update(can.util.load_file_config(path=tmp_config, section="two"))
         self.assertEqual(config, expected)
 
     def test_config_file_extra(self):
@@ -75,14 +78,16 @@ class LoadFileConfigTest(unittest.TestCase):
         expected.update(self.configuration["three"])
 
         tmp_config = self._gen_configration_file(["default", "three"])
-        config = can.util.load_file_config(path=tmp_config, section="three")
+        config = can.util.load_file_config(path=tmp_config)
+        config.update(can.util.load_file_config(path=tmp_config, section="three"))
         self.assertEqual(config, expected)
 
     def test_config_file_with_non_existing_section(self):
-        expected = {}
+        expected = self.configuration["default"].copy()
 
         tmp_config = self._gen_configration_file(["default", "one", "two", "three"])
-        config = can.util.load_file_config(path=tmp_config, section="zero")
+        config = can.util.load_file_config(path=tmp_config)
+        config.update(can.util.load_file_config(path=tmp_config, section="zero"))
         self.assertEqual(config, expected)
 
 


### PR DESCRIPTION
* Simplifying the configuration context handling
* Also allowing to use the context with environment variables
* Allowing to set other bus `config` using CAN_CONFIG/CAN_CONFIG_CONTEXT environment variable JSON
    * For example `CAN_INTERFACE=socketcan CAN_CONFIG={"receive_own_messages": true, "fd": true} python -c "import can; can.interface.Bus()"`