### PR TITLE
Avoid padding CAN_FD_MESSAGE_64 objects to 4 bytes

### DIFF
--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -208,11 +208,9 @@ class BLFReader(BaseIOHandler):
                     obj_size = header[3]
                     obj_type = header[4]
                     # Calculate position of next object
-                    if obj_size % 4 and obj_type != CAN_FD_MESSAGE_64:
-                        next_pos = pos + obj_size + (obj_size % 4)
-                    else:
-                        # CAN_FD_MESSAGE_64 objects are not padded to 4 bytes.
-                        next_pos = pos + obj_size
+                    next_pos = pos + obj_size
+                    if obj_type != CAN_FD_MESSAGE_64:
+                        next_pos += obj_size % 4
                     if next_pos > len(data):
                         # Object continues in next log container
                         break

--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -206,8 +206,13 @@ class BLFReader(BaseIOHandler):
                         raise BLFParseError()
 
                     obj_size = header[3]
+                    obj_type = header[4]
                     # Calculate position of next object
-                    next_pos = pos + obj_size + (obj_size % 4)
+                    if obj_size % 4 and obj_type != CAN_FD_MESSAGE_64:
+                        next_pos = pos + obj_size + (obj_size % 4)
+                    else:
+                        # CAN_FD_MESSAGE_64 objects are not padded to 4 bytes.
+                        next_pos = pos + obj_size
                     if next_pos > len(data):
                         # Object continues in next log container
                         break
@@ -239,7 +244,6 @@ class BLFReader(BaseIOHandler):
                         factor = 1e-9
                     timestamp = timestamp * factor + self.start_timestamp
 
-                    obj_type = header[4]
                     # Both CAN message types have the same starting content
                     if obj_type in (CAN_MESSAGE, CAN_MESSAGE2):
                         (


### PR DESCRIPTION
In the BLF files with CAN_FD_MESSAGE_64 objects that I have (unfortunately none that I can share at this point), objects of that type are not padded to multiples of four bytes. This also agrees with the implementation in vector_blf.