### PR TITLE
setup.py: require pytest-runner only when necessary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ from os import listdir
 from os.path import isfile, join
 import re
 import logging
+import sys
 from setuptools import setup, find_packages
 
 logging.basicConfig(level=logging.WARNING)
@@ -40,6 +41,13 @@ tests_require = [
 
 extras_require["test"] = tests_require
 
+# Check for 'pytest-runner' only if setup.py was invoked with 'test'.
+# This optimizes setup.py for cases when pytest-runner is not needed,
+# using the approach that is suggested upstream.
+#
+# See https://pypi.org/project/pytest-runner/#conditional-requirement
+needs_pytest = {"pytest", "test", "ptr"}.intersection(sys.argv)
+pytest_runner = ["pytest-runner"] if needs_pytest else []
 
 setup(
     # Description
@@ -96,7 +104,7 @@ setup(
         'windows-curses;platform_system=="Windows"',
         "filelock",
     ],
-    setup_requires=["pytest-runner"],
+    setup_requires=pytest_runner,
     extras_require=extras_require,
     tests_require=tests_require,
 )


### PR DESCRIPTION
This optimizes setup.py for cases when pytest-runner is not needed,
using the approach that is suggested upstream:

https://pypi.python.org/pypi/pytest-runner#conditional-requirement