### PR TITLE
Add mypy type-checking to Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,8 @@ jobs:
         # warnings to the .pylintrc-wip file to prevent them from being
         # re-introduced
         - pylint --rcfile=.pylintrc-wip can/
+        # mypy checking
+        - mypy --python-version=3.7 --ignore-missing-imports --no-implicit-optional can/bit_timing.py can/broadcastmanager.py can/bus.py can/interface.py can/listener.py can/logger.py can/message.py can/notifier.py can/player.py can/thread_safe_bus.py can/util.py
     - stage: linter
       name: "Formatting Checks"
       python: "3.7"

--- a/can/__init__.py
+++ b/can/__init__.py
@@ -6,11 +6,13 @@
 
 import logging
 
+from typing import Dict, Any
+
 __version__ = "3.2.0"
 
 log = logging.getLogger("can")
 
-rc = dict()
+rc: Dict[str, Any] = dict()
 
 
 class CanError(IOError):

--- a/can/bit_timing.py
+++ b/can/bit_timing.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional, Union
 
 
 class BitTiming:
@@ -27,15 +27,15 @@ class BitTiming:
 
     def __init__(
         self,
-        bitrate: int = None,
-        f_clock: int = None,
-        brp: int = None,
-        tseg1: int = None,
-        tseg2: int = None,
-        sjw: int = None,
+        bitrate: Optional[int] = None,
+        f_clock: Optional[int] = None,
+        brp: Optional[int] = None,
+        tseg1: Optional[int] = None,
+        tseg2: Optional[int] = None,
+        sjw: Optional[int] = None,
         nof_samples: int = 1,
-        btr0: int = None,
-        btr1: int = None,
+        btr0: Optional[int] = None,
+        btr1: Optional[int] = None,
     ):
         """
         :param int bitrate:

--- a/can/listener.py
+++ b/can/listener.py
@@ -11,7 +11,7 @@ try:
     from queue import SimpleQueue, Empty
 except ImportError:
     # Python 3.0 - 3.6
-    from queue import Queue as SimpleQueue, Empty
+    from queue import Queue as SimpleQueue, Empty  # type: ignore
 
 import asyncio
 

--- a/can/thread_safe_bus.py
+++ b/can/thread_safe_bus.py
@@ -16,11 +16,11 @@ from .interface import Bus
 
 
 try:
-    from contextlib import nullcontext
+    from contextlib import nullcontext  # type: ignore
 
 except ImportError:
 
-    class nullcontext:
+    class nullcontext:  # type: ignore
         """A context manager that does nothing at all.
         A fallback for Python 3.7's :class:`contextlib.nullcontext` manager.
         """

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,2 +1,4 @@
 pylint==2.3.1
 black==19.3b0
+mypy==0.720
+mypy-extensions==0.4.1


### PR DESCRIPTION
Currently just get a few files running under mypy without any errors.
The project can incrementally be converted and guarded by CI builds, until
python-can is completely PEP 561 compliant.

Any further refactoring to get a clean mypy build on the entire repository
can come later.