### PR TITLE
Add typing annotations for functions in can.bus

### DIFF
--- a/can/bus.py
+++ b/can/bus.py
@@ -4,7 +4,7 @@
 Contains the ABC bus implementation and its documentation.
 """
 
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Union
+from typing import Any, Iterable, Iterator, List, Optional, Sequence, Union
 
 import can.typechecking
 

--- a/can/bus.py
+++ b/can/bus.py
@@ -4,7 +4,7 @@
 Contains the ABC bus implementation and its documentation.
 """
 
-from typing import Any, Iterable, Iterator, List, Optional, Sequence, Union
+from typing import Any, Iterator, List, Optional, Sequence, Union
 
 import can.typechecking
 
@@ -311,7 +311,7 @@ class BusABC(metaclass=ABCMeta):
                 yield msg
 
     @property
-    def filters(self) -> Optional[Iterable[dict]]:
+    def filters(self) -> Optional[can.typechecking.CanFilters]:
         """
         Modify the filters of this bus. See :meth:`~can.BusABC.set_filters`
         for details.

--- a/can/bus.py
+++ b/can/bus.py
@@ -6,6 +6,8 @@ Contains the ABC bus implementation and its documentation.
 
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Union
 
+import can.typechecking
+
 from abc import ABCMeta, abstractmethod
 import can
 import logging
@@ -43,7 +45,7 @@ class BusABC(metaclass=ABCMeta):
     def __init__(
         self,
         channel: Any,
-        can_filters: Optional[List[Dict[str, Union[bool, int, str]]]] = None,
+        can_filters: Optional[can.typechecking.CanFilters] = None,
         **kwargs: object
     ):
         """Construct and open a CAN bus instance of the specified type.
@@ -317,12 +319,10 @@ class BusABC(metaclass=ABCMeta):
         return self._filters
 
     @filters.setter
-    def filters(self, filters: Optional[Iterable[Dict[str, Union[bool, int, str]]]]):
+    def filters(self, filters: Optional[can.typechecking.CanFilters]):
         self.set_filters(filters)
 
-    def set_filters(
-        self, filters: Optional[Iterable[Dict[str, Union[bool, int, str]]]] = None
-    ):
+    def set_filters(self, filters: Optional[can.typechecking.CanFilters] = None):
         """Apply filtering to all messages received by this Bus.
 
         All messages that match at least one filter are returned.
@@ -347,9 +347,7 @@ class BusABC(metaclass=ABCMeta):
         self._filters = filters or None
         self._apply_filters(self._filters)
 
-    def _apply_filters(
-        self, filters: Optional[Iterable[Dict[str, Union[bool, int, str]]]]
-    ):
+    def _apply_filters(self, filters: Optional[can.typechecking.CanFilters]):
         """
         Hook for applying the filters to the underlying kernel or
         hardware if supported/implemented by the interface.

--- a/can/typechecking.py
+++ b/can/typechecking.py
@@ -1,0 +1,6 @@
+"""Types for mypy type-checking
+"""
+import typing
+
+CanFilter = typing.Dict[str, typing.Union[bool, int, str]]
+CanFilters = typing.Iterable[CanFilter]

--- a/can/typechecking.py
+++ b/can/typechecking.py
@@ -2,5 +2,9 @@
 """
 import typing
 
-CanFilter = typing.Dict[str, typing.Union[bool, int, str]]
+import mypy_extensions
+
+CanFilter = mypy_extensions.TypedDict(
+    "CanFilter", {"can_id": int, "can_mask": int, "extended": bool}
+)
 CanFilters = typing.Iterable[CanFilter]

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setup(
         "aenum",
         'windows-curses;platform_system=="Windows"',
         "filelock",
+        "mypy_extensions >= 0.4.0, < 0.5.0",
     ],
     setup_requires=pytest_runner,
     extras_require=extras_require,


### PR DESCRIPTION
This adds typing annotations for use via mypy for all functions under
can.bus.

This works towards PEP 561 compatibility.