### PR TITLE
Add sphinx-autodoc-typehints to sphinx docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -43,6 +43,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.graphviz",
     "sphinxcontrib.programoutput",
+    "sphinx_autodoc_typehints",
 ]
 
 # Now, you can use the alias name as a new role, e.g. :issue:`123`.

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -1,2 +1,3 @@
 sphinx>=1.8.1
 sphinxcontrib-programoutput
+sphinx-autodoc-typehints==1.6.0


### PR DESCRIPTION
Add the sphinx-autodoc-typehints extension to the Sphinx documentation
generation pipeline, which allows us to automatically generate the
appropriate :type argname: and :rtype: directives in the docstring.