### PR TITLE
Extend Ixxat Driver CyclicSendTask with base ModifiableCyclicTaskABC to have modify_data() available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ sdist/
 var/
 *.egg-info/
 .installed.cfg
-*.egg
+# *.egg
 
 # PyInstaller
 #  Usually these files are written by a python script from a template


### PR DESCRIPTION
Hi, 

The Python CanOpenlib uses the self._node.rpdo[1]['Name'].raw and calls the a .update() function to call modfiy_data() if driver has the attribute. The IXXAT driver didn't have the attribute for now. But if u don't stop() and .start() in between u can't update the data. Now the modify_data() function derived from ModifiableCyclicTaskABC takes this in account and deletes the IXXAT hardware message on the CAN2USB and creates a new one without task recreation. 

Regards