### PR TITLE
Add typing annotations for can.broadcastmanager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,21 @@ jobs:
         # re-introduced
         - pylint --rcfile=.pylintrc-wip can/
         # mypy checking
-        - mypy --python-version=3.7 --ignore-missing-imports --no-implicit-optional can/bit_timing.py can/broadcastmanager.py can/bus.py can/interface.py can/listener.py can/logger.py can/message.py can/notifier.py can/player.py can/thread_safe_bus.py can/util.py
+        - mypy
+          --python-version=3.7
+          --ignore-missing-imports
+          --no-implicit-optional
+          can/bit_timing.py
+          can/broadcastmanager.py
+          can/bus.py
+          can/interface.py
+          can/listener.py
+          can/logger.py
+          can/message.py
+          can/notifier.py
+          can/player.py
+          can/thread_safe_bus.py
+          can/util.py
     - stage: linter
       name: "Formatting Checks"
       python: "3.7"

--- a/can/bus.py
+++ b/can/bus.py
@@ -4,7 +4,7 @@
 Contains the ABC bus implementation and its documentation.
 """
 
-from typing import Any, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Iterator, List, Optional, Sequence, Tuple, Union
 
 import can.typechecking
 
@@ -44,7 +44,7 @@ class BusABC(metaclass=ABCMeta):
     @abstractmethod
     def __init__(
         self,
-        channel: Any,
+        channel: can.typechecking.Channel,
         can_filters: Optional[can.typechecking.CanFilters] = None,
         **kwargs: object
     ):

--- a/can/typechecking.py
+++ b/can/typechecking.py
@@ -8,3 +8,6 @@ CanFilter = mypy_extensions.TypedDict(
     "CanFilter", {"can_id": int, "can_mask": int, "extended": bool}
 )
 CanFilters = typing.Iterable[CanFilter]
+
+# Used for the Abstract Base Class
+Channel = typing.Union[int, str]


### PR DESCRIPTION
This adds typing annotations for functions in can.broadcastmanager. A
Channel definition is introduced for use in can.bus for the generic
case.

In addition, this remove the redundant typing information that was
previously in the docstring, since we now have sphinx-autodoc-typehints
to generate the types for the docs from the annotations in the function
signature.

This works towards PEP 561 compatibility.