### PR TITLE
PCAN: Do not incorrectly reset CANMsg.MSGTYPE on remote frame.

### DIFF
--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -426,9 +426,7 @@ class PcanBus(BusABC):
             CANMsg.MSGTYPE = msgType
 
             # if a remote frame will be sent, data bytes are not important.
-            if msg.is_remote_frame:
-                CANMsg.MSGTYPE = msgType.value | PCAN_MESSAGE_RTR.value
-            else:
+            if not msg.is_remote_frame:
                 # copy data
                 for i in range(CANMsg.LEN):
                     CANMsg.DATA[i] = msg.data[i]


### PR DESCRIPTION
In `PcanBus.send()`, we initially set `msgType` based on all the flags of `msg`, including RTR. In the if/else for `self.fd`, we are incorrectly resetting it if rtr. We should not, and so we are no longer doing it.