### PR TITLE
Add typing annotations for can.message

### DIFF
--- a/can/message.py
+++ b/can/message.py
@@ -8,6 +8,9 @@ This module contains the implementation of :class:`can.Message`.
     starting with Python 3.7.
 """
 
+from typing import Optional, Union
+
+from . import typechecking
 
 from copy import deepcopy
 from math import isinf, isnan
@@ -48,28 +51,28 @@ class Message:
 
     def __init__(
         self,
-        timestamp=0.0,
-        arbitration_id=0,
-        is_extended_id=True,
-        is_remote_frame=False,
-        is_error_frame=False,
-        channel=None,
-        dlc=None,
-        data=None,
-        is_fd=False,
-        bitrate_switch=False,
-        error_state_indicator=False,
-        check=False,
+        timestamp: float = 0.0,
+        arbitration_id: int = 0,
+        is_extended_id: bool = True,
+        is_remote_frame: bool = False,
+        is_error_frame: bool = False,
+        channel: Optional[typechecking.Channel] = None,
+        dlc: Optional[int] = None,
+        data: Optional[typechecking.CanData] = None,
+        is_fd: bool = False,
+        bitrate_switch: bool = False,
+        error_state_indicator: bool = False,
+        check: bool = False,
     ):
         """
         To create a message object, simply provide any of the below attributes
         together with additional parameters as keyword arguments to the constructor.
 
-        :param bool check: By default, the constructor of this class does not strictly check the input.
-                           Thus, the caller must prevent the creation of invalid messages or
-                           set this parameter to `True`, to raise an Error on invalid inputs.
-                           Possible problems include the `dlc` field not matching the length of `data`
-                           or creating a message with both `is_remote_frame` and `is_error_frame` set to `True`.
+        :param check: By default, the constructor of this class does not strictly check the input.
+                      Thus, the caller must prevent the creation of invalid messages or
+                      set this parameter to `True`, to raise an Error on invalid inputs.
+                      Possible problems include the `dlc` field not matching the length of `data`
+                      or creating a message with both `is_remote_frame` and `is_error_frame` set to `True`.
 
         :raises ValueError: iff `check` is set to `True` and one or more arguments were invalid
         """
@@ -102,7 +105,7 @@ class Message:
         if check:
             self._check()
 
-    def __str__(self):
+    def __str__(self) -> str:
         field_strings = ["Timestamp: {0:>15.6f}".format(self.timestamp)]
         if self.is_extended_id:
             arbitration_id_string = "ID: {0:08x}".format(self.arbitration_id)
@@ -144,14 +147,14 @@ class Message:
 
         return "    ".join(field_strings).strip()
 
-    def __len__(self):
+    def __len__(self) -> int:
         # return the dlc such that it also works on remote frames
         return self.dlc
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return True
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         args = [
             "timestamp={}".format(self.timestamp),
             "arbitration_id={:#x}".format(self.arbitration_id),
@@ -177,16 +180,16 @@ class Message:
 
         return "can.Message({})".format(", ".join(args))
 
-    def __format__(self, format_spec):
+    def __format__(self, format_spec: Optional[str]) -> str:
         if not format_spec:
             return self.__str__()
         else:
             raise ValueError("non empty format_specs are not supported")
 
-    def __bytes__(self):
+    def __bytes__(self) -> bytes:
         return bytes(self.data)
 
-    def __copy__(self):
+    def __copy__(self) -> "Message":
         new = Message(
             timestamp=self.timestamp,
             arbitration_id=self.arbitration_id,
@@ -202,7 +205,7 @@ class Message:
         )
         return new
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: dict) -> "Message":
         new = Message(
             timestamp=self.timestamp,
             arbitration_id=self.arbitration_id,
@@ -278,17 +281,17 @@ class Message:
                     "error state indicator is only allowed for CAN FD frames"
                 )
 
-    def equals(self, other, timestamp_delta=1.0e-6):
+    def equals(
+        self, other: "Message", timestamp_delta: Optional[Union[float, int]] = 1.0e-6
+    ) -> bool:
         """
         Compares a given message with this one.
 
-        :param can.Message other: the message to compare with
+        :param other: the message to compare with
 
-        :type timestamp_delta: float or int or None
         :param timestamp_delta: the maximum difference at which two timestamps are
                                 still considered equal or None to not compare timestamps
 
-        :rtype: bool
         :return: True iff the given message equals this one
         """
         # see https://github.com/hardbyte/python-can/pull/413 for a discussion

--- a/can/typechecking.py
+++ b/can/typechecking.py
@@ -9,5 +9,12 @@ CanFilter = mypy_extensions.TypedDict(
 )
 CanFilters = typing.Iterable[CanFilter]
 
+# TODO: Once buffer protocol support lands in typing, we should switch to that,
+# since can.message.Message attempts to call bytearray() on the given data, so
+# this should have the same typing info.
+#
+# See: https://github.com/python/typing/issues/593
+CanData = typing.Union[bytes, bytearray, int, typing.Iterable[int]]
+
 # Used for the Abstract Base Class
 Channel = typing.Union[int, str]


### PR DESCRIPTION
This adds typing annotations for functions in can.message. Currently the
typing annotation for the Message data is incomplete due to upstream not
implementing the buffer protocol. Since can.Message attempts to cast the
data to a bytearray via bytearray(), the Message data can be any type
that bytearray() supports.

In addition, this remove the redundant typing information that was
previously in the docstring, since we now have sphinx-autodoc-typehints
to generate the types for the docs from the annotations in the function
signature.

This works towards PEP 561 compatibility.