### PR TITLE
Add RedirectReader to the generated Listener docs

### DIFF
--- a/doc/listeners.rst
+++ b/doc/listeners.rst
@@ -41,6 +41,13 @@ BufferedReader
     :members:
 
 
+RedirectReader
+--------------
+
+.. autoclass:: can.RedirectReader
+    :members:
+
+
 Logger
 ------
 


### PR DESCRIPTION
This makes Sphinx aware of the RedirectReader class, which allows
CAN Messages to be gatewayed from one Bus to another Bus.