### PR TITLE
Add the seeedstudio interface to docs

### DIFF
--- a/doc/interfaces.rst
+++ b/doc/interfaces.rst
@@ -25,6 +25,7 @@ The available interfaces are:
    interfaces/virtual
    interfaces/canalystii
    interfaces/systec
+   interfaces/seeedstudio
 
 Additional interfaces can be added via a plugin interface. An external package
 can register a new interface by using the ``can.interface`` entry point in its setup.py.


### PR DESCRIPTION
Previously the seeedstudio interface wasn't being included in the
generated docs. This silences the warning:

    WARNING: document isn't included in any toctree