### PR TITLE
Add typing to the generic IO module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,9 @@ jobs:
           can/notifier.py
           can/player.py
           can/thread_safe_bus.py
+          can/typechecking.py
           can/util.py
+          can/io/generic.py
     - stage: linter
       name: "Formatting Checks"
       python: "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,7 @@ jobs:
           can/typechecking.py
           can/util.py
           can/io/generic.py
+          can/io/logger.py
     - stage: linter
       name: "Formatting Checks"
       python: "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,8 +101,7 @@ jobs:
           can/thread_safe_bus.py
           can/typechecking.py
           can/util.py
-          can/io/generic.py
-          can/io/logger.py
+          can/io/**.py
     - stage: linter
       name: "Formatting Checks"
       python: "3.7"

--- a/can/io/generic.py
+++ b/can/io/generic.py
@@ -7,6 +7,7 @@ Contains a generic class for file IO.
 from abc import ABCMeta
 from typing import Optional, cast
 
+import can
 import can.typechecking
 
 
@@ -48,3 +49,15 @@ class BaseIOHandler(metaclass=ABCMeta):
         if self.file is not None:
             # this also implies a flush()
             self.file.close()
+
+
+# pylint: disable=abstract-method,too-few-public-methods
+class MessageWriter(
+    BaseIOHandler, can.Listener, metaclass=ABCMeta
+):
+    """The base class for all writers."""
+
+
+# pylint: disable=too-few-public-methods
+class MessageReader(BaseIOHandler, metaclass=ABCMeta):
+    """The base class for all readers."""

--- a/can/io/generic.py
+++ b/can/io/generic.py
@@ -33,7 +33,7 @@ class BaseIOHandler(metaclass=ABCMeta):
             self.file = cast(Optional[can.typechecking.FileLike], file)
         else:
             # file is some path-like object
-            self.file = open(cast(can.typechecking.PathLike, file), mode)
+            self.file = open(cast(can.typechecking.StringPathLike, file), mode)
 
         # for multiple inheritance
         super().__init__()

--- a/can/io/generic.py
+++ b/can/io/generic.py
@@ -52,9 +52,7 @@ class BaseIOHandler(metaclass=ABCMeta):
 
 
 # pylint: disable=abstract-method,too-few-public-methods
-class MessageWriter(
-    BaseIOHandler, can.Listener, metaclass=ABCMeta
-):
+class MessageWriter(BaseIOHandler, can.Listener, metaclass=ABCMeta):
     """The base class for all writers."""
 
 

--- a/can/io/generic.py
+++ b/can/io/generic.py
@@ -7,7 +7,7 @@ Contains a generic class for file IO.
 from abc import ABCMeta
 from typing import Optional, Union, cast
 
-from can.typechecking import FileLike, PathLike
+from can.typechecking import FileLike, PathLike, AcceptedIOType
 
 
 class BaseIOHandler(metaclass=ABCMeta):
@@ -20,7 +20,7 @@ class BaseIOHandler(metaclass=ABCMeta):
         was opened
     """
 
-    def __init__(self, file: Optional[Union[FileLike, PathLike]], mode: str = "rt"):
+    def __init__(self, file: AcceptedIOType, mode: str = "rt"):
         """
         :param file: a path-like object to open a file, a file-like object
                      to be used as a file or `None` to not use a file at all

--- a/can/io/generic.py
+++ b/can/io/generic.py
@@ -5,6 +5,9 @@ Contains a generic class for file IO.
 """
 
 from abc import ABCMeta
+from typing import Optional, Union, cast
+
+from can.typechecking import FileLike, PathLike
 
 
 class BaseIOHandler(metaclass=ABCMeta):
@@ -12,24 +15,24 @@ class BaseIOHandler(metaclass=ABCMeta):
 
     Can be used as a context manager.
 
-    :attr file-like file:
+    :attr Optional[FileLike] file:
         the file-like object that is kept internally, or None if none
         was opened
     """
 
-    def __init__(self, file, mode="rt"):
+    def __init__(self, file: Optional[Union[FileLike, PathLike]], mode: str = "rt"):
         """
         :param file: a path-like object to open a file, a file-like object
                      to be used as a file or `None` to not use a file at all
-        :param str mode: the mode that should be used to open the file, see
-                         :func:`open`, ignored if *file* is `None`
+        :param mode: the mode that should be used to open the file, see
+                     :func:`open`, ignored if *file* is `None`
         """
         if file is None or (hasattr(file, "read") and hasattr(file, "write")):
             # file is None or some file-like object
-            self.file = file
+            self.file = cast(Optional[FileLike], file)
         else:
             # file is some path-like object
-            self.file = open(file, mode)
+            self.file = open(cast(PathLike, file), mode)
 
         # for multiple inheritance
         super().__init__()
@@ -41,6 +44,7 @@ class BaseIOHandler(metaclass=ABCMeta):
         self.stop()
 
     def stop(self):
+        """Closes the undelying file-like object and flushes it, if it was opened in write mode."""
         if self.file is not None:
             # this also implies a flush()
             self.file.close()

--- a/can/io/generic.py
+++ b/can/io/generic.py
@@ -7,7 +7,7 @@ Contains a generic class for file IO.
 from abc import ABCMeta
 from typing import Optional, Union, cast
 
-from can.typechecking import FileLike, PathLike, AcceptedIOType
+import can.typechecking
 
 
 class BaseIOHandler(metaclass=ABCMeta):
@@ -20,7 +20,7 @@ class BaseIOHandler(metaclass=ABCMeta):
         was opened
     """
 
-    def __init__(self, file: AcceptedIOType, mode: str = "rt"):
+    def __init__(self, file: can.typechecking.AcceptedIOType, mode: str = "rt"):
         """
         :param file: a path-like object to open a file, a file-like object
                      to be used as a file or `None` to not use a file at all
@@ -29,10 +29,10 @@ class BaseIOHandler(metaclass=ABCMeta):
         """
         if file is None or (hasattr(file, "read") and hasattr(file, "write")):
             # file is None or some file-like object
-            self.file = cast(Optional[FileLike], file)
+            self.file = cast(Optional[can.typechecking.FileLike], file)
         else:
             # file is some path-like object
-            self.file = open(cast(PathLike, file), mode)
+            self.file = open(cast(can.typechecking.PathLike, file), mode)
 
         # for multiple inheritance
         super().__init__()

--- a/can/io/generic.py
+++ b/can/io/generic.py
@@ -5,7 +5,7 @@ Contains a generic class for file IO.
 """
 
 from abc import ABCMeta
-from typing import Optional, Union, cast
+from typing import Optional, cast
 
 import can.typechecking
 
@@ -20,7 +20,7 @@ class BaseIOHandler(metaclass=ABCMeta):
         was opened
     """
 
-    def __init__(self, file: can.typechecking.AcceptedIOType, mode: str = "rt"):
+    def __init__(self, file: can.typechecking.AcceptedIOType, mode: str = "rt") -> None:
         """
         :param file: a path-like object to open a file, a file-like object
                      to be used as a file or `None` to not use a file at all
@@ -37,13 +37,13 @@ class BaseIOHandler(metaclass=ABCMeta):
         # for multiple inheritance
         super().__init__()
 
-    def __enter__(self):
+    def __enter__(self) -> "BaseIOHandler":
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, *args) -> None:
         self.stop()
 
-    def stop(self):
+    def stop(self) -> None:
         """Closes the undelying file-like object and flushes it, if it was opened in write mode."""
         if self.file is not None:
             # this also implies a flush()

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -40,6 +40,7 @@ class Logger(BaseIOHandler, Listener):  # pylint: disable=abstract-method
         arguments are passed on to the returned instance.
     """
 
+    # pylint: disable=too-many-return-statements
     @staticmethod
     def __new__(
         cls, filename: typing.Optional[can.typechecking.PathLike], *args, **kwargs

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -8,6 +8,8 @@ import logging
 import pathlib
 import typing
 
+import can.typechecking
+
 from ..listener import Listener
 from .generic import BaseIOHandler
 from .asc import ASCWriter
@@ -16,8 +18,6 @@ from .canutils import CanutilsLogWriter
 from .csv import CSVWriter
 from .sqlite import SqliteWriter
 from .printer import Printer
-
-import can.typechecking
 
 log = logging.getLogger("can.io.logger")
 
@@ -43,7 +43,9 @@ class Logger(BaseIOHandler, Listener):  # pylint: disable=abstract-method
     """
 
     @staticmethod
-    def __new__(cls, filename: typing.Optional[can.typechecking.PathLike], *args, **kwargs):
+    def __new__(
+        cls, filename: typing.Optional[can.typechecking.PathLike], *args, **kwargs
+    ):
         """
         :param filename: the filename/path of the file to write to,
                          may be a path-like object or None to

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -29,6 +29,7 @@ class Logger(BaseIOHandler, Listener):  # pylint: disable=abstract-method
       * .csv: :class:`can.CSVWriter`
       * .db: :class:`can.SqliteWriter`
       * .log :class:`can.CanutilsLogWriter`
+      * .txt :class:`can.Printer`
 
     The **filename** may also be *None*, to fall back to :class:`can.Printer`.
 
@@ -62,5 +63,7 @@ class Logger(BaseIOHandler, Listener):  # pylint: disable=abstract-method
             return SqliteWriter(filename, *args, **kwargs)
         if suffix == ".log":
             return CanutilsLogWriter(filename, *args, **kwargs)
+        if suffix == ".txt":
+            return Printer(filename, *args, **kwargs)
 
         raise ValueError(f'unknown file type "{filename}"')

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -4,7 +4,6 @@
 See the :class:`Logger` class.
 """
 
-import logging
 import pathlib
 import typing
 
@@ -18,8 +17,6 @@ from .canutils import CanutilsLogWriter
 from .csv import CSVWriter
 from .sqlite import SqliteWriter
 from .printer import Printer
-
-log = logging.getLogger("can.io.logger")
 
 
 class Logger(BaseIOHandler, Listener):  # pylint: disable=abstract-method

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -17,7 +17,7 @@ from .csv import CSVWriter
 from .sqlite import SqliteWriter
 from .printer import Printer
 
-from can.typechecking import PathLike
+import can.typechecking
 
 log = logging.getLogger("can.io.logger")
 
@@ -43,7 +43,7 @@ class Logger(BaseIOHandler, Listener):  # pylint: disable=abstract-method
     """
 
     @staticmethod
-    def __new__(cls, filename: typing.Optional[PathLike], *args, **kwargs):
+    def __new__(cls, filename: typing.Optional[can.typechecking.PathLike], *args, **kwargs):
         """
         :param filename: the filename/path of the file to write to,
                          may be a path-like object or None to

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -53,18 +53,16 @@ class Logger(BaseIOHandler, Listener):  # pylint: disable=abstract-method
         if filename is None:
             return Printer(*args, **kwargs)
 
+        lookup = {
+            ".asc": ASCWriter,
+            ".blf": BLFWriter,
+            ".csv": CSVWriter,
+            ".db": SqliteWriter,
+            ".log": CanutilsLogWriter,
+            ".txt": Printer,
+        }
         suffix = pathlib.PurePath(filename).suffix
-        if suffix == ".asc":
-            return ASCWriter(filename, *args, **kwargs)
-        if suffix == ".blf":
-            return BLFWriter(filename, *args, **kwargs)
-        if suffix == ".csv":
-            return CSVWriter(filename, *args, **kwargs)
-        if suffix == ".db":
-            return SqliteWriter(filename, *args, **kwargs)
-        if suffix == ".log":
-            return CanutilsLogWriter(filename, *args, **kwargs)
-        if suffix == ".txt":
-            return Printer(filename, *args, **kwargs)
-
-        raise ValueError(f'unknown file type "{filename}"')
+        try:
+            return lookup[suffix](filename, *args, **kwargs)
+        except KeyError:
+            raise ValueError(f'unknown file type "{suffix}"')

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -65,4 +65,6 @@ class Logger(BaseIOHandler, Listener):  # pylint: disable=abstract-method
         try:
             return lookup[suffix](filename, *args, **kwargs)
         except KeyError:
-            raise ValueError(f'No write support for this unknown log format "{suffix}"')
+            raise ValueError(
+                f'No write support for this unknown log format "{suffix}"'
+            ) from None

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -42,12 +42,13 @@ class Logger(BaseIOHandler, Listener):  # pylint: disable=abstract-method
 
     @staticmethod
     def __new__(
-        cls, filename: typing.Optional[can.typechecking.PathLike], *args, **kwargs
+        cls, filename: typing.Optional[can.typechecking.StringPathLike], *args, **kwargs
     ):
         """
         :param filename: the filename/path of the file to write to,
                          may be a path-like object or None to
                          instantiate a :class:`~can.Printer`
+        :raises ValueError: if the filename's suffix is of an unknown file type
         """
         if filename is None:
             return Printer(*args, **kwargs)
@@ -64,4 +65,4 @@ class Logger(BaseIOHandler, Listener):  # pylint: disable=abstract-method
         try:
             return lookup[suffix](filename, *args, **kwargs)
         except KeyError:
-            raise ValueError(f'unknown file type "{suffix}"')
+            raise ValueError(f'No write support for this unknown log format "{suffix}"')

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -40,7 +40,6 @@ class Logger(BaseIOHandler, Listener):  # pylint: disable=abstract-method
         arguments are passed on to the returned instance.
     """
 
-    # pylint: disable=too-many-return-statements
     @staticmethod
     def __new__(
         cls, filename: typing.Optional[can.typechecking.PathLike], *args, **kwargs

--- a/can/io/player.py
+++ b/can/io/player.py
@@ -6,8 +6,11 @@ well as :class:`MessageSync` which plays back messages
 in the recorded order an time intervals.
 """
 
+import pathlib
 from time import time, sleep
-import logging
+import typing
+
+import can.typechecking
 
 from .generic import BaseIOHandler
 from .asc import ASCReader
@@ -15,8 +18,6 @@ from .blf import BLFReader
 from .canutils import CanutilsLogReader
 from .csv import CSVReader
 from .sqlite import SqliteReader
-
-log = logging.getLogger("can.io.player")
 
 
 class LogReader(BaseIOHandler):
@@ -45,45 +46,51 @@ class LogReader(BaseIOHandler):
     """
 
     @staticmethod
-    def __new__(cls, filename, *args, **kwargs):
+    def __new__(cls, filename: can.typechecking.PathLike, *args, **kwargs):
         """
-        :param str filename: the filename/path the file to read from
+        :param filename: the filename/path the file to read from
         """
-        if filename.endswith(".asc"):
-            return ASCReader(filename, *args, **kwargs)
-        elif filename.endswith(".blf"):
-            return BLFReader(filename, *args, **kwargs)
-        elif filename.endswith(".csv"):
-            return CSVReader(filename, *args, **kwargs)
-        elif filename.endswith(".db"):
+        suffix = pathlib.PurePath(filename).suffix
+
+        if suffix == ".asc":
+            return ASCReader(filename)
+        if suffix == ".blf":
+            return BLFReader(filename)
+        if suffix == ".csv":
+            return CSVReader(filename)
+        if suffix == ".db":
             return SqliteReader(filename, *args, **kwargs)
-        elif filename.endswith(".log"):
-            return CanutilsLogReader(filename, *args, **kwargs)
-        else:
-            raise NotImplementedError(
-                "No read support for this log format: {}".format(filename)
-            )
+        if suffix == ".log":
+            return CanutilsLogReader(filename)
+
+        raise NotImplementedError(f"No read support for this log format: {filename}")
 
 
-class MessageSync:
+class MessageSync:  # pylint: disable=too-few-public-methods
     """
     Used to iterate over some given messages in the recorded time.
     """
 
-    def __init__(self, messages, timestamps=True, gap=0.0001, skip=60):
+    def __init__(
+        self,
+        messages: typing.Iterable[can.Message],
+        timestamps: bool = True,
+        gap: float = 0.0001,
+        skip: float = 60.0,
+    ) -> None:
         """Creates an new **MessageSync** instance.
 
-        :param Iterable[can.Message] messages: An iterable of :class:`can.Message` instances.
-        :param bool timestamps: Use the messages' timestamps. If False, uses the *gap* parameter as the time between messages.
-        :param float gap: Minimum time between sent messages in seconds
-        :param float skip: Skip periods of inactivity greater than this (in seconds).
+        :param messages: An iterable of :class:`can.Message` instances.
+        :param timestamps: Use the messages' timestamps. If False, uses the *gap* parameter as the time between messages.
+        :param gap: Minimum time between sent messages in seconds
+        :param skip: Skip periods of inactivity greater than this (in seconds).
         """
         self.raw_messages = messages
         self.timestamps = timestamps
         self.gap = gap
         self.skip = skip
 
-    def __iter__(self):
+    def __iter__(self) -> typing.Generator[can.Message, None, None]:
         playback_start_time = time()
         recorded_start_time = None
 

--- a/can/io/player.py
+++ b/can/io/player.py
@@ -65,7 +65,9 @@ class LogReader(BaseIOHandler):
         try:
             return lookup[suffix](filename, *args, **kwargs)
         except KeyError:
-            raise ValueError(f'No read support for this unknown log format "{suffix}"')
+            raise ValueError(
+                f'No read support for this unknown log format "{suffix}"'
+            ) from None
 
 
 class MessageSync:  # pylint: disable=too-few-public-methods

--- a/can/io/player.py
+++ b/can/io/player.py
@@ -48,7 +48,7 @@ class LogReader(BaseIOHandler):
     @staticmethod
     def __new__(cls, filename: "can.typechecking.PathLike", *args, **kwargs):
         """
-        :param filename: the filename/path the file to read from
+        :param filename: the filename/path of the file to read from
         """
         suffix = pathlib.PurePath(filename).suffix
 

--- a/can/io/player.py
+++ b/can/io/player.py
@@ -10,7 +10,7 @@ import pathlib
 from time import time, sleep
 import typing
 
-import can
+import can  # pylint: disable=unused-import
 
 from .generic import BaseIOHandler
 from .asc import ASCReader

--- a/can/io/player.py
+++ b/can/io/player.py
@@ -10,7 +10,7 @@ import pathlib
 from time import time, sleep
 import typing
 
-import can.typechecking
+import can
 
 from .generic import BaseIOHandler
 from .asc import ASCReader
@@ -46,7 +46,7 @@ class LogReader(BaseIOHandler):
     """
 
     @staticmethod
-    def __new__(cls, filename: can.typechecking.PathLike, *args, **kwargs):
+    def __new__(cls, filename: "can.typechecking.PathLike", *args, **kwargs):
         """
         :param filename: the filename/path the file to read from
         """
@@ -73,7 +73,7 @@ class MessageSync:  # pylint: disable=too-few-public-methods
 
     def __init__(
         self,
-        messages: typing.Iterable[can.Message],
+        messages: typing.Iterable["can.Message"],
         timestamps: bool = True,
         gap: float = 0.0001,
         skip: float = 60.0,
@@ -90,7 +90,7 @@ class MessageSync:  # pylint: disable=too-few-public-methods
         self.gap = gap
         self.skip = skip
 
-    def __iter__(self) -> typing.Generator[can.Message, None, None]:
+    def __iter__(self) -> typing.Generator["can.Message", None, None]:
         playback_start_time = time()
         recorded_start_time = None
 

--- a/can/io/printer.py
+++ b/can/io/printer.py
@@ -22,15 +22,18 @@ class Printer(BaseIOHandler, Listener):
                               standard out
     """
 
-    def __init__(self, file=None):
+    def __init__(self, file=None, append=False):
         """
         :param file: an optional path-like object or as file-like object to "print"
                      to instead of writing to standard out (stdout)
                      If this is a file-like object, is has to opened in text
                      write mode, not binary write mode.
+        :param bool append: if set to `True` messages are appended to
+                            the file, else the file is truncated
         """
         self.write_to_file = file is not None
-        super().__init__(file, mode="w")
+        mode = "a" if append else "w"
+        super().__init__(file, mode=mode)
 
     def on_message_received(self, msg):
         if self.write_to_file:

--- a/can/typechecking.py
+++ b/can/typechecking.py
@@ -23,4 +23,5 @@ Channel = typing.Union[int, str]
 
 # Used by the IO module
 FileLike = typing.IO[typing.Any]
-PathLike = typing.Union[str, bytes, os.PathLike]
+PathLike = typing.Union[str, os.PathLike[str]]
+AcceptedIOType = typing.Optional[typing.Union[FileLike, PathLike]]

--- a/can/typechecking.py
+++ b/can/typechecking.py
@@ -1,5 +1,7 @@
 """Types for mypy type-checking
 """
+
+import os
 import typing
 
 import mypy_extensions
@@ -18,3 +20,7 @@ CanData = typing.Union[bytes, bytearray, int, typing.Iterable[int]]
 
 # Used for the Abstract Base Class
 Channel = typing.Union[int, str]
+
+# Used by the IO module
+FileLike = typing.IO[typing.Any]
+PathLike = typing.Union[str, bytes, os.PathLike]

--- a/can/typechecking.py
+++ b/can/typechecking.py
@@ -3,7 +3,7 @@
 
 import typing
 
-import os
+import os  # pylint: disable=unused-import
 
 import mypy_extensions
 

--- a/can/typechecking.py
+++ b/can/typechecking.py
@@ -23,5 +23,5 @@ Channel = typing.Union[int, str]
 
 # Used by the IO module
 FileLike = typing.IO[typing.Any]
-PathLike = typing.Union[str, os.PathLike[str]]
+PathLike = typing.Union[str, "os.PathLike[str]"]
 AcceptedIOType = typing.Optional[typing.Union[FileLike, PathLike]]

--- a/can/typechecking.py
+++ b/can/typechecking.py
@@ -3,7 +3,8 @@
 
 import typing
 
-import os  # pylint: disable=unused-import
+if typing.TYPE_CHECKING:
+    import os
 
 import mypy_extensions
 

--- a/can/typechecking.py
+++ b/can/typechecking.py
@@ -24,5 +24,5 @@ Channel = typing.Union[int, str]
 
 # Used by the IO module
 FileLike = typing.IO[typing.Any]
-PathLike = typing.Union[str, "os.PathLike[str]"]
-AcceptedIOType = typing.Optional[typing.Union[FileLike, PathLike]]
+StringPathLike = typing.Union[str, "os.PathLike[str]"]
+AcceptedIOType = typing.Optional[typing.Union[FileLike, StringPathLike]]

--- a/can/typechecking.py
+++ b/can/typechecking.py
@@ -3,8 +3,7 @@
 
 import typing
 
-if typing.TYPE_CHECKING:
-    import os
+import os
 
 import mypy_extensions
 

--- a/can/typechecking.py
+++ b/can/typechecking.py
@@ -1,8 +1,10 @@
 """Types for mypy type-checking
 """
 
-import os
 import typing
+
+if typing.TYPE_CHECKING:
+    import os
 
 import mypy_extensions
 

--- a/test/listener_test.py
+++ b/test/listener_test.py
@@ -4,12 +4,10 @@
 """
 """
 
-from time import sleep
 import unittest
 import random
 import logging
 import tempfile
-import sqlite3
 import os
 from os.path import join, dirname
 
@@ -137,12 +135,15 @@ class ListenerTest(BusTest):
         test_filetype_to_instance(".log", can.CanutilsLogWriter)
         test_filetype_to_instance(".txt", can.Printer)
 
-        # test file extensions that should use a fallback
-        test_filetype_to_instance("", can.Printer)
-        test_filetype_to_instance(".", can.Printer)
-        test_filetype_to_instance(".some_unknown_extention_42", can.Printer)
         with can.Logger(None) as logger:
             self.assertIsInstance(logger, can.Printer)
+
+        # test file extensions that should use a fallback
+        should_fail_with = ["", ".", ".some_unknown_extention_42"]
+        for supposed_fail in should_fail_with:
+            with self.assertRaises(ValueError):
+                with can.Logger(supposed_fail):  # make sure we close it anyways
+                    pass
 
     def testBufferedListenerReceives(self):
         a_listener = can.BufferedReader()

--- a/test/listener_test.py
+++ b/test/listener_test.py
@@ -111,9 +111,11 @@ class ListenerTest(BusTest):
         test_filetype_to_instance(".db", can.SqliteReader)
         test_filetype_to_instance(".log", can.CanutilsLogReader)
 
-        # test file extensions that are not supported
-        with self.assertRaisesRegex(NotImplementedError, ".xyz_42"):
-            test_filetype_to_instance(".xyz_42", can.Printer)
+    def testPlayerTypeResolutionUnsupportedFileTypes(self):
+        for should_fail_with in ["", ".", ".some_unknown_extention_42"]:
+            with self.assertRaises(ValueError):
+                with can.LogReader(should_fail_with):  # make sure we close it anyways
+                    pass
 
     def testLoggerTypeResolution(self):
         def test_filetype_to_instance(extension, klass):
@@ -138,10 +140,10 @@ class ListenerTest(BusTest):
         with can.Logger(None) as logger:
             self.assertIsInstance(logger, can.Printer)
 
-        should_fail_with = ["", ".", ".some_unknown_extention_42"]
-        for supposed_fail in should_fail_with:
+    def testLoggerTypeResolutionUnsupportedFileTypes(self):
+        for should_fail_with in ["", ".", ".some_unknown_extention_42"]:
             with self.assertRaises(ValueError):
-                with can.Logger(supposed_fail):  # make sure we close it anyways
+                with can.Logger(should_fail_with):  # make sure we close it anyways
                     pass
 
     def testBufferedListenerReceives(self):

--- a/test/listener_test.py
+++ b/test/listener_test.py
@@ -138,7 +138,6 @@ class ListenerTest(BusTest):
         with can.Logger(None) as logger:
             self.assertIsInstance(logger, can.Printer)
 
-        # test file extensions that should use a fallback
         should_fail_with = ["", ".", ".some_unknown_extention_42"]
         for supposed_fail in should_fail_with:
             with self.assertRaises(ValueError):

--- a/test/logformats_test.py
+++ b/test/logformats_test.py
@@ -459,7 +459,10 @@ class TestSqliteDatabaseFormat(ReaderWriterTest):
 
 
 class TestPrinter(unittest.TestCase):
-    """Tests that can.Printer does not crash"""
+    """Tests that can.Printer does not crash
+
+    TODO test append mode
+    """
 
     # TODO add CAN FD messages
     messages = (


### PR DESCRIPTION
I added typing to:
- `can/io/generic.py`
- `can/io/logger.py`
- `can/io/player.py`

`Printer` now has a append mode. About 4 lines were changed and it made the `Logger` more uniform.

The API of `Logger` and `Player` was changed slightly.

I introduced new types in `can/typechecking.py`.