### PR TITLE
Add typing annotations for can.listener

### DIFF
--- a/can/bus.py
+++ b/can/bus.py
@@ -15,7 +15,8 @@ import threading
 from time import time
 from aenum import Enum, auto
 
-from .broadcastmanager import ThreadBasedCyclicSendTask
+from can.broadcastmanager import ThreadBasedCyclicSendTask
+from can.message import Message
 
 LOG = logging.getLogger(__name__)
 
@@ -68,14 +69,14 @@ class BusABC(metaclass=ABCMeta):
     def __str__(self) -> str:
         return self.channel_info
 
-    def recv(self, timeout: Optional[float] = None) -> Optional[can.Message]:
+    def recv(self, timeout: Optional[float] = None) -> Optional[Message]:
         """Block waiting for a message from the Bus.
 
         :param timeout:
             seconds to wait for a message or None to wait indefinitely
 
         :return:
-            None on timeout or a :class:`can.Message` object.
+            None on timeout or a :class:`Message` object.
         :raises can.CanError:
             if an error occurred while reading
         """
@@ -109,7 +110,7 @@ class BusABC(metaclass=ABCMeta):
 
     def _recv_internal(
         self, timeout: Optional[float]
-    ) -> Tuple[Optional[can.Message], bool]:
+    ) -> Tuple[Optional[Message], bool]:
         """
         Read a message from the bus and tell whether it was filtered.
         This methods may be called by :meth:`~can.BusABC.recv`
@@ -152,12 +153,12 @@ class BusABC(metaclass=ABCMeta):
         raise NotImplementedError("Trying to read from a write only bus?")
 
     @abstractmethod
-    def send(self, msg: can.Message, timeout: Optional[float] = None):
+    def send(self, msg: Message, timeout: Optional[float] = None):
         """Transmit a message to the CAN bus.
 
         Override this method to enable the transmit path.
 
-        :param can.Message msg: A message object.
+        :param Message msg: A message object.
 
         :param timeout:
             If > 0, wait up to this many seconds for message to be ACK'ed or
@@ -173,7 +174,7 @@ class BusABC(metaclass=ABCMeta):
 
     def send_periodic(
         self,
-        msgs: Union[Sequence[can.Message], can.Message],
+        msgs: Union[Sequence[Message], Message],
         period: float,
         duration: Optional[float] = None,
         store_task: bool = True,
@@ -217,7 +218,7 @@ class BusABC(metaclass=ABCMeta):
             are associated with the Bus instance.
         """
         if not isinstance(msgs, (list, tuple)):
-            if isinstance(msgs, can.Message):
+            if isinstance(msgs, Message):
                 msgs = [msgs]
             else:
                 raise ValueError("Must be either a list, tuple, or a Message")
@@ -244,7 +245,7 @@ class BusABC(metaclass=ABCMeta):
 
     def _send_periodic_internal(
         self,
-        msgs: Union[Sequence[can.Message], can.Message],
+        msgs: Union[Sequence[Message], Message],
         period: float,
         duration: Optional[float] = None,
     ) -> can.broadcastmanager.CyclicSendTaskABC:
@@ -291,7 +292,7 @@ class BusABC(metaclass=ABCMeta):
         if remove_tasks:
             self._periodic_tasks = []
 
-    def __iter__(self) -> Iterator[can.Message]:
+    def __iter__(self) -> Iterator[Message]:
         """Allow iteration on messages as they are received.
 
             >>> for msg in bus:
@@ -299,7 +300,7 @@ class BusABC(metaclass=ABCMeta):
 
 
         :yields:
-            :class:`can.Message` msg objects.
+            :class:`Message` msg objects.
         """
         while True:
             msg = self.recv(timeout=1.0)
@@ -352,7 +353,7 @@ class BusABC(metaclass=ABCMeta):
             See :meth:`~can.BusABC.set_filters` for details.
         """
 
-    def _matches_filters(self, msg: can.Message) -> bool:
+    def _matches_filters(self, msg: Message) -> bool:
         """Checks whether the given message matches at least one of the
         current filters. See :meth:`~can.BusABC.set_filters` for details
         on how the filters work.

--- a/can/listener.py
+++ b/can/listener.py
@@ -4,6 +4,11 @@
 This module contains the implementation of `can.Listener` and some readers.
 """
 
+from typing import AsyncIterator, Awaitable, Optional
+
+from can.message import Message
+from can.bus import BusABC
+
 from abc import ABCMeta, abstractmethod
 
 try:
@@ -33,20 +38,20 @@ class Listener(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def on_message_received(self, msg):
+    def on_message_received(self, msg: Message):
         """This method is called to handle the given message.
 
-        :param can.Message msg: the delivered message
+        :param msg: the delivered message
 
         """
 
-    def __call__(self, msg):
-        return self.on_message_received(msg)
+    def __call__(self, msg: Message):
+        self.on_message_received(msg)
 
-    def on_error(self, exc):
+    def on_error(self, exc: Exception):
         """This method is called to handle any exception in the receive thread.
 
-        :param Exception exc: The exception causing the thread to stop
+        :param exc: The exception causing the thread to stop
         """
 
     def stop(self):
@@ -64,10 +69,10 @@ class RedirectReader(Listener):
 
     """
 
-    def __init__(self, bus):
+    def __init__(self, bus: BusABC):
         self.bus = bus
 
-    def on_message_received(self, msg):
+    def on_message_received(self, msg: Message):
         self.bus.send(msg)
 
 
@@ -90,7 +95,7 @@ class BufferedReader(Listener):
         self.buffer = SimpleQueue()
         self.is_stopped = False
 
-    def on_message_received(self, msg):
+    def on_message_received(self, msg: Message):
         """Append a message to the buffer.
 
         :raises: BufferError
@@ -101,16 +106,15 @@ class BufferedReader(Listener):
         else:
             self.buffer.put(msg)
 
-    def get_message(self, timeout=0.5):
+    def get_message(self, timeout: float = 0.5) -> Optional[Message]:
         """
         Attempts to retrieve the latest message received by the instance. If no message is
         available it blocks for given timeout or until a message is received, or else
         returns None (whichever is shorter). This method does not block after
         :meth:`can.BufferedReader.stop` has been called.
 
-        :param float timeout: The number of seconds to wait for a new message.
-        :rytpe: can.Message or None
-        :return: the message if there is one, or None if there is not.
+        :param timeout: The number of seconds to wait for a new message.
+        :return: the Message if there is one, or None if there is not.
         """
         try:
             return self.buffer.get(block=not self.is_stopped, timeout=timeout)
@@ -134,30 +138,29 @@ class AsyncBufferedReader(Listener):
             print(msg)
     """
 
-    def __init__(self, loop=None):
+    def __init__(self, loop: Optional[asyncio.events.AbstractEventLoop] = None):
         # set to "infinite" size
-        self.buffer = asyncio.Queue(loop=loop)
+        self.buffer: "asyncio.Queue[Message]" = asyncio.Queue(loop=loop)
 
-    def on_message_received(self, msg):
+    def on_message_received(self, msg: Message):
         """Append a message to the buffer.
 
         Must only be called inside an event loop!
         """
         self.buffer.put_nowait(msg)
 
-    async def get_message(self):
+    async def get_message(self) -> Message:
         """
         Retrieve the latest message when awaited for::
 
             msg = await reader.get_message()
 
-        :rtype: can.Message
         :return: The CAN message.
         """
         return await self.buffer.get()
 
-    def __aiter__(self):
+    def __aiter__(self) -> AsyncIterator[Message]:
         return self
 
-    def __anext__(self):
+    def __anext__(self) -> Awaitable[Message]:
         return self.buffer.get()


### PR DESCRIPTION
This adds typing annotations for functions in can.listener.

In addition, this remove the redundant typing information that was
previously in the docstring, since we now have sphinx-autodoc-typehints
to generate the types for the docs from the annotations in the function
signature.

This works towards PEP 561 compatibility.