### PR TITLE
Remove deprecated SocketCAN interfaces from list

### DIFF
--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -34,6 +34,4 @@ BACKENDS.update(
     }
 )
 
-VALID_INTERFACES = frozenset(
-    list(BACKENDS.keys()) + ["socketcan_native", "socketcan_ctypes"]
-)
+VALID_INTERFACES = frozenset(list(BACKENDS.keys()))


### PR DESCRIPTION
The SocketCAN interface used to be split into socketcan_native and
socketcan_ctypes interfaces. However, these have now been deprecated,
with a deprecation window throughout 3.*.* releases. The code relevant
to these interfaces has already been cleaned up, but it seems like these
references were missed in the process.