### PR TITLE
Allow message sequence in bus.send

### DIFF
--- a/can/interfaces/canalystii.py
+++ b/can/interfaces/canalystii.py
@@ -135,7 +135,7 @@ class CANalystIIBus(BusABC):
                 self.shutdown()
                 return
 
-    def send(self, msg, timeout=None):
+    def _send_internal(self, msg, timeout=None):
         """
 
         :param msg: message to send

--- a/can/interfaces/iscan.py
+++ b/can/interfaces/iscan.py
@@ -120,7 +120,7 @@ class IscanBus(BusABC):
         )
         return msg, False
 
-    def send(self, msg, timeout=None):
+    def _send_internal(self, msg, timeout=None):
         raw_msg = MessageExStruct(
             msg.arbitration_id,
             bool(msg.is_extended_id),

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -670,7 +670,7 @@ class IXXATBus(BusABC):
 
         return rx_msg, True
 
-    def send(self, msg, timeout=None):
+    def _send_internal(self, msg, timeout=None):
 
         # This system is not designed to be very efficient
         message = structures.CANMSG()

--- a/can/interfaces/kvaser/canlib.py
+++ b/can/interfaces/kvaser/canlib.py
@@ -592,7 +592,7 @@ class KvaserBus(BusABC):
             # log.debug('read complete -> status not okay')
             return None, self._is_filtered
 
-    def send(self, msg, timeout=None):
+    def _send_internal(self, msg, timeout=None):
         # log.debug("Writing a message: {}".format(msg))
         flags = canstat.canMSG_EXT if msg.is_extended_id else canstat.canMSG_STD
         if msg.is_remote_frame:

--- a/can/interfaces/nican.py
+++ b/can/interfaces/nican.py
@@ -276,7 +276,7 @@ class NicanBus(BusABC):
         )
         return msg, True
 
-    def send(self, msg, timeout=None):
+    def _send_internal(self, msg, timeout=None):
         """
         Send a message to NI-CAN.
 

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -375,7 +375,7 @@ class PcanBus(BusABC):
 
         return rx_msg, False
 
-    def send(self, msg, timeout=None):
+    def _send_internal(self, msg, timeout=None):
         msgType = (
             PCAN_MESSAGE_EXTENDED.value
             if msg.is_extended_id

--- a/can/interfaces/seeedstudio/seeedstudio.py
+++ b/can/interfaces/seeedstudio/seeedstudio.py
@@ -163,7 +163,7 @@ class SeeedBus(BusABC):
         logger.debug("status_frm:\t%s", byte_msg.hex())
         self.ser.write(byte_msg)
 
-    def send(self, msg, timeout=None):
+    def _send_internal(self, msg, timeout=None):
         """
         Send a message over the serial device.
 

--- a/can/interfaces/serial/serial_can.py
+++ b/can/interfaces/serial/serial_can.py
@@ -70,7 +70,7 @@ class SerialBus(BusABC):
         """
         self.ser.close()
 
-    def send(self, msg, timeout=None):
+    def _send_internal(self, msg, timeout=None):
         """
         Send a message over the serial device.
 

--- a/can/interfaces/slcan.py
+++ b/can/interfaces/slcan.py
@@ -225,7 +225,7 @@ class slcanBus(BusABC):
             return msg, False
         return None, False
 
-    def send(self, msg, timeout=None):
+    def _send_internal(self, msg, timeout=None):
         if timeout != self.serialPortOrig.write_timeout:
             self.serialPortOrig.write_timeout = timeout
         if msg.is_remote_frame:

--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -619,7 +619,7 @@ class SocketcanBus(BusABC):
             # socket wasn't readable or timeout occurred
             return None, self._is_filtered
 
-    def send(self, msg, timeout=None):
+    def _send_internal(self, msg, timeout=None):
         """Transmit a message to the CAN bus.
 
         :param can.Message msg: A message object.

--- a/can/interfaces/systec/ucanbus.py
+++ b/can/interfaces/systec/ucanbus.py
@@ -151,7 +151,7 @@ class UcanBus(BusABC):
         )
         return msg, self._is_filtered
 
-    def send(self, msg, timeout=None):
+    def _send_internal(self, msg, timeout=None):
         """
         Sends one CAN message.
 

--- a/can/interfaces/usb2can/usb2canInterface.py
+++ b/can/interfaces/usb2can/usb2canInterface.py
@@ -119,7 +119,7 @@ class Usb2canBus(BusABC):
             channel=channel, dll=dll, flags_t=flags_t, bitrate=bitrate, *args, **kwargs
         )
 
-    def send(self, msg, timeout=None):
+    def _send_internal(self, msg, timeout=None):
         tx = message_convert_tx(msg)
 
         if timeout:

--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -449,7 +449,7 @@ class VectorBus(BusABC):
                 # Wait a short time until we try again
                 time.sleep(self.poll_interval)
 
-    def send(self, msg, timeout=None):
+    def _send_internal(self, msg, timeout=None):
         msg_id = msg.arbitration_id
 
         if msg.is_extended_id:

--- a/can/interfaces/virtual.py
+++ b/can/interfaces/virtual.py
@@ -84,7 +84,7 @@ class VirtualBus(BusABC):
         else:
             return msg, False
 
-    def send(self, msg, timeout=None):
+    def _send_internal(self, msg, timeout=None):
         self._check_if_open()
 
         msg_copy = deepcopy(msg)


### PR DESCRIPTION
I have only optimize the neovi bus to handle messages sequence. Other interfaces will have to be modified if their API support it.

- [x] Agree on the new API
- [ ] update doc/internal-api.rst#extending-the-busabc-class accordingly.