### PR TITLE
Ignore error frames in can.player by default

### DIFF
--- a/can/player.py
+++ b/can/player.py
@@ -74,6 +74,12 @@ def main():
     )
 
     parser.add_argument(
+        "--error-frames",
+        help="Also send error frames to the interface.",
+        action="store_true",
+    )
+
+    parser.add_argument(
         "-g",
         "--gap",
         type=float,
@@ -111,6 +117,8 @@ def main():
     ]
     can.set_logging_level(logging_level_name)
 
+    error_frames = results.error_frames
+
     config = {"single_handle": True}
     if results.interface:
         config["interface"] = results.interface
@@ -132,6 +140,8 @@ def main():
 
     try:
         for m in in_sync:
+            if m.is_error_frame and not error_frames:
+                continue
             if verbosity >= 3:
                 print(m)
             bus.send(m)


### PR DESCRIPTION
They are usually not of interest and may fill up the transmit buffer.

Fixes #683