### PR TITLE
Fix crash in Canutils Log Reader when parsing RTR frames

### DIFF
--- a/can/io/canutils.py
+++ b/can/io/canutils.py
@@ -56,10 +56,13 @@ class CanutilsLogReader(BaseIOHandler):
 
             if data and data[0].lower() == "r":
                 isRemoteFrame = True
+
                 if len(data) > 1:
                     dlc = int(data[1:])
                 else:
                     dlc = 0
+
+                dataBin = None
             else:
                 isRemoteFrame = False
 


### PR DESCRIPTION
Variable dataBin in CanutilsLogReader was not defined before it was accessed when reading remote frames.