### PR TITLE
Fix typing annotation for LogReader constructor

### DIFF
--- a/can/io/player.py
+++ b/can/io/player.py
@@ -45,7 +45,7 @@ class LogReader(BaseIOHandler):
     """
 
     @staticmethod
-    def __new__(cls, filename: "can.typechecking.PathLike", *args, **kwargs):
+    def __new__(cls, filename: "can.typechecking.StringPathLike", *args, **kwargs):
         """
         :param filename: the filename/path of the file to read from
         :raises ValueError: if the filename's suffix is of an unknown file type


### PR DESCRIPTION
A bug was introduced sometime during refactoring of types in the helper
typechecking.py file, when PathLike was renamed to StringPathLike. This
results in mypy complaining that it can't find the PathLike type:

    error: Name 'can.typechecking.PathLike' is not defined

As such, this changes the accepted type for the LogReader constructor
to be a typechecking.StringPathLike.