### PR TITLE
Bump mypy version in lint step to 0.740

### DIFF
--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,4 +1,4 @@
 pylint==2.3.1
 black==19.3b0
-mypy==0.720
+mypy==0.740
 mypy-extensions==0.4.1


### PR DESCRIPTION
Update the version of mypy used in the CI Linter step to the latest
release.