### PR TITLE
Bump Python 3.8 from dev version in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
   # CPython; only 3.6 is supported
   - "3.6"
   - "3.7"
-  - 3.8-dev
+  - "3.8"
   - nightly
   # PyPy:
   - pypy3
@@ -39,7 +39,6 @@ jobs:
   allow_failures:
     # we allow all dev & nightly builds to fail, since these python versions might
     # still be very unstable
-    - python: 3.8-dev
     - python: nightly
 
   include:


### PR DESCRIPTION
Python 3.8 was released on October 14, 2019 and support was added to
pyenv as well, which was the dependency needed by Travis. This promotes
the version of Python 3.8 we were using from the development build to
the official release.