### PR TITLE
Fix example usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Example usage
 
     # iterate over received messages
     for msg in bus:
-        print("{X}: {}".format(msg.arbitration_id, msg.data))
+        print("{:X}: {}".format(msg.arbitration_id, msg.data))
 
     # or use an asynchronous notifier
     notifier = can.Notifier(bus, [can.Logger("recorded.log"), can.Printer()])


### PR DESCRIPTION
Code example does not work with python 3.6.
A colon is required so that the X is recognized as formatting specifier.