### PR TITLE
Update test deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,11 @@ extras_require = {
 }
 
 tests_require = [
-    "pytest~=4.3",
+    "pytest~=5.3",
     "pytest-timeout~=1.3",
-    "pytest-cov~=2.6",
+    "pytest-cov~=2.8",
     "codecov~=2.0",
-    "hypothesis",
+    "hypothesis~=4.56",
 ] + extras_require["serial"]
 
 extras_require["test"] = tests_require

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,9 @@ tests_require = [
     "pytest~=5.3",
     "pytest-timeout~=1.3",
     "pytest-cov~=2.8",
+    # coveragepy==5.0 fails with `Safety level may not be changed inside a transaction`
+    # on python 3.6 on MACOS
+    "coverage<5",
     "codecov~=2.0",
     "hypothesis~=4.56",
 ] + extras_require["serial"]


### PR DESCRIPTION
Pinning an old version of `coverage` avoids a coverage bug we are running into (on develop)[https://travis-ci.org/hardbyte/python-can/jobs/626637286] with travis on MACOS on Python3.6.0 where after the tests are complete we get an internal error:

```
INTERNALERROR> Traceback (most recent call last):

INTERNALERROR>   File "/Users/travis/virtualenv/python3.6-dev/lib/python3.6/site-packages/coverage/sqldata.py", line 1032, in execute

INTERNALERROR>     return self.con.execute(sql, parameters)

INTERNALERROR> sqlite3.OperationalError: Safety level may not be changed inside a transaction

INTERNALERROR> 
```

Appears to be https://github.com/nedbat/coveragepy/issues/703

