### PR TITLE
Add socket object to mimic the behaviour of SocketCAN for all interfaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,7 @@ jobs:
           can/message.py
           can/notifier.py
           can/player.py
+          can/socket.py
           can/thread_safe_bus.py
           can/typechecking.py
           can/util.py

--- a/can/__init__.py
+++ b/can/__init__.py
@@ -32,6 +32,7 @@ from .util import set_logging_level
 
 from .message import Message
 from .bus import BusABC, BusState
+from .socket import Socket
 from .thread_safe_bus import ThreadSafeBus
 from .notifier import Notifier
 from .interfaces import VALID_INTERFACES

--- a/can/socket.py
+++ b/can/socket.py
@@ -15,7 +15,8 @@ log = logging.getLogger("can.socket")
 log_autodetect = log.getChild("detect_available_configs")
 
 
-class SocketsThreadPool(object):
+class SocketsThreadPool:
+    # pylint: disable=no-member
     __instance = None
 
     def __new__(cls):
@@ -34,7 +35,7 @@ class SocketsThreadPool(object):
                     bus, _, _, sockets = self.buses[k]
                 except KeyError:
                     return
-            if len(sockets) == 0:
+            if not sockets:
                 return
             msg = bus.recv(timeout=0.01)
             if msg is None:
@@ -50,7 +51,7 @@ class SocketsThreadPool(object):
                     bus, tx_queue, tx_signal, sockets = self.buses[k]
                 except KeyError:
                     return
-            if len(sockets) == 0:
+            if not sockets:
                 return
             try:
                 tx_signal.acquire()
@@ -79,7 +80,7 @@ class SocketsThreadPool(object):
             bus, tx_queue, tx_signal, sockets = self.buses[k]
             sockets.append(socket)
             filters = [s.filters for s in sockets if s.filters is not None]
-            if len(filters):
+            if filters:
                 bus.set_filters(reduce(add, filters))
             socket.tx_queue = tx_queue
             socket.tx_signal = tx_signal
@@ -111,7 +112,7 @@ class SocketsThreadPool(object):
 
         for k, v in self.buses.copy().items():
             bus, _, tx_signal, sockets = v
-            if len(sockets) == 0:
+            if not sockets:
                 with self.buses_mutex:
                     del self.buses[k]
                 tx_signal.release()

--- a/can/socket.py
+++ b/can/socket.py
@@ -1,0 +1,149 @@
+import logging
+import queue
+import threading
+import time
+import copy
+
+from functools import reduce
+from operator import add
+
+from .interface import Bus
+from .bus import BusABC
+from . import CanError
+
+log = logging.getLogger("can.socket")
+log_autodetect = log.getChild("detect_available_configs")
+
+
+class SocketsThreadPool(object):
+    __instance = None
+
+    def __new__(cls):
+        if SocketsThreadPool.__instance is None:
+            SocketsThreadPool.__instance = object.__new__(cls)
+            SocketsThreadPool.__instance.buses = dict()
+            SocketsThreadPool.__instance.rx_threads = dict()
+            SocketsThreadPool.__instance.tx_threads = dict()
+            SocketsThreadPool.__instance.buses_mutex = threading.Lock()
+        return SocketsThreadPool.__instance
+
+    def recv_function(self, k):
+        while True:
+            with self.buses_mutex:
+                try:
+                    bus, _, _, sockets = self.buses[k]
+                except KeyError:
+                    return
+            if len(sockets) == 0:
+                return
+            msg = bus.recv(timeout=0.01)
+            if msg is None:
+                continue
+            for sock in sockets:
+                sock.rx_queue.put(msg)
+
+    def send_function(self, k):
+        while True:
+            with self.buses_mutex:
+                try:
+                    bus, tx_queue, tx_signal, sockets = self.buses[k]
+                except KeyError:
+                    return
+            if len(sockets) == 0:
+                return
+            try:
+                tx_signal.acquire()
+                sender, msg = tx_queue.get(timeout=0.001)
+            except queue.Empty:
+                continue
+            bus.send(msg)
+            m = copy.copy(msg)
+            for sock in sockets:
+                m.timestamp = time.time()
+                if sock != sender and sock._matches_filters(m):
+                    sock.rx_queue.put(m)
+
+    def register(self, socket, *args, **kwargs):
+        k = str(kwargs.get("bustype", "unknown_bustype") + "_" +
+                kwargs.get("channel", "unknown_channel") + "_" +
+                kwargs.get("interface", "unknown_interface"))
+        if k in self.buses:
+            bus, tx_queue, tx_signal, sockets = self.buses[k]
+            sockets.append(socket)
+            filters = [s.filters for s in sockets if s.filters is not None]
+            if len(filters):
+                bus.set_filters(reduce(add, filters))
+            socket.tx_queue = tx_queue
+            socket.tx_signal = tx_signal
+            with self.buses_mutex:
+                self.buses[k] = (bus, tx_queue, tx_signal, sockets)
+        else:
+            bus = Bus(*args, **kwargs)
+            tx_queue = queue.Queue()
+            tx_signal = threading.Semaphore(0)
+            socket.tx_queue = tx_queue
+            socket.tx_signal = tx_signal
+            with self.buses_mutex:
+                self.buses[k] = (bus, tx_queue, tx_signal, [socket])
+            self.rx_threads[k] = threading.Thread(
+                target=self.recv_function, args=(k,))
+            self.tx_threads[k] = threading.Thread(
+                target=self.send_function, args=(k,))
+            self.rx_threads[k].start()
+            self.tx_threads[k].start()
+
+    def unregister(self, socket):
+        for k, v in self.buses.copy().items():
+            bus, tx_queue, tx_signal, sockets = v
+            if socket in sockets:
+                sockets.remove(socket)
+            with self.buses_mutex:
+                self.buses[k] = (bus, tx_queue, tx_signal, sockets)
+
+        # give receiver thread time to exit recv with timeout
+        time.sleep(0.01)
+
+        for k, v in self.buses.copy().items():
+            bus, _, tx_signal, sockets = v
+            if len(sockets) == 0:
+                with self.buses_mutex:
+                    del self.buses[k]
+                tx_signal.release()
+                self.rx_threads[k].join()
+                self.tx_threads[k].join()
+                bus.shutdown()
+                del self.rx_threads[k]
+                del self.tx_threads[k]
+
+
+class Socket(BusABC):
+    """Socket for specific Bus or Interface.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super(Socket, self).__init__(*args, **kwargs)
+        self.rx_queue = queue.Queue()
+        self.tx_queue = None
+        self.tx_signal = None
+        SocketsThreadPool().register(self, *args, **kwargs)
+
+    def _recv_internal(self, timeout):
+        try:
+            return self.rx_queue.get(block=True, timeout=timeout), True
+        except queue.Empty:
+            return None, True
+
+    def send(self, msg, timeout=None):
+        try:
+            self.tx_queue.put((self, msg), block=True, timeout=timeout)
+            self.tx_signal.release()
+        except queue.Full:
+            raise CanError
+
+    def shutdown(self):
+        SocketsThreadPool().unregister(self)
+
+    @staticmethod
+    def select(sockets, *args, **kwargs):
+        return [s for s in sockets if not s.rx_queue.empty()], [], []
+

--- a/can/socket.py
+++ b/can/socket.py
@@ -68,9 +68,13 @@ class SocketsThreadPool(object):
                 continue
 
     def register(self, socket, *args, **kwargs):
-        k = str(kwargs.get("bustype", "unknown_bustype") + "_" +
-                kwargs.get("channel", "unknown_channel") + "_" +
-                kwargs.get("interface", "unknown_interface"))
+        k = str(
+            kwargs.get("bustype", "unknown_bustype")
+            + "_"
+            + kwargs.get("channel", "unknown_channel")
+            + "_"
+            + kwargs.get("interface", "unknown_interface")
+        )
         if k in self.buses:
             bus, tx_queue, tx_signal, sockets = self.buses[k]
             sockets.append(socket)
@@ -89,10 +93,8 @@ class SocketsThreadPool(object):
             socket.tx_signal = tx_signal
             with self.buses_mutex:
                 self.buses[k] = (bus, tx_queue, tx_signal, [socket])
-            self.rx_threads[k] = threading.Thread(
-                target=self.recv_function, args=(k,))
-            self.tx_threads[k] = threading.Thread(
-                target=self.send_function, args=(k,))
+            self.rx_threads[k] = threading.Thread(target=self.recv_function, args=(k,))
+            self.tx_threads[k] = threading.Thread(target=self.send_function, args=(k,))
             self.rx_threads[k].start()
             self.tx_threads[k].start()
 

--- a/can/socket.py
+++ b/can/socket.py
@@ -130,7 +130,7 @@ class Socket(BusABC):
 
     def __init__(self, *args, **kwargs) -> None:
         super(Socket, self).__init__(*args, **kwargs)
-        self.rx_queue = queue.Queue() # type: queue.Queue[Message]
+        self.rx_queue = queue.Queue()  # type: queue.Queue[Message]
         self.tx_queue = None
         self.tx_signal = None
         SocketsThreadPool().register(self, *args, **kwargs)

--- a/can/socket.py
+++ b/can/socket.py
@@ -130,7 +130,7 @@ class Socket(BusABC):
 
     def __init__(self, *args, **kwargs) -> None:
         super(Socket, self).__init__(*args, **kwargs)
-        self.rx_queue: queue.Queue[Message] = queue.Queue()
+        self.rx_queue = queue.Queue() # type: queue.Queue[Message]
         self.tx_queue = None
         self.tx_signal = None
         SocketsThreadPool().register(self, *args, **kwargs)

--- a/can/socket.py
+++ b/can/socket.py
@@ -10,6 +10,7 @@ from operator import add
 from .interface import Bus
 from .bus import BusABC
 from . import CanError
+from .message import Message
 
 log = logging.getLogger("can.socket")
 log_autodetect = log.getChild("detect_available_configs")
@@ -129,7 +130,7 @@ class Socket(BusABC):
 
     def __init__(self, *args, **kwargs) -> None:
         super(Socket, self).__init__(*args, **kwargs)
-        self.rx_queue = queue.Queue()
+        self.rx_queue: queue.Queue[Message] = queue.Queue()
         self.tx_queue = None
         self.tx_signal = None
         SocketsThreadPool().register(self, *args, **kwargs)

--- a/test/test_cyclic_socket.py
+++ b/test/test_cyclic_socket.py
@@ -48,10 +48,16 @@ class CyclicSocketCanFiltering(unittest.TestCase):
             interface=self.INTERFACE_1, channel=self.CHANNEL_1, bitrate=self.BITRATE
         )
         self._recv_bus1 = can.Socket(
-            interface=self.INTERFACE_2, channel=self.CHANNEL_2, bitrate=self.BITRATE, can_filters=[{"can_id": 0x100, "can_mask": 0x7ff, "extended": False}]
+            interface=self.INTERFACE_2,
+            channel=self.CHANNEL_2,
+            bitrate=self.BITRATE,
+            can_filters=[{"can_id": 0x100, "can_mask": 0x7FF, "extended": False}],
         )
         self._recv_bus2 = can.Socket(
-            interface=self.INTERFACE_3, channel=self.CHANNEL_3, bitrate=self.BITRATE, can_filters=[{"can_id": 0x200, "can_mask": 0x7ff, "extended": False}]
+            interface=self.INTERFACE_3,
+            channel=self.CHANNEL_3,
+            bitrate=self.BITRATE,
+            can_filters=[{"can_id": 0x200, "can_mask": 0x7FF, "extended": False}],
         )
         self._recv_bus3 = can.Socket(
             interface=self.INTERFACE_4, channel=self.CHANNEL_4, bitrate=self.BITRATE
@@ -108,10 +114,14 @@ class CyclicSocketCanFiltering(unittest.TestCase):
             )
         )
 
-        task1 = self._send_bus.send_periodic([m for m in messages if m.arbitration_id == 0x100], self.PERIOD)
+        task1 = self._send_bus.send_periodic(
+            [m for m in messages if m.arbitration_id == 0x100], self.PERIOD
+        )
         self.assertIsInstance(task1, can.broadcastmanager.CyclicSendTaskABC)
         time.sleep(self.PERIOD / 2)
-        task2 = self._send_bus.send_periodic([m for m in messages if m.arbitration_id == 0x200], self.PERIOD)
+        task2 = self._send_bus.send_periodic(
+            [m for m in messages if m.arbitration_id == 0x200], self.PERIOD
+        )
         self.assertIsInstance(task1, can.broadcastmanager.CyclicSendTaskABC)
 
         results1 = []
@@ -168,17 +178,13 @@ class CyclicSocketCanFiltering(unittest.TestCase):
             tx_message = messages[start_index]
 
             self.assertIsNotNone(rx_message)
-            self.assertEqual(tx_message.arbitration_id,
-                             rx_message.arbitration_id)
+            self.assertEqual(tx_message.arbitration_id, rx_message.arbitration_id)
             self.assertEqual(0x200, rx_message.arbitration_id)
             self.assertEqual(tx_message.dlc, rx_message.dlc)
             self.assertEqual(tx_message.data, rx_message.data)
-            self.assertEqual(tx_message.is_extended_id,
-                             rx_message.is_extended_id)
-            self.assertEqual(tx_message.is_remote_frame,
-                             rx_message.is_remote_frame)
-            self.assertEqual(tx_message.is_error_frame,
-                             rx_message.is_error_frame)
+            self.assertEqual(tx_message.is_extended_id, rx_message.is_extended_id)
+            self.assertEqual(tx_message.is_remote_frame, rx_message.is_remote_frame)
+            self.assertEqual(tx_message.is_error_frame, rx_message.is_error_frame)
             self.assertEqual(tx_message.is_fd, rx_message.is_fd)
 
             start_index = (start_index + 2) % len(messages)
@@ -192,16 +198,12 @@ class CyclicSocketCanFiltering(unittest.TestCase):
             tx_message = messages[start_index]
 
             self.assertIsNotNone(rx_message)
-            self.assertEqual(tx_message.arbitration_id,
-                             rx_message.arbitration_id)
+            self.assertEqual(tx_message.arbitration_id, rx_message.arbitration_id)
             self.assertEqual(tx_message.dlc, rx_message.dlc)
             self.assertEqual(tx_message.data, rx_message.data)
-            self.assertEqual(tx_message.is_extended_id,
-                             rx_message.is_extended_id)
-            self.assertEqual(tx_message.is_remote_frame,
-                             rx_message.is_remote_frame)
-            self.assertEqual(tx_message.is_error_frame,
-                             rx_message.is_error_frame)
+            self.assertEqual(tx_message.is_extended_id, rx_message.is_extended_id)
+            self.assertEqual(tx_message.is_remote_frame, rx_message.is_remote_frame)
+            self.assertEqual(tx_message.is_error_frame, rx_message.is_error_frame)
             self.assertEqual(tx_message.is_fd, rx_message.is_fd)
 
             start_index = (start_index + 1) % len(messages)

--- a/test/test_cyclic_socket.py
+++ b/test/test_cyclic_socket.py
@@ -1,0 +1,557 @@
+"""
+This module tests multiple message cyclic send tasks.
+"""
+import unittest
+
+import time
+import can
+
+from .config import TEST_INTERFACE_SOCKETCAN
+
+
+@unittest.skipUnless(TEST_INTERFACE_SOCKETCAN, "skip testing of socketcan")
+class CyclicSocketCan(unittest.TestCase):
+    BITRATE = 500000
+    TIMEOUT = 0.1
+
+    INTERFACE_1 = "socketcan"
+    CHANNEL_1 = "vcan0"
+    INTERFACE_2 = "socketcan"
+    CHANNEL_2 = "vcan0"
+
+    PERIOD = 1.0
+
+    DELTA = 0.01
+
+    def _find_start_index(self, tx_messages, message):
+        """
+        :param tx_messages:
+            The list of messages that were passed to the periodic backend
+        :param message:
+            The message whose data we wish to match and align to
+
+        :returns: start index in the tx_messages
+        """
+        start_index = -1
+        for index, tx_message in enumerate(tx_messages):
+            if tx_message.data == message.data:
+                start_index = index
+                break
+        return start_index
+
+    def setUp(self):
+        self._send_bus = can.Socket(
+            interface=self.INTERFACE_1, channel=self.CHANNEL_1, bitrate=self.BITRATE
+        )
+        self._recv_bus = can.Socket(
+            interface=self.INTERFACE_2, channel=self.CHANNEL_2, bitrate=self.BITRATE
+        )
+
+    def tearDown(self):
+        self._send_bus.shutdown()
+        self._recv_bus.shutdown()
+
+    def test_cyclic_initializer_list(self):
+        messages = []
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+                is_extended_id=False,
+            )
+        )
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x22, 0x22, 0x22, 0x22, 0x22, 0x22],
+                is_extended_id=False,
+            )
+        )
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x33, 0x33, 0x33, 0x33, 0x33, 0x33],
+                is_extended_id=False,
+            )
+        )
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x44, 0x44, 0x44, 0x44, 0x44, 0x44],
+                is_extended_id=False,
+            )
+        )
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x55, 0x55, 0x55, 0x55, 0x55, 0x55],
+                is_extended_id=False,
+            )
+        )
+
+        task = self._send_bus.send_periodic(messages, self.PERIOD)
+        self.assertIsInstance(task, can.broadcastmanager.CyclicSendTaskABC)
+
+        results = []
+        for _ in range(len(messages) * 2):
+            result = self._recv_bus.recv(self.PERIOD * 2)
+            if result:
+                results.append(result)
+
+        task.stop()
+
+        # Find starting index for each
+        start_index = self._find_start_index(messages, results[0])
+        self.assertTrue(start_index != -1)
+
+        # Now go through the partitioned results and assert that they're equal
+        for rx_index, rx_message in enumerate(results):
+            tx_message = messages[start_index]
+
+            self.assertIsNotNone(rx_message)
+            self.assertEqual(tx_message.arbitration_id, rx_message.arbitration_id)
+            self.assertEqual(tx_message.dlc, rx_message.dlc)
+            self.assertEqual(tx_message.data, rx_message.data)
+            self.assertEqual(tx_message.is_extended_id, rx_message.is_extended_id)
+            self.assertEqual(tx_message.is_remote_frame, rx_message.is_remote_frame)
+            self.assertEqual(tx_message.is_error_frame, rx_message.is_error_frame)
+            self.assertEqual(tx_message.is_fd, rx_message.is_fd)
+
+            start_index = (start_index + 1) % len(messages)
+
+    def test_cyclic_initializer_tuple(self):
+        messages = []
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+                is_extended_id=False,
+            )
+        )
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x22, 0x22, 0x22, 0x22, 0x22, 0x22],
+                is_extended_id=False,
+            )
+        )
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x33, 0x33, 0x33, 0x33, 0x33, 0x33],
+                is_extended_id=False,
+            )
+        )
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x44, 0x44, 0x44, 0x44, 0x44, 0x44],
+                is_extended_id=False,
+            )
+        )
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x55, 0x55, 0x55, 0x55, 0x55, 0x55],
+                is_extended_id=False,
+            )
+        )
+        messages = tuple(messages)
+
+        self.assertIsInstance(messages, tuple)
+
+        task = self._send_bus.send_periodic(messages, self.PERIOD)
+        self.assertIsInstance(task, can.broadcastmanager.CyclicSendTaskABC)
+
+        results = []
+        for _ in range(len(messages) * 2):
+            result = self._recv_bus.recv(self.PERIOD * 2)
+            if result:
+                results.append(result)
+
+        task.stop()
+
+        # Find starting index for each
+        start_index = self._find_start_index(messages, results[0])
+        self.assertTrue(start_index != -1)
+
+        # Now go through the partitioned results and assert that they're equal
+        for rx_index, rx_message in enumerate(results):
+            tx_message = messages[start_index]
+
+            self.assertIsNotNone(rx_message)
+            self.assertEqual(tx_message.arbitration_id, rx_message.arbitration_id)
+            self.assertEqual(tx_message.dlc, rx_message.dlc)
+            self.assertEqual(tx_message.data, rx_message.data)
+            self.assertEqual(tx_message.is_extended_id, rx_message.is_extended_id)
+            self.assertEqual(tx_message.is_remote_frame, rx_message.is_remote_frame)
+            self.assertEqual(tx_message.is_error_frame, rx_message.is_error_frame)
+            self.assertEqual(tx_message.is_fd, rx_message.is_fd)
+
+            start_index = (start_index + 1) % len(messages)
+
+    def test_cyclic_initializer_message(self):
+        message = can.Message(
+            arbitration_id=0x401,
+            data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+            is_extended_id=False,
+        )
+
+        task = self._send_bus.send_periodic(message, self.PERIOD)
+        self.assertIsInstance(task, can.broadcastmanager.CyclicSendTaskABC)
+
+        # Take advantage of kernel's queueing mechanisms
+        time.sleep(4 * self.PERIOD)
+        task.stop()
+
+        for _ in range(4):
+            tx_message = message
+            rx_message = self._recv_bus.recv(self.TIMEOUT)
+
+            self.assertIsNotNone(rx_message)
+            self.assertEqual(tx_message.arbitration_id, rx_message.arbitration_id)
+            self.assertEqual(tx_message.dlc, rx_message.dlc)
+            self.assertEqual(tx_message.data, rx_message.data)
+            self.assertEqual(tx_message.is_extended_id, rx_message.is_extended_id)
+            self.assertEqual(tx_message.is_remote_frame, rx_message.is_remote_frame)
+            self.assertEqual(tx_message.is_error_frame, rx_message.is_error_frame)
+            self.assertEqual(tx_message.is_fd, rx_message.is_fd)
+
+    def test_cyclic_initializer_invalid_none(self):
+        with self.assertRaises(ValueError):
+            task = self._send_bus.send_periodic(None, self.PERIOD)
+
+    def test_cyclic_initializer_invalid_empty_list(self):
+        with self.assertRaises(ValueError):
+            task = self._send_bus.send_periodic([], self.PERIOD)
+
+    def test_cyclic_initializer_different_arbitration_ids(self):
+        messages = []
+        messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+                is_extended_id=False,
+            )
+        )
+        messages.append(
+            can.Message(
+                arbitration_id=0x3E1,
+                data=[0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE],
+                is_extended_id=False,
+            )
+        )
+        with self.assertRaises(ValueError):
+            task = self._send_bus.send_periodic(messages, self.PERIOD)
+
+    def test_modify_data_list(self):
+        messages_odd = []
+        messages_odd.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+                is_extended_id=False,
+            )
+        )
+        messages_odd.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x33, 0x33, 0x33, 0x33, 0x33, 0x33],
+                is_extended_id=False,
+            )
+        )
+        messages_odd.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x55, 0x55, 0x55, 0x55, 0x55, 0x55],
+                is_extended_id=False,
+            )
+        )
+        messages_even = []
+        messages_even.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x22, 0x22, 0x22, 0x22, 0x22, 0x22],
+                is_extended_id=False,
+            )
+        )
+        messages_even.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x44, 0x44, 0x44, 0x44, 0x44, 0x44],
+                is_extended_id=False,
+            )
+        )
+        messages_even.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x66, 0x66, 0x66, 0x66, 0x66, 0x66],
+                is_extended_id=False,
+            )
+        )
+
+        task = self._send_bus.send_periodic(messages_odd, self.PERIOD)
+        self.assertIsInstance(task, can.broadcastmanager.ModifiableCyclicTaskABC)
+
+        results_odd = []
+        results_even = []
+        for _ in range(len(messages_odd) * 2):
+            result = self._recv_bus.recv(self.PERIOD * 2)
+            if result:
+                results_odd.append(result)
+
+        task.modify_data(messages_even)
+        for _ in range(len(messages_even) * 2):
+            result = self._recv_bus.recv(self.PERIOD * 2)
+            if result:
+                results_even.append(result)
+
+        task.stop()
+
+        # Make sure we received some messages
+        self.assertTrue(len(results_even) != 0)
+        self.assertTrue(len(results_odd) != 0)
+
+        # Find starting index for each
+        start_index_even = self._find_start_index(messages_even, results_even[0])
+        self.assertTrue(start_index_even != -1)
+
+        start_index_odd = self._find_start_index(messages_odd, results_odd[0])
+        self.assertTrue(start_index_odd != -1)
+
+        # Now go through the partitioned results and assert that they're equal
+        for rx_index, rx_message in enumerate(results_even):
+            tx_message = messages_even[start_index_even]
+
+            self.assertEqual(tx_message.arbitration_id, rx_message.arbitration_id)
+            self.assertEqual(tx_message.dlc, rx_message.dlc)
+            self.assertEqual(tx_message.data, rx_message.data)
+            self.assertEqual(tx_message.is_extended_id, rx_message.is_extended_id)
+            self.assertEqual(tx_message.is_remote_frame, rx_message.is_remote_frame)
+            self.assertEqual(tx_message.is_error_frame, rx_message.is_error_frame)
+            self.assertEqual(tx_message.is_fd, rx_message.is_fd)
+
+            start_index_even = (start_index_even + 1) % len(messages_even)
+
+            if rx_index != 0:
+                prev_rx_message = results_even[rx_index - 1]
+                # Assert timestamps are within the expected period
+                self.assertTrue(
+                    abs(
+                        (rx_message.timestamp - prev_rx_message.timestamp) - self.PERIOD
+                    )
+                    <= self.DELTA
+                )
+
+        for rx_index, rx_message in enumerate(results_odd):
+            tx_message = messages_odd[start_index_odd]
+
+            self.assertEqual(tx_message.arbitration_id, rx_message.arbitration_id)
+            self.assertEqual(tx_message.dlc, rx_message.dlc)
+            self.assertEqual(tx_message.data, rx_message.data)
+            self.assertEqual(tx_message.is_extended_id, rx_message.is_extended_id)
+            self.assertEqual(tx_message.is_remote_frame, rx_message.is_remote_frame)
+            self.assertEqual(tx_message.is_error_frame, rx_message.is_error_frame)
+            self.assertEqual(tx_message.is_fd, rx_message.is_fd)
+
+            start_index_odd = (start_index_odd + 1) % len(messages_odd)
+
+            if rx_index != 0:
+                prev_rx_message = results_odd[rx_index - 1]
+                # Assert timestamps are within the expected period
+                self.assertTrue(
+                    abs(
+                        (rx_message.timestamp - prev_rx_message.timestamp) - self.PERIOD
+                    )
+                    <= self.DELTA
+                )
+
+    def test_modify_data_message(self):
+        message_odd = can.Message(
+            arbitration_id=0x401,
+            data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+            is_extended_id=False,
+        )
+        message_even = can.Message(
+            arbitration_id=0x401,
+            data=[0x22, 0x22, 0x22, 0x22, 0x22, 0x22],
+            is_extended_id=False,
+        )
+        task = self._send_bus.send_periodic(message_odd, self.PERIOD)
+        self.assertIsInstance(task, can.broadcastmanager.ModifiableCyclicTaskABC)
+
+        results_odd = []
+        results_even = []
+        for _ in range(1 * 4):
+            result = self._recv_bus.recv(self.PERIOD * 2)
+            if result:
+                results_odd.append(result)
+
+        task.modify_data(message_even)
+        for _ in range(1 * 4):
+            result = self._recv_bus.recv(self.PERIOD * 2)
+            if result:
+                results_even.append(result)
+
+        task.stop()
+
+        # Now go through the partitioned results and assert that they're equal
+        for rx_index, rx_message in enumerate(results_even):
+            tx_message = message_even
+
+            self.assertEqual(tx_message.arbitration_id, rx_message.arbitration_id)
+            self.assertEqual(tx_message.dlc, rx_message.dlc)
+            self.assertEqual(tx_message.data, rx_message.data)
+            self.assertEqual(tx_message.is_extended_id, rx_message.is_extended_id)
+            self.assertEqual(tx_message.is_remote_frame, rx_message.is_remote_frame)
+            self.assertEqual(tx_message.is_error_frame, rx_message.is_error_frame)
+            self.assertEqual(tx_message.is_fd, rx_message.is_fd)
+
+            if rx_index != 0:
+                prev_rx_message = results_even[rx_index - 1]
+                # Assert timestamps are within the expected period
+                self.assertTrue(
+                    abs(
+                        (rx_message.timestamp - prev_rx_message.timestamp) - self.PERIOD
+                    )
+                    <= self.DELTA
+                )
+
+        for rx_index, rx_message in enumerate(results_odd):
+            tx_message = message_odd
+
+            self.assertEqual(tx_message.arbitration_id, rx_message.arbitration_id)
+            self.assertEqual(tx_message.dlc, rx_message.dlc)
+            self.assertEqual(tx_message.data, rx_message.data)
+            self.assertEqual(tx_message.is_extended_id, rx_message.is_extended_id)
+            self.assertEqual(tx_message.is_remote_frame, rx_message.is_remote_frame)
+            self.assertEqual(tx_message.is_error_frame, rx_message.is_error_frame)
+            self.assertEqual(tx_message.is_fd, rx_message.is_fd)
+
+            if rx_index != 0:
+                prev_rx_message = results_odd[rx_index - 1]
+                # Assert timestamps are within the expected period
+                self.assertTrue(
+                    abs(
+                        (rx_message.timestamp - prev_rx_message.timestamp) - self.PERIOD
+                    )
+                    <= self.DELTA
+                )
+
+    def test_modify_data_invalid(self):
+        message = can.Message(
+            arbitration_id=0x401,
+            data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+            is_extended_id=False,
+        )
+        task = self._send_bus.send_periodic(message, self.PERIOD)
+        self.assertIsInstance(task, can.broadcastmanager.ModifiableCyclicTaskABC)
+
+        time.sleep(2 * self.PERIOD)
+
+        with self.assertRaises(ValueError):
+            task.modify_data(None)
+
+    def test_modify_data_unequal_lengths(self):
+        message = can.Message(
+            arbitration_id=0x401,
+            data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+            is_extended_id=False,
+        )
+        new_messages = []
+        new_messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+                is_extended_id=False,
+            )
+        )
+        new_messages.append(
+            can.Message(
+                arbitration_id=0x401,
+                data=[0x22, 0x22, 0x22, 0x22, 0x22, 0x22],
+                is_extended_id=False,
+            )
+        )
+
+        task = self._send_bus.send_periodic(message, self.PERIOD)
+        self.assertIsInstance(task, can.broadcastmanager.ModifiableCyclicTaskABC)
+
+        time.sleep(2 * self.PERIOD)
+
+        with self.assertRaises(ValueError):
+            task.modify_data(new_messages)
+
+    def test_modify_data_different_arbitration_id_than_original(self):
+        old_message = can.Message(
+            arbitration_id=0x401,
+            data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+            is_extended_id=False,
+        )
+        new_message = can.Message(
+            arbitration_id=0x3E1,
+            data=[0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE],
+            is_extended_id=False,
+        )
+
+        task = self._send_bus.send_periodic(old_message, self.PERIOD)
+        self.assertIsInstance(task, can.broadcastmanager.ModifiableCyclicTaskABC)
+
+        time.sleep(2 * self.PERIOD)
+
+        with self.assertRaises(ValueError):
+            task.modify_data(new_message)
+
+    def test_stop_all_periodic_tasks_and_remove_task(self):
+        message_a = can.Message(
+            arbitration_id=0x401,
+            data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+            is_extended_id=False,
+        )
+        message_b = can.Message(
+            arbitration_id=0x402,
+            data=[0x22, 0x22, 0x22, 0x22, 0x22, 0x22],
+            is_extended_id=False,
+        )
+        message_c = can.Message(
+            arbitration_id=0x403,
+            data=[0x33, 0x33, 0x33, 0x33, 0x33, 0x33],
+            is_extended_id=False,
+        )
+
+        # Start Tasks
+        task_a = self._send_bus.send_periodic(message_a, self.PERIOD)
+        task_b = self._send_bus.send_periodic(message_b, self.PERIOD)
+        task_c = self._send_bus.send_periodic(message_c, self.PERIOD)
+
+        self.assertIsInstance(task_a, can.broadcastmanager.ModifiableCyclicTaskABC)
+        self.assertIsInstance(task_b, can.broadcastmanager.ModifiableCyclicTaskABC)
+        self.assertIsInstance(task_c, can.broadcastmanager.ModifiableCyclicTaskABC)
+
+        for _ in range(6):
+            _ = self._recv_bus.recv(self.PERIOD)
+
+        # Stop all tasks and delete
+        self._send_bus.stop_all_periodic_tasks(remove_tasks=True)
+
+        # Now wait for a few periods, after which we should definitely not
+        # receive any CAN messages
+        time.sleep(4 * self.PERIOD)
+
+        # If we successfully deleted everything, then we will eventually read
+        # 0 messages.
+        successfully_stopped = False
+        for _ in range(6):
+            rx_message = self._recv_bus.recv(self.PERIOD)
+
+            if rx_message is None:
+                successfully_stopped = True
+                break
+        self.assertTrue(successfully_stopped, "Still received messages after stopping")
+
+        # None of the tasks should still be associated with the bus
+        self.assertEqual(0, len(self._send_bus._periodic_tasks))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi, 
this PR tries to mimic the behaviour of Linux SocketCAN for any interface
I'm a contributor to the Scapy project, where I'm heavily using python-can for automotive related stuff.
During my work with python-can, two problems occur once a while. 
1. If I'm using a interface, for example Vector, I can not create multiple bus objects, since the access to the library is exclusive. SocketCAN differs here.
2. The handling of background threads for receiving asynchronous is inconvenient and for many use-cases I have to implement a select-like behaviour on my own.

This is my first PR to the python-can project. I hope I followed the coding guidelines. 
I only made one unit-test based on SocketCAN, for now. Do you have ideas for further unit tests?
