### PR TITLE
Fix date format to show correct day of month

### DIFF
--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -147,7 +147,7 @@ class ASCWriter(BaseIOHandler, Listener):
             "{bit_timing_conf_ext_data:>8}",
         ]
     )
-    FORMAT_DATE = "%a %b %m %I:%M:%S.{} %p %Y"
+    FORMAT_DATE = "%a %b %d %I:%M:%S.{} %p %Y"
     FORMAT_EVENT = "{timestamp: 9.6f} {message}\n"
 
     def __init__(self, file, channel=1):
@@ -162,7 +162,7 @@ class ASCWriter(BaseIOHandler, Listener):
         self.channel = channel
 
         # write start of file header
-        now = datetime.now().strftime("%a %b %m %I:%M:%S.%f %p %Y")
+        now = datetime.now().strftime("%a %b %d %I:%M:%S.%f %p %Y")
         self.file.write("date %s\n" % now)
         self.file.write("base hex  timestamps absolute\n")
         self.file.write("internal events logged\n")


### PR DESCRIPTION
ASCWriter currently writes the month twice (once as three-letter abbreviation and once as  zero-padded decimal number), but does not write the day of month. I don't think this is correct. For example, today's date (2020-01-07) is currently written Tue Jan 01 01:14:48.625694 PM 2020.

With this fix, today's date will instead be written Tue Jan 07 01:14:48.625694 PM 2020.