### PR TITLE
'can.interface' NOT 'can.interfaces.interface'

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -11,7 +11,7 @@ In Code
 -------
 
 The ``can`` object exposes an ``rc`` dictionary which can be used to set
-the **interface** and **channel** before importing from ``can.interfaces``.
+the **interface** and **channel**.
 
 ::
 
@@ -19,7 +19,7 @@ the **interface** and **channel** before importing from ``can.interfaces``.
     can.rc['interface'] = 'socketcan'
     can.rc['channel'] = 'vcan0'
     can.rc['bitrate'] = 500000
-    from can.interfaces.interface import Bus
+    from can.interface import Bus
 
     bus = Bus()
 
@@ -79,7 +79,7 @@ The configuration can also contain additional sections (or context):
 
 ::
 
-    from can.interfaces.interface import Bus
+    from can.interface import Bus
 
     hs_bus = Bus(context='HS')
     ms_bus = Bus(context='MS')


### PR DESCRIPTION
I was getting the following error (see below)

####################################################################
C:\Users\arovellequartz>python auden_scratchpad_002.py
Traceback (most recent call last):
  File "auden_scratchpad_002.py", line 18, in <module>
    from can.interfaces.interface import Bus
ModuleNotFoundError: No module named 'can.interfaces.interface'
####################################################################