### PR TITLE
Changes to add direction to CAN messages

### DIFF
--- a/can/interfaces/ics_neovi/neovi_bus.py
+++ b/can/interfaces/ics_neovi/neovi_bus.py
@@ -306,9 +306,7 @@ class NeoViBus(BusABC):
                 dlc=ics_msg.NumberBytesData,
                 is_extended_id=bool(ics_msg.StatusBitField & ics.SPY_STATUS_XTD_FRAME),
                 is_fd=is_fd,
-                is_rx=not bool(
-                    ics_msg.StatusBitField & ics.SPY_STATUS_TX_MSG
-                ),
+                is_rx=not bool(ics_msg.StatusBitField & ics.SPY_STATUS_TX_MSG),
                 is_remote_frame=bool(
                     ics_msg.StatusBitField & ics.SPY_STATUS_REMOTE_FRAME
                 ),
@@ -328,9 +326,7 @@ class NeoViBus(BusABC):
                 dlc=ics_msg.NumberBytesData,
                 is_extended_id=bool(ics_msg.StatusBitField & ics.SPY_STATUS_XTD_FRAME),
                 is_fd=is_fd,
-                is_rx=not bool(
-                    ics_msg.StatusBitField & ics.SPY_STATUS_TX_MSG
-                ),
+                is_rx=not bool(ics_msg.StatusBitField & ics.SPY_STATUS_TX_MSG),
                 is_remote_frame=bool(
                     ics_msg.StatusBitField & ics.SPY_STATUS_REMOTE_FRAME
                 ),

--- a/can/interfaces/ics_neovi/neovi_bus.py
+++ b/can/interfaces/ics_neovi/neovi_bus.py
@@ -306,6 +306,9 @@ class NeoViBus(BusABC):
                 dlc=ics_msg.NumberBytesData,
                 is_extended_id=bool(ics_msg.StatusBitField & ics.SPY_STATUS_XTD_FRAME),
                 is_fd=is_fd,
+                is_rx=not bool(
+                    ics_msg.StatusBitField & ics.SPY_STATUS_TX_MSG
+                ),
                 is_remote_frame=bool(
                     ics_msg.StatusBitField & ics.SPY_STATUS_REMOTE_FRAME
                 ),
@@ -325,6 +328,9 @@ class NeoViBus(BusABC):
                 dlc=ics_msg.NumberBytesData,
                 is_extended_id=bool(ics_msg.StatusBitField & ics.SPY_STATUS_XTD_FRAME),
                 is_fd=is_fd,
+                is_rx=not bool(
+                    ics_msg.StatusBitField & ics.SPY_STATUS_TX_MSG
+                ),
                 is_remote_frame=bool(
                     ics_msg.StatusBitField & ics.SPY_STATUS_REMOTE_FRAME
                 ),

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -303,6 +303,6 @@ class ASCWriter(BaseIOHandler, Listener):
                 id=arb_id,
                 dir="Rx" if msg.is_rx else "Tx",
                 dtype=dtype,
-                data=" ".join(data)
+                data=" ".join(data),
             )
         self.log_event(serialized, msg.timestamp)

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -164,7 +164,7 @@ class ASCWriter(BaseIOHandler, Listener):
     It the first message does not have a timestamp, it is set to zero.
     """
 
-    FORMAT_MESSAGE = "{channel}  {id:<15} Rx   {dtype} {data}"
+    FORMAT_MESSAGE = "{channel}  {id:<15} {dir:<4} {dtype} {data}"
     FORMAT_MESSAGE_FD = " ".join(
         [
             "CANFD",
@@ -276,7 +276,7 @@ class ASCWriter(BaseIOHandler, Listener):
             serialized = self.FORMAT_MESSAGE_FD.format(
                 channel=channel,
                 id=arb_id,
-                dir="Rx",
+                dir="Rx" if msg.is_rx else "Tx",
                 symbolic_name="",
                 brs=1 if msg.bitrate_switch else 0,
                 esi=1 if msg.error_state_indicator else 0,
@@ -294,6 +294,10 @@ class ASCWriter(BaseIOHandler, Listener):
             )
         else:
             serialized = self.FORMAT_MESSAGE.format(
-                channel=channel, id=arb_id, dtype=dtype, data=" ".join(data)
+                channel=channel,
+                id=arb_id,
+                dir="Rx" if msg.is_rx else "Tx",
+                dtype=dtype,
+                data=" ".join(data)
             )
         self.log_event(serialized, msg.timestamp)

--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -91,6 +91,7 @@ REMOTE_FLAG = 0x80
 EDL = 0x1
 BRS = 0x2
 ESI = 0x4
+DIR = 0x1
 
 TIME_TEN_MICS = 0x00000001
 TIME_ONE_NANS = 0x00000002
@@ -258,6 +259,7 @@ class BLFReader(BaseIOHandler):
                     arbitration_id=can_id & 0x1FFFFFFF,
                     is_extended_id=bool(can_id & CAN_MSG_EXT),
                     is_remote_frame=bool(flags & REMOTE_FLAG),
+                    is_rx=not bool(flags & DIR),
                     dlc=dlc,
                     data=can_data[:dlc],
                     channel=channel - 1,
@@ -287,7 +289,8 @@ class BLFReader(BaseIOHandler):
                     arbitration_id=can_id & 0x1FFFFFFF,
                     is_extended_id=bool(can_id & CAN_MSG_EXT),
                     is_remote_frame=bool(flags & REMOTE_FLAG),
-                    is_fd=bool(fd_flags & 0x1),
+                    is_fd=bool(flags & 0x1),
+                    is_rx=not bool(flags & DIR),
                     bitrate_switch=bool(fd_flags & 0x2),
                     error_state_indicator=bool(fd_flags & 0x4),
                     dlc=dlc2len(dlc),
@@ -399,6 +402,8 @@ class BLFWriter(BaseIOHandler, Listener):
         if msg.is_extended_id:
             arb_id |= CAN_MSG_EXT
         flags = REMOTE_FLAG if msg.is_remote_frame else 0
+        if not msg.is_rx:
+            flags |= DIR
         can_data = bytes(msg.data)
 
         if msg.is_error_frame:

--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -289,7 +289,7 @@ class BLFReader(BaseIOHandler):
                     arbitration_id=can_id & 0x1FFFFFFF,
                     is_extended_id=bool(can_id & CAN_MSG_EXT),
                     is_remote_frame=bool(flags & REMOTE_FLAG),
-                    is_fd=bool(flags & 0x1),
+                    is_fd=bool(fd_flags & 0x1),
                     is_rx=not bool(flags & DIR),
                     bitrate_switch=bool(fd_flags & 0x2),
                     error_state_indicator=bool(fd_flags & 0x4),

--- a/can/message.py
+++ b/can/message.py
@@ -202,6 +202,7 @@ class Message:
             dlc=self.dlc,
             data=self.data,
             is_fd=self.is_fd,
+            is_rx=self.is_rx,
             bitrate_switch=self.bitrate_switch,
             error_state_indicator=self.error_state_indicator,
         )
@@ -218,6 +219,7 @@ class Message:
             dlc=self.dlc,
             data=deepcopy(self.data, memo),
             is_fd=self.is_fd,
+            is_rx=self.is_rx,
             bitrate_switch=self.bitrate_switch,
             error_state_indicator=self.error_state_indicator,
         )

--- a/can/message.py
+++ b/can/message.py
@@ -42,6 +42,7 @@ class Message:
         "dlc",
         "data",
         "is_fd",
+        "is_rx",
         "bitrate_switch",
         "error_state_indicator",
         "__weakref__",  # support weak references to messages
@@ -58,6 +59,7 @@ class Message:
         dlc: Optional[int] = None,
         data: Optional[typechecking.CanData] = None,
         is_fd: bool = False,
+        is_rx: bool = True,
         bitrate_switch: bool = False,
         error_state_indicator: bool = False,
         check: bool = False,
@@ -81,6 +83,7 @@ class Message:
         self.is_error_frame = is_error_frame
         self.channel = channel
         self.is_fd = is_fd
+        self.is_rx = is_rx
         self.bitrate_switch = bitrate_switch
         self.error_state_indicator = error_state_indicator
 
@@ -114,6 +117,7 @@ class Message:
         flag_string = " ".join(
             [
                 "X" if self.is_extended_id else "S",
+                "Rx" if self.is_rx else "Tx",
                 "E" if self.is_error_frame else " ",
                 "R" if self.is_remote_frame else " ",
                 "F" if self.is_fd else " ",

--- a/can/message.py
+++ b/can/message.py
@@ -163,6 +163,9 @@ class Message:
             "is_extended_id={}".format(self.is_extended_id),
         ]
 
+        if not self.is_rx:
+            args.append("is_rx=False")
+
         if self.is_remote_frame:
             args.append("is_remote_frame={}".format(self.is_remote_frame))
 
@@ -286,7 +289,10 @@ class Message:
                 )
 
     def equals(
-        self, other: "Message", timestamp_delta: Optional[Union[float, int]] = 1.0e-6
+        self,
+        other: "Message",
+        timestamp_delta: Optional[Union[float, int]] = 1.0e-6,
+        check_direction: bool = True,
     ) -> bool:
         """
         Compares a given message with this one.
@@ -295,6 +301,8 @@ class Message:
 
         :param timestamp_delta: the maximum difference at which two timestamps are
                                 still considered equal or None to not compare timestamps
+
+        :param check_direction: do we compare the messages' directions (Tx/Rx)
 
         :return: True iff the given message equals this one
         """
@@ -310,6 +318,7 @@ class Message:
                     timestamp_delta is None
                     or abs(self.timestamp - other.timestamp) <= timestamp_delta
                 )
+                and (self.is_rx == other.is_rx or not check_direction)
                 and self.arbitration_id == other.arbitration_id
                 and self.is_extended_id == other.is_extended_id
                 and self.dlc == other.dlc

--- a/doc/message.rst
+++ b/doc/message.rst
@@ -145,6 +145,13 @@ Message
         Indicates that this message is a CAN FD message.
 
 
+    .. attribute:: is_rx
+
+        :type: bool
+
+        Indicates whether this message is a transmitted (Tx) or received (Rx) frame
+
+
     .. attribute:: bitrate_switch
 
         :type: bool


### PR DESCRIPTION
Adds direction to can.Message with the bool attribute is_rx
Adds corresponding changes to ASC & BLF io

