### PR TITLE
Adding plugin support to can.io Reader/Writer

### DIFF
--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -60,10 +60,12 @@ class Logger(BaseIOHandler, Listener):  # pylint: disable=abstract-method
             ".log": CanutilsLogWriter,
             ".txt": Printer,
         }
-        lookup.update({
-            writer.name: writer.load()
-            for writer in iter_entry_points("can.io.message_writer")
-        })
+        lookup.update(
+            {
+                writer.name: writer.load()
+                for writer in iter_entry_points("can.io.message_writer")
+            }
+        )
         suffix = pathlib.PurePath(filename).suffix
         try:
             return lookup[suffix](filename, *args, **kwargs)

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -5,6 +5,7 @@ See the :class:`Logger` class.
 import pathlib
 import typing
 
+from pkg_resources import iter_entry_points
 import can.typechecking
 
 from ..listener import Listener
@@ -59,6 +60,10 @@ class Logger(BaseIOHandler, Listener):  # pylint: disable=abstract-method
             ".log": CanutilsLogWriter,
             ".txt": Printer,
         }
+        lookup.update({
+            writer.name: writer.load()
+            for writer in iter_entry_points("can.io.message_writer")
+        })
         suffix = pathlib.PurePath(filename).suffix
         try:
             return lookup[suffix](filename, *args, **kwargs)

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -38,6 +38,7 @@ class Logger(BaseIOHandler, Listener):  # pylint: disable=abstract-method
         This class itself is just a dispatcher, and any positional and keyword
         arguments are passed on to the returned instance.
     """
+
     fetched_plugins = False
     message_writers = {
         ".asc": ASCWriter,

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -38,6 +38,15 @@ class Logger(BaseIOHandler, Listener):  # pylint: disable=abstract-method
         This class itself is just a dispatcher, and any positional and keyword
         arguments are passed on to the returned instance.
     """
+    fetched_plugins = False
+    message_writers = {
+        ".asc": ASCWriter,
+        ".blf": BLFWriter,
+        ".csv": CSVWriter,
+        ".db": SqliteWriter,
+        ".log": CanutilsLogWriter,
+        ".txt": Printer,
+    }
 
     @staticmethod
     def __new__(
@@ -52,23 +61,18 @@ class Logger(BaseIOHandler, Listener):  # pylint: disable=abstract-method
         if filename is None:
             return Printer(*args, **kwargs)
 
-        lookup = {
-            ".asc": ASCWriter,
-            ".blf": BLFWriter,
-            ".csv": CSVWriter,
-            ".db": SqliteWriter,
-            ".log": CanutilsLogWriter,
-            ".txt": Printer,
-        }
-        lookup.update(
-            {
-                writer.name: writer.load()
-                for writer in iter_entry_points("can.io.message_writer")
-            }
-        )
+        if not Logger.fetched_plugins:
+            Logger.message_writers.update(
+                {
+                    writer.name: writer.load()
+                    for writer in iter_entry_points("can.io.message_writer")
+                }
+            )
+            Logger.fetched_plugins = True
+
         suffix = pathlib.PurePath(filename).suffix
         try:
-            return lookup[suffix](filename, *args, **kwargs)
+            return Logger.message_writers[suffix](filename, *args, **kwargs)
         except KeyError:
             raise ValueError(
                 f'No write support for this unknown log format "{suffix}"'

--- a/can/io/player.py
+++ b/can/io/player.py
@@ -61,10 +61,12 @@ class LogReader(BaseIOHandler):
             ".db": SqliteReader,
             ".log": CanutilsLogReader,
         }
-        lookup.update({
-            reader.name: reader.load()
-            for reader in iter_entry_points("can.io.message_reader")
-        })
+        lookup.update(
+            {
+                reader.name: reader.load()
+                for reader in iter_entry_points("can.io.message_reader")
+            }
+        )
         suffix = pathlib.PurePath(filename).suffix
         try:
             return lookup[suffix](filename, *args, **kwargs)

--- a/can/io/player.py
+++ b/can/io/player.py
@@ -45,6 +45,7 @@ class LogReader(BaseIOHandler):
         This class itself is just a dispatcher, and any positional an keyword
         arguments are passed on to the returned instance.
     """
+
     fetched_plugins = False
     message_readers = {
         ".asc": ASCReader,

--- a/can/io/player.py
+++ b/can/io/player.py
@@ -8,6 +8,8 @@ import pathlib
 from time import time, sleep
 import typing
 
+from pkg_resources import iter_entry_points
+
 if typing.TYPE_CHECKING:
     import can
 
@@ -59,6 +61,10 @@ class LogReader(BaseIOHandler):
             ".db": SqliteReader,
             ".log": CanutilsLogReader,
         }
+        lookup.update({
+            reader.name: reader.load()
+            for reader in iter_entry_points("can.io.message_reader")
+        })
         suffix = pathlib.PurePath(filename).suffix
         try:
             return lookup[suffix](filename, *args, **kwargs)

--- a/doc/listeners.rst
+++ b/doc/listeners.rst
@@ -30,6 +30,24 @@ readers are also documented here.
     completely unchanged message again, since some properties are not (yet)
     supported by some file formats.
 
+.. note ::
+
+    Additional file formats for both reading/writing log files can be added via
+    a plugin reader/writer. An external package can register a new reader
+    by using the ``can.io.message_reader`` entry point. Similarly, a writer can
+    be added using the ``can.io.message_writer`` entry point.
+
+    The format of the entry point is ``reader_name=module:classname`` where ``classname``
+    is a :class:`can.io.generic.BaseIOHandler` concrete implementation.
+
+    ::
+
+     entry_points={
+         'can.io.message_reader': [
+            '.asc = my_package.io.asc:ASCReader'
+        ]
+     },
+
 
 BufferedReader
 --------------


### PR DESCRIPTION
Allows users to plug in their own reader/writer implementation to can.io functions. Similar to how we have plugin support for can interfaces (BACKENDS) 