### PR TITLE
Relax restriction of arbitration ID uniqueness for SocketCAN

### DIFF
--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -323,6 +323,8 @@ class CyclicSendTask(
     ):
         """
         :param bcm_socket: An open BCM socket on the desired CAN channel.
+        :param task_id:
+            The identifier used to uniquely reference particular cyclic send task.
         :param messages:
             The messages to be sent periodically.
         :param period:

--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -710,9 +710,7 @@ class SocketcanBus(BusABC):
         return task
 
     def _get_next_task_id(self) -> int:
-        if self._task_id >= 2 ** 11 - 1:
-            self._task_id = 0
-        self._task_id += 1
+        self._task_id = (self._task_id + 1) % (2 ** 11 - 1)
         return self._task_id
 
     def _get_bcm_socket(self, channel: str) -> socket.socket:

--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -727,15 +727,23 @@ class SocketcanBus(BusABC):
     ) -> CyclicSendTask:
         """Start sending messages at a given period on this bus.
 
-        The Linux kernel's Broadcast Manager SocketCAN API is used.
+        The Linux kernel's Broadcast Manager SocketCAN API is used to schedule
+        periodic sending of CAN messages. The wrapping 32-bit counter (see
+        :meth:`~_get_next_task_id()`) designated to distinguish different
+        :class:`CyclicSendTask` within BCM provides flexibility to schedule
+        CAN messages sending with the same CAN ID, but different CAN data.
 
         :param messages:
-            The messages to be sent periodically
+            The message(s) to be sent periodically.
         :param period:
             The rate in seconds at which to send the messages.
         :param duration:
             Approximate duration in seconds to continue sending messages. If
             no duration is provided, the task will continue indefinitely.
+
+        :raises ValueError:
+            If task identifier passed to :class:`CyclicSendTask` can't be used
+            to schedule new task in Linux BCM.
 
         :return:
             A :class:`CyclicSendTask` task instance. This can be used to modify the data,

--- a/doc/bus.rst
+++ b/doc/bus.rst
@@ -67,7 +67,7 @@ This thread safe version of the :class:`~can.BusABC` class can be used by multip
 Sending and receiving is locked separately to avoid unnecessary delays.
 Conflicting calls are executed by blocking until the bus is accessible.
 
-It can be used exactly like the normal :class:`~can.BusABC`:
+It can be used exactly like the normal :class:`~can.BusABC`::
 
     # 'socketcan' is only an example interface, it works with all the others too
     my_bus = can.ThreadSafeBus(interface='socketcan', channel='vcan0')

--- a/doc/interfaces/socketcan.rst
+++ b/doc/interfaces/socketcan.rst
@@ -2,7 +2,7 @@ SocketCAN
 =========
 
 The `SocketCAN`_ documentation can be found in the Linux kernel docs at
-``networking`` directory. Hereafter is quote from SocketCAN Linux document::
+``networking`` directory. Quoting from the SocketCAN Linux documentation::
 
 > The socketcan package is an implementation of CAN protocols
 > (Controller Area Network) for Linux.  CAN is a networking technology

--- a/doc/interfaces/socketcan.rst
+++ b/doc/interfaces/socketcan.rst
@@ -1,16 +1,26 @@
 SocketCAN
 =========
 
-The full documentation for socketcan can be found in the kernel docs at
-`networking/can.txt <https://www.kernel.org/doc/Documentation/networking/can.txt>`_.
+The `SocketCAN`_ documentation can be found in the Linux kernel docs at
+``networking`` directory. Hereafter is quote from SocketCAN Linux document::
 
+> The socketcan package is an implementation of CAN protocols
+> (Controller Area Network) for Linux.  CAN is a networking technology
+> which has widespread use in automation, embedded devices, and
+> automotive fields.  While there have been other CAN implementations
+> for Linux based on character devices, SocketCAN uses the Berkeley
+> socket API, the Linux network stack and implements the CAN device
+> drivers as network interfaces.  The CAN socket API has been designed
+> as similar as possible to the TCP/IP protocols to allow programmers,
+> familiar with network programming, to easily learn how to use CAN
+> sockets.
 
-.. note::
+.. important::
 
-    Versions before 2.2 had two different implementations named
+    `python-can` versions before 2.2 had two different implementations named
     ``socketcan_ctypes`` and ``socketcan_native``. These are now
     deprecated and the aliases to ``socketcan`` will be removed in
-    version 4.0.  3.x releases raise a DeprecationWarning.
+    version 4.0. 3.x releases raise a DeprecationWarning.
 
 
 Socketcan Quickstart
@@ -53,7 +63,8 @@ existing ``can0`` interface with a bitrate of 1MB:
 PCAN
 ~~~~
 
-Kernels >= 3.4 supports the PCAN adapters natively via :doc:`/interfaces/socketcan`, so there is no need to install any drivers. The CAN interface can be brought like so:
+Kernels >= 3.4 supports the PCAN adapters natively via :doc:`/interfaces/socketcan`,
+so there is no need to install any drivers. The CAN interface can be brought like so:
 
 ::
 
@@ -61,12 +72,22 @@ Kernels >= 3.4 supports the PCAN adapters natively via :doc:`/interfaces/socketc
     sudo modprobe peak_pci
     sudo ip link set can0 up type can bitrate 500000
 
+Intrepid
+~~~~~~~~
+
+The Intrepid Control Systems, Inc provides several devices (e.g. ValueCAN) as well
+as Linux module and user-space daemon to make it possible to use them via SocketCAN.
+
+Refer to below repositories for installation instructions:
+
+- `Intrepid kernel module`_
+- `Intrepid user-space daemon`_
+
 Send Test Message
 ^^^^^^^^^^^^^^^^^
 
-The `can-utils <https://github.com/linux-can/can-utils>`_ library for linux
-includes a script `cansend` which is useful to send known payloads. For
-example to send a message on `vcan0`:
+The `can-utils`_ library for Linux includes a `cansend` tool which is useful to
+send known payloads. For example to send a message on `vcan0`:
 
 .. code-block:: bash
 
@@ -138,7 +159,7 @@ To spam a bus:
 
     def producer(id):
         """:param id: Spam the bus with messages including the data id."""
-        bus = can.interface.Bus(channel=channel, bustype=bustype)
+        bus = can.Bus(channel=channel, interface=bustype)
         for i in range(10):
             msg = can.Message(arbitration_id=0xc0ffee, data=[id, i, 0, 1, 3, 1, 4, 1], is_extended_id=False)
             bus.send(msg)
@@ -170,8 +191,7 @@ function:
 
     import can
 
-    can_interface = 'vcan0'
-    bus = can.interface.Bus(can_interface, bustype='socketcan')
+    bus = can.Bus(channel='vcan0', interface='socketcan')
     message = bus.recv()
 
 By default, this performs a blocking read, which means ``bus.recv()`` won't
@@ -204,30 +224,39 @@ socket api. This allows the cyclic transmission of CAN messages at given interva
 The overhead for periodic message sending is extremely low as all the heavy lifting occurs
 within the linux kernel.
 
-send_periodic()
-~~~~~~~~~~~~~~~
+The :class:`~can.BusABC` initialized for `socketcan` interface transparently handles
+scheduling of CAN messages to Linux BCM via :meth:`~can.BusABC.send_periodic`:
 
-An example that uses the send_periodic is included in ``python-can/examples/cyclic.py``
+.. code-block:: python
 
-The object returned can be used to halt, alter or cancel the periodic message task.
+    with can.interface.Bus(interface="socketcan", channel="can0") as bus:
+        task = bus.send_periodic(...)
+
+More examples that uses :meth:`~can.BusABC.send_periodic` are included
+in ``python-can/examples/cyclic.py``.
+
+The `task` object returned by :meth:`~can.BusABC.send_periodic` can be used to halt,
+alter or cancel the periodic message task:
 
 .. autoclass:: can.interfaces.socketcan.CyclicSendTask
-
+    :members:
 
 Bus
 ---
 
+The :class:`~can.interfaces.socketcan.SocketcanBus` specializes :class:`~can.BusABC`
+to ensure usage of SocketCAN Linux API. The most important differences are:
+
+- usage of SocketCAN BCM for periodic messages scheduling;
+- filtering of CAN messages on Linux kernel level.
+
 .. autoclass:: can.interfaces.socketcan.SocketcanBus
+    :members:
+    :inherited-members:
 
-   .. method:: recv(timeout=None)
+.. External references
 
-      Block waiting for a message from the Bus.
-
-      :param float timeout:
-          seconds to wait for a message or None to wait indefinitely
-
-      :rtype: can.Message or None
-      :return:
-          None on timeout or a :class:`can.Message` object.
-      :raises can.CanError:
-          if an error occurred while reading
+.. _SocketCAN: https://www.kernel.org/doc/Documentation/networking/can.txt
+.. _Intrepid kernel module: https://github.com/intrepidcs/intrepid-socketcan-kernel-module
+.. _Intrepid user-space daemon: https://github.com/intrepidcs/icsscand
+.. _can-utils: https://github.com/linux-can/can-utils

--- a/test/test_cyclic_socketcan.py
+++ b/test/test_cyclic_socketcan.py
@@ -244,27 +244,6 @@ class CyclicSocketCan(unittest.TestCase):
         with self.assertRaises(ValueError):
             task = self._send_bus.send_periodic(messages, self.PERIOD)
 
-    def test_create_same_id_raises_exception(self):
-        messages_a = can.Message(
-            arbitration_id=0x401,
-            data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
-            is_extended_id=False,
-        )
-
-        messages_b = can.Message(
-            arbitration_id=0x401,
-            data=[0x22, 0x22, 0x22, 0x22, 0x22, 0x22],
-            is_extended_id=False,
-        )
-
-        task_a = self._send_bus.send_periodic(messages_a, 1)
-        self.assertIsInstance(task_a, can.broadcastmanager.CyclicSendTaskABC)
-
-        # The second one raises a ValueError when we attempt to create a new
-        # Task, since it has the same arbitration ID.
-        with self.assertRaises(ValueError):
-            task_b = self._send_bus.send_periodic(messages_b, 1)
-
     def test_modify_data_list(self):
         messages_odd = []
         messages_odd.append(

--- a/test/test_cyclic_socketcan.py
+++ b/test/test_cyclic_socketcan.py
@@ -244,6 +244,26 @@ class CyclicSocketCan(unittest.TestCase):
         with self.assertRaises(ValueError):
             task = self._send_bus.send_periodic(messages, self.PERIOD)
 
+    def test_start_already_started_task(self):
+        messages_a = can.Message(
+            arbitration_id=0x401,
+            data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+            is_extended_id=False,
+        )
+
+        task_a = self._send_bus.send_periodic(messages_a, self.PERIOD)
+        time.sleep(0.1)
+
+        # Try to start it again, task_id is not incremented in this case
+        with self.assertRaises(ValueError) as ctx:
+            task_a.start()
+        self.assertEqual(
+            "A periodic task for Task ID 1 is already in progress by SocketCAN Linux layer",
+            str(ctx.exception),
+        )
+
+        task_a.stop()
+
     def test_create_same_id(self):
         messages_a = can.Message(
             arbitration_id=0x401,

--- a/test/test_cyclic_socketcan.py
+++ b/test/test_cyclic_socketcan.py
@@ -244,6 +244,55 @@ class CyclicSocketCan(unittest.TestCase):
         with self.assertRaises(ValueError):
             task = self._send_bus.send_periodic(messages, self.PERIOD)
 
+    def test_create_same_id(self):
+        messages_a = can.Message(
+            arbitration_id=0x401,
+            data=[0x11, 0x11, 0x11, 0x11, 0x11, 0x11],
+            is_extended_id=False,
+        )
+
+        messages_b = can.Message(
+            arbitration_id=0x401,
+            data=[0x22, 0x22, 0x22, 0x22, 0x22, 0x22],
+            is_extended_id=False,
+        )
+
+        task_a = self._send_bus.send_periodic(messages_a, self.PERIOD)
+        self.assertIsInstance(task_a, can.broadcastmanager.CyclicSendTaskABC)
+        task_b = self._send_bus.send_periodic(messages_b, self.PERIOD)
+        self.assertIsInstance(task_b, can.broadcastmanager.CyclicSendTaskABC)
+
+        time.sleep(self.PERIOD * 4)
+
+        task_a.stop()
+        task_b.stop()
+
+        msgs = []
+        for _ in range(4):
+            msg = self._recv_bus.recv(self.PERIOD * 2)
+            self.assertIsNotNone(msg)
+
+            msgs.append(msg)
+
+        self.assertTrue(len(msgs) >= 4)
+
+        # Both messages should be recevied on the bus,
+        # even with the same arbitration id
+        msg_a_data_present = msg_b_data_present = False
+        for rx_message in msgs:
+            self.assertTrue(
+                rx_message.arbitration_id
+                == messages_a.arbitration_id
+                == messages_b.arbitration_id
+            )
+            if rx_message.data == messages_a.data:
+                msg_a_data_present = True
+            if rx_message.data == messages_b.data:
+                msg_b_data_present = True
+
+        self.assertTrue(msg_a_data_present)
+        self.assertTrue(msg_b_data_present)
+
     def test_modify_data_list(self):
         messages_odd = []
         messages_odd.append(


### PR DESCRIPTION
References #721 
I am unsure about the correct way to make a unique identifier. Please, suggest.