### PR TITLE
Add _detect_available_configs to serial_can

### DIFF
--- a/can/interfaces/serial/serial_can.py
+++ b/can/interfaces/serial/serial_can.py
@@ -21,6 +21,11 @@ except ImportError:
     )
     serial = None
 
+try:
+    from serial.tools import list_ports
+except ImportError:
+    list_ports = None
+
 
 class SerialBus(BusABC):
     """
@@ -162,3 +167,15 @@ class SerialBus(BusABC):
             return self.ser.fileno()
         # Return an invalid file descriptor on Windows
         return -1
+
+    @staticmethod
+    def _detect_available_configs():
+        channels = []
+        serial_ports = []
+
+        if list_ports:
+            serial_ports = list_ports.comports()
+
+        for port in serial_ports:
+            channels.append({"interface": "serial", "channel": port.device})
+        return channels


### PR DESCRIPTION
Hi I am using serial_can interface and I was missing the serial port detection.

This is very simple PR, it just adds pySerial `list_ports.comports()` call non-intrusive way. 
I.e. if the detection fails (or `serial.tools.list_ports` is not available) for one reason or another it just gives an empty list.
It does not attempt to get more detailed configuration (e.g. baudrates) besides the list of serial ports.

Tested on Linux and Windows:
Linux:
```
>>> can.detect_available_configs('serial')
[{'interface': 'serial', 'channel': '/dev/ttyUSB0'}]
```
Window:
```
>>> can.detect_available_configs('serial')
[{'interface': 'serial', 'channel': 'COM4'}]
```
As you'd expect. These configs can be directly used to connect to the interface (with the default baudrate of the serial interface).
