### PR TITLE
Fix Vector CANlib treatment of empty app name

### DIFF
--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -112,7 +112,7 @@ class VectorBus(BusABC):
         else:
             # Assume comma separated string of channels
             self.channels = [int(ch.strip()) for ch in channel.split(",")]
-        self._app_name = app_name.encode() if app_name is not None else ""
+        self._app_name = app_name.encode() if app_name is not None else b""
         self.channel_info = "Application %s: %s" % (
             app_name,
             ", ".join("CAN %d" % (ch + 1) for ch in self.channels),


### PR DESCRIPTION
In Python 2, the str type was used for text and bytes, whereas in Python
3, these are separate and incompatible types. This broke instantiation
of a VectorBus when the app_name parameter in __init__ was set to None.

This correctly sets it to a bytes object.

Fixes #796