### PR TITLE
Possible fix for tests sometimes failing

### DIFF
--- a/test/simplecyclic_test.py
+++ b/test/simplecyclic_test.py
@@ -168,6 +168,7 @@ class SimpleCyclicSendTaskTest(unittest.TestCase, ComparingMessagesTestCase):
         on_error_mock.assert_not_called()
         task.stop()
         bus.shutdown()
+        sleep(.5)
 
         # bus has been shutted down
         on_error_mock.reset_mock()

--- a/test/simplecyclic_test.py
+++ b/test/simplecyclic_test.py
@@ -168,10 +168,9 @@ class SimpleCyclicSendTaskTest(unittest.TestCase, ComparingMessagesTestCase):
         on_error_mock.assert_not_called()
         task.stop()
         bus.shutdown()
-        sleep(.5)
 
         # bus has been shutted down
-        on_error_mock.reset_mock()
+        on_error_mock = MagicMock(return_value=False)
         task = can.broadcastmanager.ThreadBasedCyclicSendTask(
             bus, bus._lock_send_periodic, msg, 0.1, 3, on_error_mock
         )


### PR DESCRIPTION
Fixed a minor issue in tests where I think previously we were sometimes getting some left over messages from the first cyclic thread, causing the tests to fail. 

One example PR where the tests were failing due to this: https://github.com/hardbyte/python-can/pull/825
Travis link: https://travis-ci.org/github/hardbyte/python-can/jobs/683606723