### PR TITLE
Add callback for updating Message data

### DIFF
--- a/can/message.py
+++ b/can/message.py
@@ -77,11 +77,6 @@ class Message:
             Possible problems include the `dlc` field not matching the length of `data`
             or creating a message with both `is_remote_frame` and `is_error_frame` set to `True`.
 
-        :param data_callback:
-            This optional function is called every time the `data` property is accessed. The function
-            `data_callback` must accept `arbitration_id: int, data: CanData` as arguments and return
-            the new `data`.
-
         :raises ValueError: iff `check` is set to `True` and one or more arguments were invalid
         """
         self.timestamp = timestamp

--- a/can/message.py
+++ b/can/message.py
@@ -308,7 +308,7 @@ class Message:
             raise TypeError(err)
 
     @property
-    def current_data(self) -> CanData:
+    def current_data(self) -> bytearray:
         """Retrieve the current data of auto modifying messages without changing it."""
         return self._data
 

--- a/can/message.py
+++ b/can/message.py
@@ -93,8 +93,6 @@ class Message:
 
         if data is None or is_remote_frame:
             self._data = bytearray()
-        elif isinstance(data, bytearray):
-            self._data = data
         else:
             self.data = data
 
@@ -297,7 +295,7 @@ class Message:
         return self._data
 
     @data.setter
-    def data(self, data: Optional[CanData]):
+    def data(self, data: CanData):
         try:
             self._data = bytearray(data)
         except TypeError:

--- a/doc/message.rst
+++ b/doc/message.rst
@@ -67,6 +67,40 @@ Message
             >>> m2.data
             bytearray(b'deadbeef')
 
+        Every access of the :attr:`~can.Message.data` triggers a refresh if a :attr:`~can.Message.data_callback`
+        was added to the :class:`~can.Message`.
+
+
+    .. attribute:: data_callback
+
+        :type: Callable
+
+        This function is called on every access to the :attr:`~can.Message.data` property. It must accept the
+        :attr:`~can.Message.arbitration_id` and the :attr:`~can.Message.current_data` as arguments and return
+        the new :attr:`~can.Message.data`. This can be used to update signal values, increment rolling counters
+        or to calculate the :abbr:`CRC (Cyclic redundancy check)`.
+
+            >>> from can import Message
+            >>>
+            >>> def increment_counter(arbitration_id, data):
+            >>>     data[0] = (data[0] + 1) % 16
+            >>>     return data
+            >>>
+            >>> msg = Message(data=[1, 2, 3, 4, 5], data_callback=increment_counter)
+            >>> msg.current_data
+            bytearray(b'\x01\x02\x03\x04\x05')
+            >>> msg.data
+            bytearray(b'\x02\x02\x03\x04\x05')
+            >>> print(msg)
+            Timestamp:        0.000000    ID: 00000000    X Rx                DLC:  5    02 02 03 04 05
+
+    .. attribute:: current_data
+
+        :type: bytearray
+
+        If a :attr:`~can.Message.data_callback` was added to the :class:`~can.Message` then this property
+        gives access to the :attr:`~can.Message.data` without modifying it.
+
 
     .. attribute:: dlc
 

--- a/test/test_message_class.py
+++ b/test/test_message_class.py
@@ -8,6 +8,7 @@ from copy import copy, deepcopy
 
 from hypothesis import given, settings, reproduce_failure
 import hypothesis.strategies as st
+import pytest
 
 from can import Message
 
@@ -108,6 +109,12 @@ class TestMessageClass(unittest.TestCase):
         msg = Message()
         msg.data = bytearray([1, 2, 3, 4, 5, 6, 7, 8])
         assert msg.current_data == bytearray([1, 2, 3, 4, 5, 6, 7, 8])
+
+        with pytest.raises(TypeError):
+            msg.data = [0, 1, 2, 3]
+
+        with pytest.raises(TypeError):
+            msg.data = "string"
 
     def test_pickle_message(self):
         msg = Message(data=[1, 2, 3, 4])

--- a/test/test_message_class.py
+++ b/test/test_message_class.py
@@ -84,6 +84,31 @@ class TestMessageClass(unittest.TestCase):
                 self.assertTrue(message.equals(other))
                 self.assertTrue(message.equals(other, timestamp_delta=0))
 
+    def test_data_callback(self):
+        arbitration_id = 123
+
+        def increment_counter(a_id, data):
+            assert a_id == arbitration_id
+            data[0] = (data[0] + 1) % 16
+            return data
+
+        msg = Message(
+            arbitration_id=arbitration_id,
+            data=[1, 2, 3, 4, 5, 6, 7, 8],
+            data_callback=increment_counter,
+        )
+
+        # test getters
+        assert msg.current_data == bytearray([1, 2, 3, 4, 5, 6, 7, 8])
+        assert msg.data == bytearray([2, 2, 3, 4, 5, 6, 7, 8])
+        assert msg.current_data == bytearray([2, 2, 3, 4, 5, 6, 7, 8])
+        assert msg.data == bytearray([3, 2, 3, 4, 5, 6, 7, 8])
+
+    def test_data_setter(self):
+        msg = Message()
+        msg.data = [1, 2, 3, 4, 5, 6, 7, 8]
+        assert msg.current_data == bytearray([1, 2, 3, 4, 5, 6, 7, 8])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_message_class.py
+++ b/test/test_message_class.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
-
+import pickle
 import unittest
 import sys
 from math import isinf, isnan
@@ -106,8 +106,13 @@ class TestMessageClass(unittest.TestCase):
 
     def test_data_setter(self):
         msg = Message()
-        msg.data = [1, 2, 3, 4, 5, 6, 7, 8]
+        msg.data = bytearray([1, 2, 3, 4, 5, 6, 7, 8])
         assert msg.current_data == bytearray([1, 2, 3, 4, 5, 6, 7, 8])
+
+    def test_pickle_message(self):
+        msg = Message(data=[1, 2, 3, 4])
+        p = pickle.dumps(msg)
+        assert msg.equals(pickle.loads(p))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add callback to `Message` class. Make the `data` attribute a property with getter and setter.
Every call to `Message.data` will return the updated data if a callback function is present.

I added an alternative property `current_data` to retrieve the data without triggering the update.