### PR TITLE
Fix typo in can.interface.Bus docstring

### DIFF
--- a/can/interface.py
+++ b/can/interface.py
@@ -68,7 +68,7 @@ class Bus(BusABC):  # pylint disable=abstract-method
         Some might have a special meaning, see below.
 
         :param channel:
-            Set to ``None`` to let it be resloved automatically from the default
+            Set to ``None`` to let it be resolved automatically from the default
             configuration. That might fail, see below.
 
             Expected type is backend dependent.


### PR DESCRIPTION
s/resloved/resolved