### PR TITLE
Specify tox environment in docs

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -34,7 +34,7 @@ The project can be installed in editable mode with::
 The unit tests can be run with::
 
     pip install tox
-    tox
+    tox -e py
 
 The documentation can be built with::
 


### PR DESCRIPTION
Just a small edit, otherwise it runs both the travis and appveyor environment and executes codecov at the end.