### PR TITLE
Make VectorError picklable

### DIFF
--- a/can/interfaces/vector/exceptions.py
+++ b/can/interfaces/vector/exceptions.py
@@ -8,3 +8,9 @@ class VectorError(CanError):
     def __init__(self, error_code, error_string, function):
         self.error_code = error_code
         super().__init__(f"{function} failed ({error_string})")
+
+        # keep reference to args for pickling
+        self._args = error_code, error_string, function
+
+    def __reduce__(self):
+        return VectorError, self._args, {}

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -6,6 +6,7 @@ Test for Vector Interface
 """
 
 import ctypes
+import pickle
 import time
 import logging
 import os
@@ -15,7 +16,7 @@ from unittest.mock import Mock
 import pytest
 
 import can
-from can.interfaces.vector import canlib, xldefine, xlclass
+from can.interfaces.vector import canlib, xldefine, xlclass, VectorError
 
 
 class TestVectorBus(unittest.TestCase):
@@ -254,6 +255,23 @@ class TestVectorBus(unittest.TestCase):
             with self.assertRaises(OSError):
                 # do not set the _testing argument, since it supresses the exception
                 can.Bus(channel=0, bustype="vector")
+
+    def test_vector_error_pickle(self) -> None:
+        error_code = 118
+        error_string = "XL_ERROR"
+        function = "function_name"
+
+        exc = VectorError(error_code, error_string, function)
+
+        # pickle and unpickle
+        p = pickle.dumps(exc)
+        exc_unpickled: VectorError = pickle.loads(p)
+
+        self.assertEqual(str(exc), str(exc_unpickled))
+        self.assertEqual(error_code, exc_unpickled.error_code)
+
+        with pytest.raises(VectorError):
+            raise exc_unpickled
 
 
 def xlGetApplConfig(


### PR DESCRIPTION
Unpickling the VectorError raises a TypeError, this PR fixes that.