### PR TITLE
Refactor VectorBus.send()

### DIFF
--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -11,6 +11,8 @@ import logging
 import time
 import os
 
+import typing
+
 try:
     # Try builtin Python 3 Windows API
     from _winapi import WaitForSingleObject, INFINITE
@@ -482,57 +484,94 @@ class VectorBus(BusABC):
         """
         pass
 
-    def send(self, msg, timeout=None):
-        msg_id = msg.arbitration_id
+    def send(self, msg: Message, timeout: typing.Optional[float] = None):
+        self._send_sequence([msg])
 
+    def _send_sequence(self, msgs: typing.Sequence[Message]) -> int:
+        """Send messages and return number of successful transmissions."""
+        if self.fd:
+            return self._send_can_fd_msg_sequence(msgs)
+        else:
+            return self._send_can_msg_sequence(msgs)
+
+    def _get_tx_channel_mask(self, msgs: typing.Sequence[Message]) -> int:
+        if len(msgs) == 1:
+            return self.channel_masks.get(msgs[0].channel, self.mask)
+        else:
+            return self.mask
+
+    def _send_can_msg_sequence(self, msgs: typing.Sequence[Message]) -> int:
+        """Send CAN messages and return number of successful transmissions."""
+        mask = self._get_tx_channel_mask(msgs)
+        message_count = ctypes.c_uint(len(msgs))
+
+        xl_event_array = (xlclass.XLevent * message_count.value)()
+        for idx, msg in enumerate(msgs):
+            xl_event_array[idx] = self._build_xl_event(msg)
+
+        xldriver.xlCanTransmit(self.port_handle, mask, message_count, xl_event_array)
+        return message_count.value
+
+    @staticmethod
+    def _build_xl_event(msg: Message) -> xlclass.XLevent:
+        msg_id = msg.arbitration_id
         if msg.is_extended_id:
             msg_id |= xldefine.XL_MessageFlagsExtended.XL_CAN_EXT_MSG_ID.value
 
         flags = 0
+        if msg.is_remote_frame:
+            flags |= xldefine.XL_MessageFlags.XL_CAN_MSG_FLAG_REMOTE_FRAME.value
 
-        # If channel has been specified, try to send only to that one.
-        # Otherwise send to all channels
-        mask = self.channel_masks.get(msg.channel, self.mask)
+        xl_event = xlclass.XLevent()
+        xl_event.tag = xldefine.XL_EventTags.XL_TRANSMIT_MSG.value
+        xl_event.tagData.msg.id = msg_id
+        xl_event.tagData.msg.dlc = msg.dlc
+        xl_event.tagData.msg.flags = flags
+        for idx, value in enumerate(msg.data):
+            xl_event.tagData.msg.data[idx] = value
 
-        if self.fd:
-            if msg.is_fd:
-                flags |= xldefine.XL_CANFD_TX_MessageFlags.XL_CAN_TXMSG_FLAG_EDL.value
-            if msg.bitrate_switch:
-                flags |= xldefine.XL_CANFD_TX_MessageFlags.XL_CAN_TXMSG_FLAG_BRS.value
-            if msg.is_remote_frame:
-                flags |= xldefine.XL_CANFD_TX_MessageFlags.XL_CAN_TXMSG_FLAG_RTR.value
+        return xl_event
 
-            message_count = 1
-            MsgCntSent = ctypes.c_uint(1)
+    def _send_can_fd_msg_sequence(self, msgs: typing.Sequence[Message]) -> int:
+        """Send CAN FD messages and return number of successful transmissions."""
+        mask = self._get_tx_channel_mask(msgs)
+        message_count = len(msgs)
 
-            XLcanTxEvent = xlclass.XLcanTxEvent()
-            XLcanTxEvent.tag = xldefine.XL_CANFD_TX_EventTags.XL_CAN_EV_TAG_TX_MSG.value
-            XLcanTxEvent.transId = 0xFFFF
+        xl_can_tx_event_array = (xlclass.XLcanTxEvent * message_count)()
+        for idx, msg in enumerate(msgs):
+            xl_can_tx_event_array[idx] = self._build_xl_can_tx_event(msg)
 
-            XLcanTxEvent.tagData.canMsg.canId = msg_id
-            XLcanTxEvent.tagData.canMsg.msgFlags = flags
-            XLcanTxEvent.tagData.canMsg.dlc = len2dlc(msg.dlc)
-            for idx, value in enumerate(msg.data):
-                XLcanTxEvent.tagData.canMsg.data[idx] = value
-            xldriver.xlCanTransmitEx(
-                self.port_handle, mask, message_count, MsgCntSent, XLcanTxEvent
-            )
+        msg_count_sent = ctypes.c_uint(0)
+        xldriver.xlCanTransmitEx(
+            self.port_handle, mask, message_count, msg_count_sent, xl_can_tx_event_array
+        )
+        return msg_count_sent.value
 
-        else:
-            if msg.is_remote_frame:
-                flags |= xldefine.XL_MessageFlags.XL_CAN_MSG_FLAG_REMOTE_FRAME.value
+    @staticmethod
+    def _build_xl_can_tx_event(msg: Message) -> xlclass.XLcanTxEvent:
+        msg_id = msg.arbitration_id
+        if msg.is_extended_id:
+            msg_id |= xldefine.XL_MessageFlagsExtended.XL_CAN_EXT_MSG_ID.value
 
-            message_count = ctypes.c_uint(1)
+        flags = 0
+        if msg.is_fd:
+            flags |= xldefine.XL_CANFD_TX_MessageFlags.XL_CAN_TXMSG_FLAG_EDL.value
+        if msg.bitrate_switch:
+            flags |= xldefine.XL_CANFD_TX_MessageFlags.XL_CAN_TXMSG_FLAG_BRS.value
+        if msg.is_remote_frame:
+            flags |= xldefine.XL_CANFD_TX_MessageFlags.XL_CAN_TXMSG_FLAG_RTR.value
 
-            xl_event = xlclass.XLevent()
-            xl_event.tag = xldefine.XL_EventTags.XL_TRANSMIT_MSG.value
+        xl_can_tx_event = xlclass.XLcanTxEvent()
+        xl_can_tx_event.tag = xldefine.XL_CANFD_TX_EventTags.XL_CAN_EV_TAG_TX_MSG.value
+        xl_can_tx_event.transId = 0xFFFF
 
-            xl_event.tagData.msg.id = msg_id
-            xl_event.tagData.msg.dlc = msg.dlc
-            xl_event.tagData.msg.flags = flags
-            for idx, value in enumerate(msg.data):
-                xl_event.tagData.msg.data[idx] = value
-            xldriver.xlCanTransmit(self.port_handle, mask, message_count, xl_event)
+        xl_can_tx_event.tagData.canMsg.canId = msg_id
+        xl_can_tx_event.tagData.canMsg.msgFlags = flags
+        xl_can_tx_event.tagData.canMsg.dlc = len2dlc(msg.dlc)
+        for idx, value in enumerate(msg.data):
+            xl_can_tx_event.tagData.canMsg.data[idx] = value
+
+        return xl_can_tx_event
 
     def flush_tx_buffer(self):
         xldriver.xlCanFlushTransmitQueue(self.port_handle, self.mask)


### PR DESCRIPTION
I made the `send()` method a little cleaner.

The `send()` method now calls `_send_can_msg_sequence()` which can send multiple messages  with a single vxlapi call. But i did not add it to the public API since there is another PR #688 for that.

(Also i fixed a mistake i made in the `handle_can_event`/`handle_canfd_event` docstrings)

