### PR TITLE
Use tox for testing with github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[test]
-    - name: Test with pytest
+        pip install tox
+        pip install -r requirements-lint.txt
+    - name: Test with pytest via tox
       run: |
-        pytest
+        tox -e gh
+    - name: Code Format Check with Black
+      run: |
+        black --check --verbose .

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,11 @@ commands =
 
 recreate = True
 
+[testenv:gh]
+passenv =
+    CI
+    PYTHONPATH
+
 [testenv:travis]
 passenv =
     CI


### PR DESCRIPTION
Small tweak to use tox instead of directly invoking `pytest`, main benefit is `tox` install pytest and plugins and we already have a complex incantation to run pytest with coverage etc.

See #827 