### PR TITLE
Fix RecursionError in Message.__getattr__

### DIFF
--- a/can/message.py
+++ b/can/message.py
@@ -53,7 +53,9 @@ class Message(object):
         # TODO keep this for a version, in order to not break old code
         # this entire method (as well as the _dict attribute in __slots__ and the __setattr__ method)
         # can be removed in 4.0
-        # this method is only called if the attribute was not found elsewhere, like in __slots__
+        # this method is only called if the attribute was not found elsewhere, like in __slots_
+        if key not in self.__slots__:
+            raise AttributeError
         try:
             warnings.warn("Custom attributes of messages are deprecated and will be removed in 4.0", DeprecationWarning)
             return self._dict[key]

--- a/test/test_message_class.py
+++ b/test/test_message_class.py
@@ -5,11 +5,14 @@ import unittest
 import sys
 from math import isinf, isnan
 from copy import copy, deepcopy
+import pickle
 
 from hypothesis import given, settings, reproduce_failure
 import hypothesis.strategies as st
 
 from can import Message
+
+from .message_helper import ComparingMessagesTestCase
 
 
 class TestMessageClass(unittest.TestCase):
@@ -70,7 +73,7 @@ class TestMessageClass(unittest.TestCase):
 
         # check copies and equalities
         if is_valid:
-            self.assertEqual(message, message)        
+            self.assertEqual(message, message)
             normal_copy = copy(message)
             deep_copy = deepcopy(message)
             for other in (normal_copy, deep_copy, message):
@@ -79,5 +82,31 @@ class TestMessageClass(unittest.TestCase):
                 self.assertTrue(message.equals(other, timestamp_delta=0))
 
 
-if __name__ == '__main__':
+class MessageSerialization(unittest.TestCase, ComparingMessagesTestCase):
+    def __init__(self, *args, **kwargs):
+        unittest.TestCase.__init__(self, *args, **kwargs)
+        ComparingMessagesTestCase.__init__(
+            self, allowed_timestamp_delta=0.016, preserves_channel=True
+        )
+
+    def test_serialization(self):
+        message = Message(
+            timestamp=1.0,
+            arbitration_id=0x401,
+            is_extended_id=False,
+            is_remote_frame=False,
+            is_error_frame=False,
+            channel=1,
+            dlc=6,
+            data=bytearray([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
+            is_fd=False,
+        )
+
+        serialized = pickle.dumps(message, -1)
+        deserialized = pickle.loads(serialized)
+
+        self.assertMessageEqual(message, deserialized)
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
__getattr__ incorrectly assumes that self._dict always exists. However,
if self._dict doesn't exist, the function attempts to call __getattr__
again, which results in infinite recursion when serializing the object
via pickle.

This fixes the implementation of __getattr__ and adds a test to exercise
pickling/unpickling the Message.

Fixes #804

