### PR TITLE
Fix ixxat ascii Python 2.7

### DIFF
--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -462,7 +462,7 @@ class IXXATBus(BusABC):
             else:
                 if (UniqueHardwareId is None) or (
                     self._device_info.UniqueHardwareId.AsChar
-                    == UniqueHardwareId.encode('ascii')
+                    == UniqueHardwareId.encode("ascii")
                 ):
                     break
                 else:

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -462,7 +462,7 @@ class IXXATBus(BusABC):
             else:
                 if (UniqueHardwareId is None) or (
                     self._device_info.UniqueHardwareId.AsChar
-                    == bytes(UniqueHardwareId, "ascii")
+                    == UniqueHardwareId.encode('ascii')
                 ):
                     break
                 else:


### PR DESCRIPTION
I used the IXXAT interface with Python 2.7. But his gave me the following error:

> File "C:\Python27\lib\site-packages\can\interfaces\ixxat\canlib.py", line 336, in __init__
>    if (UniqueHardwareId is None) or (self._device_info.UniqueHardwareId.AsChar == bytes(UniqueHardwareId, 'ascii')):
>TypeError: str() takes at most 1 argument (2 given)

I found a few sources which suggested using string.encode() instead since this is compatible with Python 2 and 3.
https://stackoverflow.com/questions/14472650/python-3-encode-decode-vs-bytes-str

The included solution fixed the problem and allowed me to use CAN communication with IXXAT USB-to-CAN device. 

P.S.: This is my first time contributing to an open source project. I tried following the guidelines, please let me know if something should be done differently.