### PR TITLE
Find the correct Reader/Writer independently of the file extension case

### DIFF
--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -71,7 +71,7 @@ class Logger(BaseIOHandler, Listener):  # pylint: disable=abstract-method
             )
             Logger.fetched_plugins = True
 
-        suffix = pathlib.PurePath(filename).suffix
+        suffix = pathlib.PurePath(filename).suffix.lower()
         try:
             return Logger.message_writers[suffix](filename, *args, **kwargs)
         except KeyError:

--- a/can/io/player.py
+++ b/can/io/player.py
@@ -70,7 +70,7 @@ class LogReader(BaseIOHandler):
             )
             LogReader.fetched_plugins = True
 
-        suffix = pathlib.PurePath(filename).suffix
+        suffix = pathlib.PurePath(filename).suffix.lower()
         try:
             return LogReader.message_readers[suffix](filename, *args, **kwargs)
         except KeyError:


### PR DESCRIPTION
Find the correct Reader/Writer independently of the file extension case.

For example `logfile.asc`, `LOGFILE.ASC` or `logfile.AsC` should all be valid asc file.