### PR TITLE
seeed interface: fix fileno issue with windows

### DIFF
--- a/can/interfaces/seeedstudio/seeedstudio.py
+++ b/can/interfaces/seeedstudio/seeedstudio.py
@@ -8,6 +8,7 @@ SKU 114991193
 
 import logging
 import struct
+import io
 from time import time
 from can import BusABC, Message
 
@@ -262,7 +263,7 @@ class SeeedBus(BusABC):
         return None, None
 
     def fileno(self):
-        if hasattr(self.ser, "fileno"):
+        try:
             return self.ser.fileno()
-        # Return an invalid file descriptor on Windows
-        return -1
+        except io.UnsupportedOperation:
+            raise NotImplementedError("fileno is not implemented using current CAN bus")


### PR DESCRIPTION
**Environment:**

* Python: 3.8.2
* Windows-10-10.0.18362-SP0

**Issue**
When using the seeedstudio interface on Linux or MacOS, I'm able to connect to the interface and send/receive messages.
When running the same script on Windows 10 the following error is thrown:
```
Traceback (most recent call last):
  File "<redacted>.py", line 264, in <module>
  File "<redacted>.py", line 44, in __init__
  File "can\notifier.py", line 56, in __init__
  File "can\notifier.py", line 66, in add_bus
  File "can\interfaces\seeedstudio\seeedstudio.py", line 266, in fileno
io.UnsupportedOperation: fileno
```

From the [python-serial docs](https://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.Serial.fileno), `fileno()` is only supported on Posix platforms.

The commit below fixes the issue for me, without breaking functionality on Linux, although I'm not sure if this is correct solution.