### PR TITLE
Add function to list hwids of available IXXAT devices

### DIFF
--- a/can/interfaces/ixxat/__init__.py
+++ b/can/interfaces/ixxat/__init__.py
@@ -4,4 +4,4 @@ Ctypes wrapper module for IXXAT Virtual CAN Interface V3 on win32 systems
 Copyright (C) 2016 Giuseppe Corbelli <giuseppe.corbelli@weightpack.com>
 """
 
-from can.interfaces.ixxat.canlib import IXXATBus
+from can.interfaces.ixxat.canlib import IXXATBus, get_ixxat_hwids

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -811,9 +811,7 @@ def get_ixxat_hwids():
     _canlib.vciEnumDeviceOpen(ctypes.byref(device_handle))
     while True:
         try:
-            _canlib.vciEnumDeviceNext(
-                device_handle, ctypes.byref(device_info)
-            )
+            _canlib.vciEnumDeviceNext(device_handle, ctypes.byref(device_info))
         except StopIteration:
             break
         else:

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -800,3 +800,24 @@ def _format_can_status(status_flags: int):
         return "CAN status message: {}".format(", ".join(states))
     else:
         return "Empty CAN status message"
+
+
+def get_ixxat_hwids():
+    """Get a list of hardware ids of all available IXXAT devices."""
+    hwids = []
+    device_handle = HANDLE()
+    device_info = structures.VCIDEVICEINFO()
+
+    _canlib.vciEnumDeviceOpen(ctypes.byref(device_handle))
+    while True:
+        try:
+            _canlib.vciEnumDeviceNext(
+                device_handle, ctypes.byref(device_info)
+            )
+        except StopIteration:
+            break
+        else:
+            hwids.append(device_info.UniqueHardwareId.AsChar.decode("ascii"))
+    _canlib.vciEnumDeviceClose(device_handle)
+
+    return hwids

--- a/doc/interfaces/ixxat.rst
+++ b/doc/interfaces/ixxat.rst
@@ -55,7 +55,7 @@ VCI documentation, section "Message filters" for more info.
 
 List available devices
 -----------------
-In case you have multiple IXXAT devices connected, you have to select them by using their unique hardware id.
+In case you have connected multiple IXXAT devices, you have to select them by using their unique hardware id.
 To get a list of all connected IXXAT you can use the function ``get_ixxat_hwids()`` as demonstrated below:
 
     >>> from can.interfaces.ixxat import get_ixxat_hwids

--- a/doc/interfaces/ixxat.rst
+++ b/doc/interfaces/ixxat.rst
@@ -53,6 +53,16 @@ The can_id/mask must be specified according to IXXAT behaviour, that is
 bit 0 of can_id/mask parameters represents the RTR field in CAN frame. See IXXAT
 VCI documentation, section "Message filters" for more info.
 
+List available devices
+-----------------
+In case you have multiple IXXAT devices connected, you have to select them by using their unique hardware id.
+To get a list of all connected IXXAT you can use the function ``get_ixxat_hwids()`` as demonstrated below:
+
+    >>> from can.interfaces.ixxat import get_ixxat_hwids
+    >>> for hwid in get_ixxat_hwids(): print("Found IXXAT with hardware id '%s'." % hwid)
+    Found IXXAT with hardware id 'HW441489'.
+    Found IXXAT with hardware id 'HW107422'.
+
 
 Internals
 ---------


### PR DESCRIPTION
To use multiple IXXAT devices at same time you have to know their hwids beforehand.
If it does not matter which device is used, a list of available devices is needed.

A potential use case is simulating both ends of a CAN bus with another device in between,
so it does not matter which device is sender or receiver.

Usage is as easy as:
`>>> from can.interfaces.ixxat import get_ixxat_hwids`
`>>> for hwid in get_ixxat_hwids(): print("Found IXXAT with hardware id '%s'." % hwid)`
`Found IXXAT with hardware id 'HW441489'.`
`Found IXXAT with hardware id 'HW107422'.`