### PR TITLE
removes use of the bloated pywin32 library

### DIFF
--- a/can/events.py
+++ b/can/events.py
@@ -1,0 +1,93 @@
+WAIT_OBJECT_0 = 0x00000000
+INFINITE = -1
+
+try:
+    import ctypes.wintypes
+    import ctypes
+
+    _HANDLE = ctypes.wintypes.HANDLE
+    _BOOL = ctypes.wintypes.BOOL
+    _LARGE_INTEGER = ctypes.wintypes.LARGE_INTEGER
+    _LONG = ctypes.wintypes.LONG
+    _DWORD = ctypes.wintypes.DWORD
+
+    _kernel32 = ctypes.windll.Kernel32
+
+    _CreateWaitableTimerW = _kernel32.CreateWaitableTimerW
+    _CreateWaitableTimerW.restype = _HANDLE
+
+    def CreateWaitableTimer(lpTimerAttributes, bManualReset, lpTimerName):
+        return _CreateWaitableTimerW(
+            lpTimerAttributes,
+            _BOOL(bManualReset),
+            lpTimerName
+        )
+
+
+    _CancelWaitableTimer = _kernel32.CancelWaitableTimer
+    _CancelWaitableTimer.restype = _BOOL
+
+    def CancelWaitableTimer(hTimer):
+        return _CancelWaitableTimer(_HANDLE(hTimer))
+
+    _SetWaitableTimer = _kernel32.SetWaitableTimer
+    _SetWaitableTimer.restype = _BOOL
+
+    def SetWaitableTimer(
+        hTimer,
+        lpDueTime,
+        lPeriod,
+        pfnCompletionRoutine,
+        lpArgToCompletionRoutine,
+        fResume
+    ):
+        lpDueTime = _LARGE_INTEGER(lpDueTime)
+        return _SetWaitableTimer(
+            _HANDLE(hTimer),
+            ctypes.byref(lpDueTime),
+            _LONG(lPeriod),
+            pfnCompletionRoutine,
+            lpArgToCompletionRoutine,
+            _BOOL(fResume)
+        )
+
+    _WaitForSingleObject = _kernel32.WaitForSingleObject
+    _WaitForSingleObject.restype = _DWORD
+
+    def WaitForSingleObject(hHandle, dwMilliseconds, _=None):
+        return _WaitForSingleObject(
+            _HANDLE(hHandle),
+            _DWORD(dwMilliseconds)
+        )
+
+    _CreateEventW = _kernel32.CreateEventW
+    _CreateEventW.restype = _HANDLE
+
+    def CreateEvent(lpEventAttributes, bManualReset, bInitialState, lpName):
+        return _CreateEventW(
+            lpEventAttributes,
+            _BOOL(bManualReset),
+            _BOOL(bInitialState),
+            lpName
+        )
+
+except ImportError:
+    import time
+
+    def CreateWaitableTimer(*_):
+        return None
+
+    def CancelWaitableTimer(_):
+        return True
+
+    def SetWaitableTimer(*_):
+        return True
+
+    def WaitForSingleObject(_, dwMilliseconds, dwStarted):
+        # Compensate for the time it takes to send the message
+        delay = (dwMilliseconds / 1000.0) - (time.perf_counter() - dwStarted)
+        time.sleep(max(0.0, delay))
+
+    def CreateEvent(*_):
+        return None
+

--- a/can/interfaces/usb2can/serial_selector.py
+++ b/can/interfaces/usb2can/serial_selector.py
@@ -137,7 +137,7 @@ try:
                     else:
                         raise ctypes.WinError()
 
-            _SetupDiDestroyDeviceInfoList(hDevInfo)
+        _SetupDiDestroyDeviceInfoList(hDevInfo)
 
 
 except ImportError:
@@ -190,4 +190,3 @@ def find_serial_devices(serial_matcher="ED"):
             res.add(instance_id)
 
     return [ins_id for ins_id in res]
-

--- a/can/interfaces/usb2can/serial_selector.py
+++ b/can/interfaces/usb2can/serial_selector.py
@@ -4,9 +4,10 @@
 import logging
 
 try:
-    import win32com.client
+    import pysetupdi
+
 except ImportError:
-    logging.warning("win32com.client module required for usb2can")
+    logging.warning("pysetupdi required for usb2can")
     raise
 
 
@@ -48,8 +49,11 @@ def find_serial_devices(serial_matcher="ED"):
 
     :rtype: List[str]
     """
-    objWMIService = win32com.client.Dispatch("WbemScripting.SWbemLocator")
-    objSWbemServices = objWMIService.ConnectServer(".", "root\\cimv2")
-    items = objSWbemServices.ExecQuery("SELECT * FROM Win32_USBControllerDevice")
-    ids = (item.Dependent.strip('"')[-8:] for item in items)
-    return [e for e in ids if e.startswith(serial_matcher)]
+    res = set()
+    for device in pysetupdi.devices(enumerator='USB'):
+        instance_id = device.instance_id.strip('"')[-8:]
+        if instance_id.startswith(serial_matcher):
+            res.add(instance_id)
+
+    return [ins_id for ins_id in res]
+

--- a/can/interfaces/usb2can/serial_selector.py
+++ b/can/interfaces/usb2can/serial_selector.py
@@ -4,10 +4,144 @@
 import logging
 
 try:
-    import pysetupdi
+    import ctypes.wintypes
+    import ctypes
+
+    _setupapi = ctypes.windll.SetupApi
+    _kernel32 = ctypes.WinDLL.Kernel32
+    _ole32 = ctypes.windll.Ole32
+
+    _BOOL = ctypes.wintypes.BOOL
+    _UINT32 = ctypes.c_uint32
+    _UINT16 = ctypes.c_uint16
+    _UBYTE = ctypes.c_ubyte
+    _PWCHAR = ctypes.c_wchar_p
+    _ULONG = ctypes.wintypes.ULONG
+    _LPVOID = ctypes.c_void_p
+    _HDEVINFO = ctypes.wintypes.HANDLE
+
+    INVALID_HANDLE_VALUE = -1
+    DIOD_INHERIT_CLASSDRVS = 2
+    DIGCF_PRESENT = 0x00000002
+    DIGCF_ALLCLASSES = 0x00000004
+    ERROR_NO_MORE_ITEMS = 0x00000103
+    ERROR_INSUFFICIENT_BUFFER = 0x0000007A
+
+
+    class GUID(ctypes.Structure):
+        _fields_ = [
+            ('Data1', _UINT32),
+            ('Data2', _UINT16),
+            ('Data3', _UINT16),
+            ('Data4', _UBYTE * 8)
+        ]
+
+        def __init__(self, guid="{00000000-0000-0000-0000-000000000000}"):
+            super().__init__()
+            ret = _ole32.CLSIDFromString(
+                ctypes.create_unicode_buffer(guid),
+                ctypes.byref(self)
+            )
+            if ret < 0:
+                raise ctypes.WinError()
+
+    class DevicePropertyKey(ctypes.Structure):
+        _fields_ = [
+            ('fmtid', GUID),
+            ('pid', _ULONG)
+        ]
+
+
+    DEVPKEY_Device_InstanceId = DevicePropertyKey(
+        '{78c34fc8-104a-4aca-9ea4-524d52996e57}',
+        256
+    )
+
+
+    class _SP_DEVINFO_DATA(ctypes.Structure):
+        _fields_ = [
+            ('cbSize', _ULONG),
+            ('ClassGuid', GUID),
+            ('DevInst', _ULONG),
+            ('Reserved', _LPVOID)
+        ]
+
+    _SetupDiGetClassDevsW = _setupapi.SetupDiGetClassDevsW
+    _SetupDiGetClassDevsW.restype = _HDEVINFO
+
+    _SetupDiEnumDeviceInfo = _setupapi.SetupDiEnumDeviceInfo
+    _SetupDiEnumDeviceInfo.restype = _BOOL
+
+    _SetupDiGetDevicePropertyW = _setupapi.SetupDiGetDevicePropertyW
+    _SetupDiGetDevicePropertyW.restype = _BOOL
+
+    _SetupDiDestroyDeviceInfoList = _setupapi.SetupDiDestroyDeviceInfoList
+    _SetupDiDestroyDeviceInfoList.restype = _BOOL
+
+
+    def devices():
+        flags = DIGCF_PRESENT | DIGCF_ALLCLASSES
+        enumerator = ctypes.create_unicode_buffer('USB')
+
+        guid = GUID()
+        _ole32.CLSIDFromString("{A5DCBF10-6530-11D2-901F-00C04FB951ED}", ctypes.byref(guid))
+
+        hDevInfo = _SetupDiGetClassDevsW(guid, enumerator, None, flags)
+        if hDevInfo == INVALID_HANDLE_VALUE:
+            raise ctypes.WinError()
+
+        deviceInfoData = _SP_DEVINFO_DATA()
+        deviceInfoData.cbSize = ctypes.sizeof(_SP_DEVINFO_DATA)
+
+        i = 0
+        while True:
+            if not _SetupDiEnumDeviceInfo(
+                hDevInfo,
+                i,
+                ctypes.byref(deviceInfoData)
+            ):
+                err = ctypes.GetLastError()
+                if err == ERROR_NO_MORE_ITEMS:
+                    break
+                else:
+                    raise ctypes.WinError(err)
+            i += 1
+
+            prop_type = _ULONG()
+            required_size = _ULONG()
+            if not _SetupDiGetDevicePropertyW(
+                hDevInfo,
+                ctypes.byref(deviceInfoData),
+                ctypes.byref(DEVPKEY_Device_InstanceId),
+                ctypes.byref(prop_type),
+                None,
+                0,
+                ctypes.byref(required_size),
+                0
+            ):
+                err_no = ctypes.GetLastError()
+                if err_no == ERROR_INSUFFICIENT_BUFFER:
+                    instance_id_buffer = ctypes.create_string_buffer(required_size.value)
+                    if _setupapi.SetupDiGetDevicePropertyW(
+                            hDevInfo,
+                            ctypes.byref(deviceInfoData),
+                            ctypes.byref(DEVPKEY_Device_InstanceId),
+                            ctypes.byref(prop_type),
+                            ctypes.byref(instance_id_buffer),
+                            required_size.value,
+                            ctypes.byref(required_size),
+                            0
+                    ):
+                        yield instance_id_buffer.value
+
+                    else:
+                        raise ctypes.WinError()
+
+            _SetupDiDestroyDeviceInfoList(hDevInfo)
+
 
 except ImportError:
-    logging.warning("pysetupdi required for usb2can")
+    logging.warning("unsupported operating system.")
     raise
 
 
@@ -50,8 +184,8 @@ def find_serial_devices(serial_matcher="ED"):
     :rtype: List[str]
     """
     res = set()
-    for device in pysetupdi.devices(enumerator='USB'):
-        instance_id = device.instance_id.strip('"')[-8:]
+    for instance_id in devices():
+        instance_id = instance_id.strip('"')[-8:]
         if instance_id.startswith(serial_matcher):
             res.add(instance_id)
 

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ setup(
     # Installation
     # see https://www.python.org/dev/peps/pep-0345/#version-specifiers
     python_requires=">=3.6",
-    dependency_links=['https://github.com/gwangyi/pysetupdi/tarball/master#egg=pysetupdi-2018.10.22'],
     install_requires=[
         # Setuptools provides pkg_resources which python-can makes use of.
         "setuptools",
@@ -85,7 +84,6 @@ setup(
         'windows-curses;platform_system=="Windows"',
         "filelock",
         "mypy_extensions >= 0.4.0, < 0.5.0",
-        'pysetupdi;platform_system=="Windows"',
     ],
     extras_require=extras_require,
 )

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
     # Installation
     # see https://www.python.org/dev/peps/pep-0345/#version-specifiers
     python_requires=">=3.6",
+    dependency_links=['https://github.com/gwangyi/pysetupdi/tarball/master#egg=pysetupdi-2018.10.22'],
     install_requires=[
         # Setuptools provides pkg_resources which python-can makes use of.
         "setuptools",
@@ -84,7 +85,7 @@ setup(
         'windows-curses;platform_system=="Windows"',
         "filelock",
         "mypy_extensions >= 0.4.0, < 0.5.0",
-        'pywin32;platform_system=="Windows"',
+        'pysetupdi;platform_system=="Windows"',
     ],
     extras_require=extras_require,
 )


### PR DESCRIPTION
Most of the code I hard coded in what pywin32 does. There is a portion of the code that used wmi to enumerate usb devices and would return a piece of the instance id. I elected to use an already made library for this (pysetupdi) instead of coding it myself, which I can do if needed. This library is not listed on the python package index and is installed from the authors GitHub repository using setuptools. Collecting the instance ids using pysetupdi is going to be leaps and bounds faster then using COM objects to access the Windows WMI database. It is also going to be less prone to problems.

I have not tested the code because I do not have the devices that used pywin32. If there are people that do have these devices and are willing to report back if the code changes work or not that would be really helpful.