### PR TITLE
removes setuptools from install requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,8 +78,6 @@ setup(
     # see https://www.python.org/dev/peps/pep-0345/#version-specifiers
     python_requires=">=3.6",
     install_requires=[
-        # Setuptools provides pkg_resources which python-can makes use of.
-        "setuptools",
         "wrapt~=1.10",
         'windows-curses;platform_system=="Windows"',
         "filelock",

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,8 @@ setup(
     # see https://www.python.org/dev/peps/pep-0345/#version-specifiers
     python_requires=">=3.6",
     install_requires=[
+        # Note setuptools provides pkg_resources which python-can makes use of, but we assume it is already installed
+        #"setuptools",
         "wrapt~=1.10",
         'windows-curses;platform_system=="Windows"',
         "filelock",

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         # Note setuptools provides pkg_resources which python-can makes use of, but we assume it is already installed
-        #"setuptools",
+        # "setuptools",
         "wrapt~=1.10",
         'windows-curses;platform_system=="Windows"',
         "mypy_extensions>=0.4.0,<0.5.0",

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,8 @@ setup(
     # see https://www.python.org/dev/peps/pep-0345/#version-specifiers
     python_requires=">=3.6",
     install_requires=[
-        # Note setuptools provides pkg_resources which python-can makes use of, but we assume it is already installed
+        # Note setuptools provides pkg_resources which python-can makes use of, 
+        # but we assume it is already installed.
         # "setuptools",
         "wrapt~=1.10",
         'windows-curses;platform_system=="Windows"',


### PR DESCRIPTION
It would be rather redundant to have setuptools in install requires when setuptools is being imported at the top of the setup.py file.