### PR TITLE
removes whitespace from mypy_extension in install_requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         "wrapt~=1.10",
         'windows-curses;platform_system=="Windows"',
         "filelock",
-        "mypy_extensions >= 0.4.0, < 0.5.0",
+        "mypy_extensions>=0.4.0,<0.5.0",
         'pywin32;platform_system=="Windows"',
     ],
     extras_require=extras_require,


### PR DESCRIPTION
The whitespace would cause an issue where the module would not be installed resulting in an error when importing python-can.