### PR TITLE
Pcan extended message

### DIFF
--- a/can/interfaces/pcan/basic.py
+++ b/can/interfaces/pcan/basic.py
@@ -716,7 +716,7 @@ class PCANBasic:
             logger.error("Exception on PCANBasic.GetStatus")
             raise
 
-    def Read(self, Channel):
+    def Read(self, Channel, mac_use_standard_message=False):
 
         """
           Reads a CAN message from the receive queue of a PCAN Channel
@@ -731,12 +731,13 @@ class PCANBasic:
 
         Parameters:
           Channel  : A TPCANHandle representing a PCAN Channel
+          mac_use_standard_message : Whether to use standard message size on OSX
 
         Returns:
           A touple with three values
         """
         try:
-            if platform.system() == "Darwin":
+            if platform.system() == "Darwin" and not mac_use_standard_message:
                 msg = TPCANMsgMac()
                 timestamp = TPCANTimestampMac()
             else:
@@ -748,7 +749,7 @@ class PCANBasic:
             logger.error("Exception on PCANBasic.Read")
             raise
 
-    def ReadFD(self, Channel):
+    def ReadFD(self, Channel, mac_use_standard_message=False):
 
         """
           Reads a CAN message from the receive queue of a FD capable PCAN Channel
@@ -763,12 +764,13 @@ class PCANBasic:
 
         Parameters:
           Channel  : The handle of a FD capable PCAN Channel
+          mac_use_standard_message : Whether to use standard message size on OSX
 
         Returns:
           A touple with three values
         """
         try:
-            if platform.system() == "Darwin":
+            if platform.system() == "Darwin" and not mac_use_standard_message:
                 msg = TPCANMsgFDMac()
             else:
                 msg = TPCANMsgFD()

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -316,9 +316,13 @@ class PcanBus(BusABC):
         result = None
         while result is None:
             if self.fd:
-                result = self.m_objPCANBasic.ReadFD(self.m_PcanHandle, self.mac_use_standard_message)
+                result = self.m_objPCANBasic.ReadFD(
+                    self.m_PcanHandle, self.mac_use_standard_message
+                )
             else:
-                result = self.m_objPCANBasic.Read(self.m_PcanHandle, self.mac_use_standard_message)
+                result = self.m_objPCANBasic.Read(
+                    self.m_PcanHandle, self.mac_use_standard_message
+                )
             if result[0] == PCAN_ERROR_QRCVEMPTY:
                 if HAS_EVENTS:
                     result = None

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -170,6 +170,10 @@ class PcanBus(BusABC):
             that the controller can resynchronize every bit.
             In the range (1..16).
             Ignored if not using CAN-FD.
+            
+        :param bool mac_use_standard_message:
+            Whether to use the standard message (TPCANMsg) when
+            communicating with the PCAN driver.
 
         """
         self.channel_info = channel
@@ -182,6 +186,7 @@ class PcanBus(BusABC):
 
         self.m_objPCANBasic = PCANBasic()
         self.m_PcanHandle = globals()[channel]
+        self.mac_use_standard_message = kwargs.get("mac_use_standard_message", False)
 
         if state is BusState.ACTIVE or state is BusState.PASSIVE:
             self.state = state
@@ -311,9 +316,9 @@ class PcanBus(BusABC):
         result = None
         while result is None:
             if self.fd:
-                result = self.m_objPCANBasic.ReadFD(self.m_PcanHandle)
+                result = self.m_objPCANBasic.ReadFD(self.m_PcanHandle, self.mac_use_standard_message)
             else:
-                result = self.m_objPCANBasic.Read(self.m_PcanHandle)
+                result = self.m_objPCANBasic.Read(self.m_PcanHandle, self.mac_use_standard_message)
             if result[0] == PCAN_ERROR_QRCVEMPTY:
                 if HAS_EVENTS:
                     result = None
@@ -401,7 +406,7 @@ class PcanBus(BusABC):
 
         if self.fd:
             # create a TPCANMsg message structure
-            if platform.system() == "Darwin":
+            if platform.system() == "Darwin" and not self.mac_use_standard_message:
                 CANMsg = TPCANMsgFDMac()
             else:
                 CANMsg = TPCANMsgFD()
@@ -422,7 +427,7 @@ class PcanBus(BusABC):
 
         else:
             # create a TPCANMsg message structure
-            if platform.system() == "Darwin":
+            if platform.system() == "Darwin" and not self.mac_use_standard_message:
                 CANMsg = TPCANMsgMac()
             else:
                 CANMsg = TPCANMsg()


### PR DESCRIPTION
# Problem
It appears like the latest Mac PCUSB driver is using 32 bit MSG ID values instead of 64 bit. This breaks extended message IDs which show up as standard-size at the receiver.

For example:
```
message = can.Message(arbitration_id=0xF123, is_extended_id=True,
                      data=[0x11, 0x22, 0x33])
```
will actually end up with `arbitration_id=0x123`

# Solution
This change adds a (backwards compatible) flag `mac_use_standard_message` which uses the standard message type (as in not the mac-specific one) for communicating with the driver.

The arguments all use default values, and this will not break upgrades for any existing users.

This change was validated on `Mac OSX 10.14.6` with `libPCUSB v0.9`