### PR TITLE
changes absolute imports to explicit relative imports 

### DIFF
--- a/can/broadcastmanager.py
+++ b/can/broadcastmanager.py
@@ -7,12 +7,12 @@ The main entry point to these classes should be through
 
 from typing import Optional, Sequence, Tuple, Union, Callable, TYPE_CHECKING
 
-from can import typechecking
+from . import typechecking
 
 if TYPE_CHECKING:
-    from can.bus import BusABC
+    from .bus import BusABC
 
-from can.message import Message
+from .message import Message
 
 import abc
 import logging

--- a/can/bus.py
+++ b/can/bus.py
@@ -4,17 +4,18 @@ Contains the ABC bus implementation and its documentation.
 
 from typing import cast, Any, Iterator, List, Optional, Sequence, Tuple, Union
 
-import can.typechecking
+from . import typechecking
 
 from abc import ABCMeta, abstractmethod
-import can
+
 import logging
 import threading
 from time import time
 from enum import Enum, auto
 
-from can.broadcastmanager import ThreadBasedCyclicSendTask
-from can.message import Message
+from . import broadcastmanager
+from .broadcastmanager import ThreadBasedCyclicSendTask
+from .message import Message
 
 LOG = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ class BusABC(metaclass=ABCMeta):
     def __init__(
         self,
         channel: Any,
-        can_filters: Optional[can.typechecking.CanFilters] = None,
+        can_filters: Optional[typechecking.CanFilters] = None,
         **kwargs: object
     ):
         """Construct and open a CAN bus instance of the specified type.
@@ -61,7 +62,7 @@ class BusABC(metaclass=ABCMeta):
         :param dict kwargs:
             Any backend dependent configurations are passed in this dictionary
         """
-        self._periodic_tasks: List[can.broadcastmanager.CyclicSendTaskABC] = []
+        self._periodic_tasks: List[broadcastmanager.CyclicSendTaskABC] = []
         self.set_filters(can_filters)
 
     def __str__(self) -> str:
@@ -176,7 +177,7 @@ class BusABC(metaclass=ABCMeta):
         period: float,
         duration: Optional[float] = None,
         store_task: bool = True,
-    ) -> can.broadcastmanager.CyclicSendTaskABC:
+    ) -> broadcastmanager.CyclicSendTaskABC:
         """Start sending messages at a given period on this bus.
 
         The task will be active until one of the following conditions are met:
@@ -246,7 +247,7 @@ class BusABC(metaclass=ABCMeta):
         msgs: Union[Sequence[Message], Message],
         period: float,
         duration: Optional[float] = None,
-    ) -> can.broadcastmanager.CyclicSendTaskABC:
+    ) -> broadcastmanager.CyclicSendTaskABC:
         """Default implementation of periodic message sending using threading.
 
         Override this method to enable a more efficient backend specific approach.
@@ -306,7 +307,7 @@ class BusABC(metaclass=ABCMeta):
                 yield msg
 
     @property
-    def filters(self) -> Optional[can.typechecking.CanFilters]:
+    def filters(self) -> Optional[typechecking.CanFilters]:
         """
         Modify the filters of this bus. See :meth:`~can.BusABC.set_filters`
         for details.
@@ -314,10 +315,10 @@ class BusABC(metaclass=ABCMeta):
         return self._filters
 
     @filters.setter
-    def filters(self, filters: Optional[can.typechecking.CanFilters]):
+    def filters(self, filters: Optional[typechecking.CanFilters]):
         self.set_filters(filters)
 
-    def set_filters(self, filters: Optional[can.typechecking.CanFilters] = None):
+    def set_filters(self, filters: Optional[typechecking.CanFilters] = None):
         """Apply filtering to all messages received by this Bus.
 
         All messages that match at least one filter are returned.
@@ -342,7 +343,7 @@ class BusABC(metaclass=ABCMeta):
         self._filters = filters or None
         self._apply_filters(self._filters)
 
-    def _apply_filters(self, filters: Optional[can.typechecking.CanFilters]):
+    def _apply_filters(self, filters: Optional[typechecking.CanFilters]):
         """
         Hook for applying the filters to the underlying kernel or
         hardware if supported/implemented by the interface.
@@ -370,7 +371,7 @@ class BusABC(metaclass=ABCMeta):
         for _filter in self._filters:
             # check if this filter even applies to the message
             if "extended" in _filter:
-                _filter = cast(can.typechecking.CanFilterExtended, _filter)
+                _filter = cast(typechecking.CanFilterExtended, _filter)
                 if _filter["extended"] != msg.is_extended_id:
                     continue
 
@@ -418,7 +419,7 @@ class BusABC(metaclass=ABCMeta):
         raise NotImplementedError("Property is not implemented.")
 
     @staticmethod
-    def _detect_available_configs() -> List[can.typechecking.AutoDetectedConfig]:
+    def _detect_available_configs() -> List[typechecking.AutoDetectedConfig]:
         """Detect all configurations/channels that this interface could
         currently connect with.
 

--- a/can/interfaces/canalystii.py
+++ b/can/interfaces/canalystii.py
@@ -1,7 +1,7 @@
 from ctypes import *
 import logging
 import platform
-from can import BusABC, Message
+from .. import BusABC, Message
 
 logger = logging.getLogger(__name__)
 

--- a/can/interfaces/cantact.py
+++ b/can/interfaces/cantact.py
@@ -6,7 +6,7 @@ import time
 import logging
 from unittest.mock import Mock
 
-from can import BusABC, Message
+from .. import BusABC, Message
 
 logger = logging.getLogger(__name__)
 

--- a/can/interfaces/ics_neovi/__init__.py
+++ b/can/interfaces/ics_neovi/__init__.py
@@ -1,4 +1,4 @@
 """
 """
 
-from can.interfaces.ics_neovi.neovi_bus import NeoViBus
+from .neovi_bus import NeoViBus

--- a/can/interfaces/ics_neovi/neovi_bus.py
+++ b/can/interfaces/ics_neovi/neovi_bus.py
@@ -15,7 +15,7 @@ from collections import deque, defaultdict
 from itertools import cycle
 from threading import Event
 
-from can import Message, CanError, BusABC
+from ... import Message, CanError, BusABC
 
 logger = logging.getLogger(__name__)
 

--- a/can/interfaces/iscan.py
+++ b/can/interfaces/iscan.py
@@ -6,7 +6,7 @@ import ctypes
 import time
 import logging
 
-from can import CanError, BusABC, Message
+from .. import CanError, BusABC, Message
 
 logger = logging.getLogger(__name__)
 

--- a/can/interfaces/ixxat/__init__.py
+++ b/can/interfaces/ixxat/__init__.py
@@ -4,4 +4,4 @@ Ctypes wrapper module for IXXAT Virtual CAN Interface V3 on win32 systems
 Copyright (C) 2016 Giuseppe Corbelli <giuseppe.corbelli@weightpack.com>
 """
 
-from can.interfaces.ixxat.canlib import IXXATBus
+from .canlib import IXXATBus

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -16,12 +16,12 @@ import functools
 import logging
 import sys
 
-from can import BusABC, Message
-from can.broadcastmanager import (
+from ... import BusABC, Message
+from ...broadcastmanager import (
     LimitedDurationCyclicSendTaskABC,
     RestartableCyclicTaskABC,
 )
-from can.ctypesutil import CLibrary, HANDLE, PHANDLE, HRESULT as ctypes_HRESULT
+from ...ctypesutil import CLibrary, HANDLE, PHANDLE, HRESULT as ctypes_HRESULT
 
 from . import constants, structures
 from .exceptions import *

--- a/can/interfaces/ixxat/exceptions.py
+++ b/can/interfaces/ixxat/exceptions.py
@@ -4,7 +4,7 @@ Ctypes wrapper module for IXXAT Virtual CAN Interface V3 on win32 systems
 Copyright (C) 2016 Giuseppe Corbelli <giuseppe.corbelli@weightpack.com>
 """
 
-from can import CanError
+from ... import CanError
 
 __all__ = [
     "VCITimeout",

--- a/can/interfaces/kvaser/__init__.py
+++ b/can/interfaces/kvaser/__init__.py
@@ -1,4 +1,4 @@
 """
 """
 
-from can.interfaces.kvaser.canlib import *
+from .canlib import *

--- a/can/interfaces/kvaser/canlib.py
+++ b/can/interfaces/kvaser/canlib.py
@@ -11,8 +11,8 @@ import time
 import logging
 import ctypes
 
-from can import CanError, BusABC
-from can import Message
+from ... import CanError, BusABC
+from ... import Message
 from . import constants as canstat
 from . import structures
 

--- a/can/interfaces/nican.py
+++ b/can/interfaces/nican.py
@@ -17,7 +17,7 @@ import ctypes
 import logging
 import sys
 
-from can import CanError, BusABC, Message
+from .. import CanError, BusABC, Message
 
 logger = logging.getLogger(__name__)
 

--- a/can/interfaces/pcan/__init__.py
+++ b/can/interfaces/pcan/__init__.py
@@ -1,4 +1,4 @@
 """
 """
 
-from can.interfaces.pcan.pcan import PcanBus
+from .pcan import PcanBus

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -6,9 +6,9 @@ import logging
 import time
 
 from typing import Optional
-from can import CanError, Message, BusABC
-from can.bus import BusState
-from can.util import len2dlc, dlc2len
+from ... import CanError, Message, BusABC
+from ...bus import BusState
+from ...util import len2dlc, dlc2len
 from .basic import *
 
 try:

--- a/can/interfaces/robotell.py
+++ b/can/interfaces/robotell.py
@@ -5,7 +5,7 @@ Interface for Chinese Robotell compatible interfaces (win32/linux).
 import time
 import logging
 
-from can import BusABC, Message
+from .. import BusABC, Message
 
 logger = logging.getLogger(__name__)
 

--- a/can/interfaces/seeedstudio/__init__.py
+++ b/can/interfaces/seeedstudio/__init__.py
@@ -1,4 +1,4 @@
 """
 """
 
-from can.interfaces.seeedstudio.seeedstudio import SeeedBus
+from .seeedstudio import SeeedBus

--- a/can/interfaces/seeedstudio/seeedstudio.py
+++ b/can/interfaces/seeedstudio/seeedstudio.py
@@ -10,7 +10,7 @@ import logging
 import struct
 import io
 from time import time
-from can import BusABC, Message
+from ... import BusABC, Message
 
 logger = logging.getLogger("seeedbus")
 

--- a/can/interfaces/serial/__init__.py
+++ b/can/interfaces/serial/__init__.py
@@ -1,4 +1,4 @@
 """
 """
 
-from can.interfaces.serial.serial_can import SerialBus as Bus
+from .serial_can import SerialBus as Bus

--- a/can/interfaces/serial/serial_can.py
+++ b/can/interfaces/serial/serial_can.py
@@ -8,7 +8,7 @@ recording CAN traces.
 import logging
 import struct
 
-from can import BusABC, Message
+from ... import BusABC, Message
 
 logger = logging.getLogger("can.serial")
 

--- a/can/interfaces/slcan.py
+++ b/can/interfaces/slcan.py
@@ -8,12 +8,12 @@ Interface for slcan compatible interfaces (win32/linux).
 """
 
 from typing import Any, Optional, Tuple
-from can import typechecking
+from .. import typechecking
 
 import time
 import logging
 
-from can import BusABC, Message
+from .. import BusABC, Message
 
 logger = logging.getLogger(__name__)
 

--- a/can/interfaces/socketcan/utils.py
+++ b/can/interfaces/socketcan/utils.py
@@ -10,8 +10,8 @@ import struct
 import subprocess
 from typing import cast, Iterable, Optional
 
-from can.interfaces.socketcan.constants import CAN_EFF_FLAG
-import can.typechecking as typechecking
+from .constants import CAN_EFF_FLAG
+from ... import typechecking
 
 log = logging.getLogger(__name__)
 

--- a/can/interfaces/systec/__init__.py
+++ b/can/interfaces/systec/__init__.py
@@ -1,4 +1,4 @@
 """
 """
 
-from can.interfaces.systec.ucanbus import UcanBus
+from .ucanbus import UcanBus

--- a/can/interfaces/systec/exceptions.py
+++ b/can/interfaces/systec/exceptions.py
@@ -1,5 +1,5 @@
 from .constants import ReturnCode
-from can import CanError
+from ... import CanError
 
 
 class UcanException(CanError):

--- a/can/interfaces/systec/ucanbus.py
+++ b/can/interfaces/systec/ucanbus.py
@@ -1,7 +1,7 @@
 import logging
 from threading import Event
 
-from can import BusABC, BusState, Message
+from ... import BusABC, BusState, Message
 
 from .constants import *
 from .structures import *

--- a/can/interfaces/usb2can/usb2canInterface.py
+++ b/can/interfaces/usb2can/usb2canInterface.py
@@ -5,7 +5,7 @@ This interface is for Windows only, otherwise use socketCAN.
 import logging
 from ctypes import byref
 
-from can import BusABC, Message, CanError
+from ... import BusABC, Message, CanError
 from .usb2canabstractionlayer import *
 from .serial_selector import find_serial_devices
 

--- a/can/interfaces/usb2can/usb2canabstractionlayer.py
+++ b/can/interfaces/usb2can/usb2canabstractionlayer.py
@@ -6,8 +6,7 @@ Socket CAN is recommended under Unix/Linux systems.
 from ctypes import *
 from struct import *
 import logging
-
-import can
+from ... import CanError
 
 log = logging.getLogger("can.usb2can")
 
@@ -98,7 +97,7 @@ class Usb2CanAbstractionLayer:
             result = self.__m_dllBasic.CanalOpen(config_ascii, flags)
         except Exception as ex:
             # catch any errors thrown by this call and re-raise
-            raise can.CanError(
+            raise CanError(
                 'CanalOpen() failed, configuration: "{}", error: {}'.format(
                     configuration, ex
                 )
@@ -108,7 +107,7 @@ class Usb2CanAbstractionLayer:
             # (see https://grodansparadis.gitbooks.io/the-vscp-daemon/canal_interface_specification.html)
             # raise an error if the return code is <= 0
             if result <= 0:
-                raise can.CanError(
+                raise CanError(
                     'CanalOpen() failed, configuration: "{}", return code: {}'.format(
                         configuration, result
                     )
@@ -130,7 +129,7 @@ class Usb2CanAbstractionLayer:
             return res
         except:
             log.warning("Sending error")
-            raise can.CanError("Failed to transmit frame")
+            raise CanError("Failed to transmit frame")
 
     def receive(self, handle, msg):
         try:

--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -31,8 +31,8 @@ except ImportError:
 
 # Import Modules
 # ==============
-from can import BusABC, Message
-from can.util import len2dlc, dlc2len, deprecated_args_alias
+from ... import BusABC, Message
+from ...util import len2dlc, dlc2len, deprecated_args_alias
 from .exceptions import VectorError
 
 # Define Module Logger

--- a/can/interfaces/vector/exceptions.py
+++ b/can/interfaces/vector/exceptions.py
@@ -1,7 +1,7 @@
 """
 """
 
-from can import CanError
+from ... import CanError
 
 
 class VectorError(CanError):

--- a/can/interfaces/virtual.py
+++ b/can/interfaces/virtual.py
@@ -6,7 +6,7 @@ Any VirtualBus instances connecting to the same channel
 and reside in the same process will receive the same messages.
 """
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
-from can import typechecking
+from .. import typechecking
 
 from copy import deepcopy
 import logging
@@ -15,9 +15,9 @@ import queue
 from threading import RLock
 from random import randint
 
-from can import CanError
-from can.bus import BusABC
-from can.message import Message
+from .. import CanError
+from ..bus import BusABC
+from ..message import Message
 
 logger = logging.getLogger(__name__)
 

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -7,7 +7,7 @@ Example .asc files:
 """
 
 from typing import cast, Any, Generator, IO, List, Optional, Union, Dict
-from can import typechecking
+from .. import typechecking
 
 from datetime import datetime
 import time

--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -19,9 +19,9 @@ import time
 import logging
 from typing import List
 
-from can.message import Message
-from can.listener import Listener
-from can.util import len2dlc, dlc2len, channel2int
+from ..message import Message
+from ..listener import Listener
+from ..util import len2dlc, dlc2len, channel2int
 from .generic import BaseIOHandler
 
 

--- a/can/io/canutils.py
+++ b/can/io/canutils.py
@@ -6,8 +6,8 @@ It is is compatible with "candump -L" from the canutils program
 
 import logging
 
-from can.message import Message
-from can.listener import Listener
+from ..message import Message
+from ..listener import Listener
 from .generic import BaseIOHandler
 
 

--- a/can/io/csv.py
+++ b/can/io/csv.py
@@ -11,8 +11,8 @@ TODO: This module could use https://docs.python.org/2/library/csv.html#module-cs
 
 from base64 import b64encode, b64decode
 
-from can.message import Message
-from can.listener import Listener
+from ..message import Message
+from ..listener import Listener
 from .generic import BaseIOHandler
 
 

--- a/can/io/generic.py
+++ b/can/io/generic.py
@@ -5,8 +5,8 @@ Contains a generic class for file IO.
 from abc import ABCMeta
 from typing import Optional, cast, Union, TextIO, BinaryIO
 
-import can
-import can.typechecking
+from .. import typechecking
+from ..listener import Listener
 
 
 class BaseIOHandler(metaclass=ABCMeta):
@@ -19,7 +19,7 @@ class BaseIOHandler(metaclass=ABCMeta):
         was opened
     """
 
-    def __init__(self, file: can.typechecking.AcceptedIOType, mode: str = "rt") -> None:
+    def __init__(self, file: typechecking.AcceptedIOType, mode: str = "rt") -> None:
         """
         :param file: a path-like object to open a file, a file-like object
                      to be used as a file or `None` to not use a file at all
@@ -28,10 +28,10 @@ class BaseIOHandler(metaclass=ABCMeta):
         """
         if file is None or (hasattr(file, "read") and hasattr(file, "write")):
             # file is None or some file-like object
-            self.file = cast(Optional[can.typechecking.FileLike], file)
+            self.file = cast(Optional[typechecking.FileLike], file)
         else:
             # file is some path-like object
-            self.file = open(cast(can.typechecking.StringPathLike, file), mode)
+            self.file = open(cast(typechecking.StringPathLike, file), mode)
 
         # for multiple inheritance
         super().__init__()
@@ -50,7 +50,7 @@ class BaseIOHandler(metaclass=ABCMeta):
 
 
 # pylint: disable=abstract-method,too-few-public-methods
-class MessageWriter(BaseIOHandler, can.Listener, metaclass=ABCMeta):
+class MessageWriter(BaseIOHandler, Listener, metaclass=ABCMeta):
     """The base class for all writers."""
 
 

--- a/can/io/printer.py
+++ b/can/io/printer.py
@@ -4,7 +4,7 @@ This Listener simply prints to stdout / the terminal or a file.
 
 import logging
 
-from can.listener import Listener
+from ..listener import Listener
 from .generic import BaseIOHandler
 
 log = logging.getLogger("can.io.printer")

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -9,8 +9,8 @@ import threading
 import logging
 import sqlite3
 
-from can.listener import BufferedReader
-from can.message import Message
+from ..listener import BufferedReader
+from ..message import Message
 from .generic import BaseIOHandler
 
 log = logging.getLogger("can.io.sqlite")

--- a/can/listener.py
+++ b/can/listener.py
@@ -4,8 +4,8 @@ This module contains the implementation of `can.Listener` and some readers.
 
 from typing import AsyncIterator, Awaitable, Optional
 
-from can.message import Message
-from can.bus import BusABC
+from .message import Message
+from .bus import BusABC
 
 from abc import ABCMeta, abstractmethod
 

--- a/can/logger.py
+++ b/can/logger.py
@@ -19,8 +19,14 @@ import argparse
 import socket
 from datetime import datetime
 
-import can
-from can import Bus, BusState, Logger, SizedRotatingLogger
+from . import (
+    Bus,
+    BusState,
+    Logger,
+    SizedRotatingLogger,
+    VALID_INTERFACES,
+    set_logging_level
+)
 
 
 def main():
@@ -69,7 +75,7 @@ def main():
         dest="interface",
         help="""Specify the backend CAN interface to use. If left blank,
                         fall back to reading from configuration files.""",
-        choices=can.VALID_INTERFACES,
+        choices=VALID_INTERFACES,
     )
 
     parser.add_argument(
@@ -118,7 +124,7 @@ def main():
     logging_level_name = ["critical", "error", "warning", "info", "debug", "subdebug"][
         min(5, verbosity)
     ]
-    can.set_logging_level(logging_level_name)
+    set_logging_level(logging_level_name)
 
     can_filters = []
     if results.filter:

--- a/can/notifier.py
+++ b/can/notifier.py
@@ -4,9 +4,9 @@ This module contains the implementation of :class:`~can.Notifier`.
 
 from typing import Iterable, List, Optional, Union
 
-from can.bus import BusABC
-from can.listener import Listener
-from can.message import Message
+from .bus import BusABC
+from .listener import Listener
+from .message import Message
 
 import threading
 import logging

--- a/can/player.py
+++ b/can/player.py
@@ -9,8 +9,13 @@ import sys
 import argparse
 from datetime import datetime
 
-import can
-from can import Bus, LogReader, MessageSync
+from . import (
+    Bus,
+    LogReader,
+    MessageSync,
+    VALID_INTERFACES,
+    set_logging_level
+)
 
 
 def main():
@@ -49,7 +54,7 @@ def main():
         dest="interface",
         help="""Specify the backend CAN interface to use. If left blank,
                         fall back to reading from configuration files.""",
-        choices=can.VALID_INTERFACES,
+        choices=VALID_INTERFACES,
     )
 
     parser.add_argument(
@@ -113,7 +118,7 @@ def main():
     logging_level_name = ["critical", "error", "warning", "info", "debug", "subdebug"][
         min(5, verbosity)
     ]
-    can.set_logging_level(logging_level_name)
+    set_logging_level(logging_level_name)
 
     error_frames = results.error_frames
 

--- a/can/util.py
+++ b/can/util.py
@@ -5,7 +5,7 @@ import functools
 import warnings
 from typing import Dict, Optional, Union
 
-from can import typechecking
+from . import typechecking
 
 import json
 import os
@@ -15,8 +15,12 @@ import re
 import logging
 from configparser import ConfigParser
 
-import can
-from can.interfaces import VALID_INTERFACES
+from .interfaces import VALID_INTERFACES
+from . import (
+    rc,
+    BitTiming,
+    log
+)
 
 log = logging.getLogger("can.util")
 
@@ -159,7 +163,7 @@ def load_config(
     # use the given dict for default values
     config_sources = [
         given_config,
-        can.rc,
+        rc,
         lambda _context: load_environment_config(  # pylint: disable=unnecessary-lambda
             _context
         ),
@@ -216,9 +220,9 @@ def load_config(
             del config[key]
     if timing_conf:
         timing_conf["bitrate"] = config.get("bitrate")
-        config["timing"] = can.BitTiming(**timing_conf)
+        config["timing"] = BitTiming(**timing_conf)
 
-    can.log.debug("can config: {}".format(config))
+    log.debug("can config: {}".format(config))
     return config
 
 

--- a/can/viewer.py
+++ b/can/viewer.py
@@ -28,8 +28,11 @@ import sys
 import time
 from typing import Dict, List, Tuple, Union
 
-import can
-from can import __version__
+from . import (
+    __version__,
+    VALID_INTERFACES,
+    Bus
+)
 
 logger = logging.getLogger("can.serial")
 
@@ -455,7 +458,7 @@ def parse_args(args):
         "--interface",
         dest="interface",
         help="R|Specify the backend CAN interface to use.",
-        choices=sorted(can.VALID_INTERFACES),
+        choices=sorted(VALID_INTERFACES),
     )
 
     # Print help message when no arguments are given
@@ -551,7 +554,7 @@ def main():  # pragma: no cover
         config["data_bitrate"] = parsed_args.data_bitrate
 
     # Create a CAN-Bus interface
-    bus = can.Bus(parsed_args.channel, **config)
+    bus = Bus(parsed_args.channel, **config)
     # print('Connected to {}: {}'.format(bus.__class__.__name__, bus.channel_info))
 
     curses.wrapper(CanViewer, bus, data_structs)


### PR DESCRIPTION
this is done so if a user wants to package the library into their application they will be able to without having to modify sys.path.
It is also done to prevent name conflicts with any other package that may be named can.