### PR TITLE
Fixed is_extended_id for canalystii

### DIFF
--- a/can/interfaces/canalystii.py
+++ b/can/interfaces/canalystii.py
@@ -185,6 +185,7 @@ class CANalystIIBus(BusABC):
                     timestamp=raw_message.TimeStamp if raw_message.TimeFlag else 0.0,
                     arbitration_id=raw_message.ID,
                     is_remote_frame=raw_message.RemoteFlag,
+                    is_extended_id=raw_message.ExternFlag,
                     channel=0,
                     dlc=raw_message.DataLen,
                     data=raw_message.Data,


### PR DESCRIPTION
Canalyst II USB adapter always returns "is_extende_id" to TRUE regardless of the messages received.
With this patch the Message returned by _recv_internal take advantage of the internal data in raw_message.ExternFlag and copy that information to the proper field is_extended_id.