### PR TITLE
Fix compatibility with latest PCAN macOS SDK.

### DIFF
--- a/can/interfaces/pcan/basic.py
+++ b/can/interfaces/pcan/basic.py
@@ -1,18 +1,29 @@
-"""
-PCAN-Basic API
+#  PCANBasic.py
+#
+#  ~~~~~~~~~~~~
+#
+#  PCAN-Basic API
+#
+#  ~~~~~~~~~~~~
+#
+#  ------------------------------------------------------------------
+#  Author : Keneth Wagner
+#  Last change: 14.01.2021 Wagner
+#
+#  Language: Python 2.7, 3.7
+#  ------------------------------------------------------------------
+#
+#  Copyright (C) 1999-2021  PEAK-System Technik GmbH, Darmstadt
+#  more Info at http://www.peak-system.com
+#
 
-Author: Keneth Wagner
-Last change: 02.07.2020 Wagner
-
-Language: Python 2.7, 3.5
-
-Copyright (C) 1999-2020  PEAK-System Technik GmbH, Darmstadt, Germany
-http://www.peak-system.com
-"""
-
+# Module Imports
+#
 from ctypes import *
+from ctypes.util import find_library
 from string import *
 import platform
+
 import logging
 
 if platform.system() == "Windows":
@@ -41,7 +52,7 @@ TPCANTimestampFD = c_ulonglong  # Represents a timestamp of a received PCAN FD m
 # ///////////////////////////////////////////////////////////
 
 # Currently defined and supported PCAN channels
-
+#
 PCAN_NONEBUS = TPCANHandle(0x00)  # Undefined/default value for a PCAN bus
 
 PCAN_ISABUS1 = TPCANHandle(0x21)  # PCAN-ISA interface, channel 1
@@ -110,6 +121,7 @@ PCAN_LANBUS15 = TPCANHandle(0x80F)  # PCAN-LAN interface, channel 15
 PCAN_LANBUS16 = TPCANHandle(0x810)  # PCAN-LAN interface, channel 16
 
 # Represent the PCAN error and status codes
+#
 PCAN_ERROR_OK = TPCANStatus(0x00000)  # No error
 PCAN_ERROR_XMTFULL = TPCANStatus(0x00001)  # Transmit buffer in CAN controller is full
 PCAN_ERROR_OVERRUN = TPCANStatus(0x00002)  # CAN controller was read too late
@@ -171,10 +183,9 @@ PCAN_ERROR_ILLOPERATION = TPCANStatus(
 )  # Invalid operation [Value was changed from 0x80000 to 0x8000000]
 
 # PCAN devices
+#
 PCAN_NONE = TPCANDevice(0x00)  # Undefined, unknown or not selected PCAN device value
-PCAN_PEAKCAN = TPCANDevice(
-    0x01
-)  # PCAN Non-Plug&Play devices. NOT USED WITHIN PCAN-Basic API
+PCAN_PEAKCAN = TPCANDevice(0x01)  # PCAN Non-PnP devices. NOT USED WITHIN PCAN-Basic API
 PCAN_ISA = TPCANDevice(0x02)  # PCAN-ISA, PCAN-PC/104, and PCAN-PC/104-Plus
 PCAN_DNG = TPCANDevice(0x03)  # PCAN-Dongle
 PCAN_PCI = TPCANDevice(0x04)  # PCAN-PCI, PCAN-cPCI, PCAN-miniPCI, and PCAN-PCI Express
@@ -186,8 +197,9 @@ PCAN_VIRTUAL = TPCANDevice(
 PCAN_LAN = TPCANDevice(0x08)  # PCAN Gateway devices
 
 # PCAN parameters
-PCAN_DEVICE_ID = TPCANParameter(0x01)  # PCAN-USB device identifier parameter
-PCAN_5VOLTS_POWER = TPCANParameter(0x02)  # PCAN-PC Card 5-Volt power parameter
+#
+PCAN_DEVICE_ID = TPCANParameter(0x01)  # Device identifier parameter
+PCAN_5VOLTS_POWER = TPCANParameter(0x02)  # 5-Volt power parameter
 PCAN_RECEIVE_EVENT = TPCANParameter(0x03)  # PCAN receive event handler parameter
 PCAN_MESSAGE_FILTER = TPCANParameter(0x04)  # PCAN message filter parameter
 PCAN_API_VERSION = TPCANParameter(0x05)  # PCAN-Basic API version parameter
@@ -277,9 +289,11 @@ PCAN_ATTACHED_CHANNELS = TPCANParameter(
 )  # Get information about PCAN channels attached to a system
 
 # DEPRECATED parameters
+#
 PCAN_DEVICE_NUMBER = PCAN_DEVICE_ID  # DEPRECATED. Use PCAN_DEVICE_ID instead
 
 # PCAN parameter values
+#
 PCAN_PARAMETER_OFF = int(0x00)  # The PCAN parameter is not set (inactive)
 PCAN_PARAMETER_ON = int(0x01)  # The PCAN parameter is set (active)
 PCAN_FILTER_CLOSE = int(0x00)  # The PCAN filter is closed. No messages will be received
@@ -294,7 +308,7 @@ PCAN_CHANNEL_UNAVAILABLE = int(
 )  # The PCAN-Channel handle is illegal, or its associated hardware is not available
 PCAN_CHANNEL_AVAILABLE = int(
     0x01
-)  # The PCAN-Channel handle is available to be connected (Plug&Play Hardware: it means furthermore that the hardware is plugged-in)
+)  # The PCAN-Channel handle is available to be connected (PnP Hardware: it means furthermore that the hardware is plugged-in)
 PCAN_CHANNEL_OCCUPIED = int(
     0x02
 )  # The PCAN-Channel handle is valid, and is already being used
@@ -340,6 +354,7 @@ SERVICE_STATUS_STOPPED = int(0x01)  # The service is not running
 SERVICE_STATUS_RUNNING = int(0x04)  # The service is running
 
 # Other constants
+#
 MAX_LENGTH_HARDWARE_NAME = int(
     33
 )  # Maximum length of the name of a device: 32 characters + terminator
@@ -348,6 +363,7 @@ MAX_LENGTH_VERSION_STRING = int(
 )  # Maximum length of a version string: 17 characters + terminator
 
 # PCAN message types
+#
 PCAN_MESSAGE_STANDARD = TPCANMessageType(
     0x00
 )  # The PCAN message is a CAN Standard Frame (11-bit identifier)
@@ -373,7 +389,19 @@ PCAN_MESSAGE_STATUS = TPCANMessageType(
     0x80
 )  # The PCAN message represents a PCAN status message
 
+# LookUp Parameters
+#
+LOOKUP_DEVICE_TYPE = (
+    b"devicetype"
+)  # Lookup channel by Device type (see PCAN devices e.g. PCAN_USB)
+LOOKUP_DEVICE_ID = b"deviceid"  # Lookup channel by device id
+LOOKUP_CONTROLLER_NUMBER = (
+    b"controllernumber"
+)  # Lookup channel by CAN controller 0-based index
+LOOKUP_IP_ADDRESS = b"ipaddress"  # Lookup channel by IP address (LAN channels only)
+
 # Frame Type / Initialization Mode
+#
 PCAN_MODE_STANDARD = PCAN_MESSAGE_STANDARD
 PCAN_MODE_EXTENDED = PCAN_MESSAGE_EXTENDED
 
@@ -381,21 +409,21 @@ PCAN_MODE_EXTENDED = PCAN_MESSAGE_EXTENDED
 # You can define your own Baud rate with the BTROBTR1 register.
 # Take a look at www.peak-system.com for our free software "BAUDTOOL"
 # to calculate the BTROBTR1 register for every bit rate and sample point.
-
-PCAN_BAUD_1M = TPCANBaudrate(0x0014)  #   1     MBit/s
-PCAN_BAUD_800K = TPCANBaudrate(0x0016)  # 800     kBit/s
-PCAN_BAUD_500K = TPCANBaudrate(0x001C)  # 500     kBit/s
-PCAN_BAUD_250K = TPCANBaudrate(0x011C)  # 250     kBit/s
-PCAN_BAUD_125K = TPCANBaudrate(0x031C)  # 125     kBit/s
-PCAN_BAUD_100K = TPCANBaudrate(0x432F)  # 100     kBit/s
+#
+PCAN_BAUD_1M = TPCANBaudrate(0x0014)  #   1 MBit/s
+PCAN_BAUD_800K = TPCANBaudrate(0x0016)  # 800 kBit/s
+PCAN_BAUD_500K = TPCANBaudrate(0x001C)  # 500 kBit/s
+PCAN_BAUD_250K = TPCANBaudrate(0x011C)  # 250 kBit/s
+PCAN_BAUD_125K = TPCANBaudrate(0x031C)  # 125 kBit/s
+PCAN_BAUD_100K = TPCANBaudrate(0x432F)  # 100 kBit/s
 PCAN_BAUD_95K = TPCANBaudrate(0xC34E)  #  95,238 kBit/s
 PCAN_BAUD_83K = TPCANBaudrate(0x852B)  #  83,333 kBit/s
-PCAN_BAUD_50K = TPCANBaudrate(0x472F)  #  50     kBit/s
+PCAN_BAUD_50K = TPCANBaudrate(0x472F)  #  50 kBit/s
 PCAN_BAUD_47K = TPCANBaudrate(0x1414)  #  47,619 kBit/s
 PCAN_BAUD_33K = TPCANBaudrate(0x8B2F)  #  33,333 kBit/s
-PCAN_BAUD_20K = TPCANBaudrate(0x532F)  #  20     kBit/s
-PCAN_BAUD_10K = TPCANBaudrate(0x672F)  #  10     kBit/s
-PCAN_BAUD_5K = TPCANBaudrate(0x7F7F)  #   5     kBit/s
+PCAN_BAUD_20K = TPCANBaudrate(0x532F)  #  20 kBit/s
+PCAN_BAUD_10K = TPCANBaudrate(0x672F)  #  10 kBit/s
+PCAN_BAUD_5K = TPCANBaudrate(0x7F7F)  #   5 kBit/s
 
 # Represents the configuration for a CAN bit rate
 # Note:
@@ -418,7 +446,8 @@ PCAN_BR_DATA_TSEG2 = TPCANBitrateFD(b"data_tseg2")
 PCAN_BR_DATA_SJW = TPCANBitrateFD(b"data_sjw")
 PCAN_BR_DATA_SAMPLE = TPCANBitrateFD(b"data_ssp_offset")
 
-# Supported No-Plug-And-Play Hardware types
+# Supported Non-PnP Hardware types
+#
 PCAN_TYPE_ISA = TPCANType(0x01)  # PCAN-ISA 82C200
 PCAN_TYPE_ISA_SJA = TPCANType(0x09)  # PCAN-ISA SJA1000
 PCAN_TYPE_ISA_PHYTEC = TPCANType(0x04)  # PHYTEC ISA
@@ -460,6 +489,8 @@ PCAN_DICT_STATUS = {
 }
 
 
+# Represents a PCAN message
+#
 class TPCANMsg(Structure):
     """
     Represents a PCAN message
@@ -473,22 +504,9 @@ class TPCANMsg(Structure):
     ]  # Data of the message (DATA[0]..DATA[7])
 
 
-class TPCANMsgMac(Structure):
-    """
-    Represents a PCAN message
-    """
-
-    _fields_ = [
-        (
-            "ID",
-            c_ulong,
-        ),  # 11/29-bit message identifier - was changed from u_uint to c_ulong, so it is compatible with the PCAN-USB Driver for macOS
-        ("MSGTYPE", TPCANMessageType),  # Type of the message
-        ("LEN", c_ubyte),  # Data Length Code of the message (0..8)
-        ("DATA", c_ubyte * 8),
-    ]  # Data of the message (DATA[0]..DATA[7])
-
-
+# Represents a timestamp of a received PCAN message
+# Total Microseconds = micros + 1000 * millis + 0x100000000 * 1000 * millis_overflow
+#
 class TPCANTimestamp(Structure):
     """
     Represents a timestamp of a received PCAN message
@@ -502,22 +520,8 @@ class TPCANTimestamp(Structure):
     ]  # Microseconds: 0..999
 
 
-class TPCANTimestampMac(Structure):
-    """
-    Represents a timestamp of a received PCAN message
-    Total Microseconds = micros + 1000 * millis + 0x100000000 * 1000 * millis_overflow
-    """
-
-    _fields_ = [
-        (
-            "millis",
-            c_ulong,
-        ),  # Base-value: milliseconds: 0.. 2^32-1 - was changed from u_uint to c_ulong, so it is compatible with the PCAN-USB Driver for macOS
-        ("millis_overflow", c_ushort),  # Roll-arounds of millis
-        ("micros", c_ushort),
-    ]  # Microseconds: 0..999
-
-
+# Represents a PCAN message from a FD capable hardware
+#
 class TPCANMsgFD(Structure):
     """
     Represents a PCAN message
@@ -531,22 +535,8 @@ class TPCANMsgFD(Structure):
     ]  # Data of the message (DATA[0]..DATA[63])
 
 
-class TPCANMsgFDMac(Structure):
-    """
-    Represents a PCAN message
-    """
-
-    _fields_ = [
-        (
-            "ID",
-            c_ulong,
-        ),  # 11/29-bit message identifier - was changed from u_uint to c_ulong, so it is compatible with the PCAN-USB Driver for macOS
-        ("MSGTYPE", TPCANMessageType),  # Type of the message
-        ("DLC", c_ubyte),  # Data Length Code of the message (0..15)
-        ("DATA", c_ubyte * 64),
-    ]  # Data of the message (DATA[0]..DATA[63])
-
-
+# Describes an available PCAN channel
+#
 class TPCANChannelInformation(Structure):
     """
     Describes an available PCAN channel
@@ -567,14 +557,18 @@ class TPCANChannelInformation(Structure):
 # PCAN-Basic API function declarations
 # ///////////////////////////////////////////////////////////
 
-
+# PCAN-Basic API class implementation
+#
 class PCANBasic:
-    """PCAN-Basic API class implementation
+    """
+      PCAN-Basic API class implementation
     """
 
     def __init__(self):
-        # Loads the PCANBasic.dll and checks if driver is available
+        # Loads the PCANBasic API
+        #
         if platform.system() == "Windows":
+            # Loads the API on Windows
             self.__m_dllBasic = windll.LoadLibrary("PCANBasic")
             aReg = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
             try:
@@ -588,13 +582,18 @@ class PCANBasic:
             self.__m_dllBasic = cdll.LoadLibrary("PCANBasic.dll")
             # Unfortunately cygwin python has no winreg module, so we can't
             # check for the registry key.
+        elif platform.system() == "Linux":
+            # Loads the API on Linux
+            self.__m_dllBasic = cdll.LoadLibrary("libpcanbasic.so")
         elif platform.system() == "Darwin":
-            self.__m_dllBasic = cdll.LoadLibrary(util.find_library("libPCBUSB.dylib"))
+            self.__m_dllBasic = cdll.LoadLibrary(find_library("libPCBUSB.dylib"))
         else:
             self.__m_dllBasic = cdll.LoadLibrary("libpcanbasic.so")
         if self.__m_dllBasic is None:
             logger.error("Exception: The PCAN-Basic DLL couldn't be loaded!")
 
+    # Initializes a PCAN Channel
+    #
     def Initialize(
         self,
         Channel,
@@ -610,10 +609,10 @@ class PCANBasic:
         Parameters:
           Channel  : A TPCANHandle representing a PCAN Channel
           Btr0Btr1 : The speed for the communication (BTR0BTR1 code)
-          HwType   : NON PLUG&PLAY: The type of hardware and operation mode
-          IOPort   : NON PLUG&PLAY: The I/O address for the parallel port
-          Interrupt: NON PLUG&PLAY: Interrupt number of the parallel port
-
+          HwType   : Non-PnP: The type of hardware and operation mode
+          IOPort   : Non-PnP: The I/O address for the parallel port
+          Interrupt: Non-PnP: Interrupt number of the parallel port
+        
         Returns:
           A TPCANStatus error code
         """
@@ -626,24 +625,26 @@ class PCANBasic:
             logger.error("Exception on PCANBasic.Initialize")
             raise
 
+    # Initializes a FD capable PCAN Channel
+    #
     def InitializeFD(self, Channel, BitrateFD):
 
         """
-          Initializes a FD capable PCAN Channel
+          Initializes a FD capable PCAN Channel  
 
         Parameters:
           Channel  : The handle of a FD capable PCAN Channel
           BitrateFD : The speed for the communication (FD bit rate string)
 
-    Remarks:
-      See PCAN_BR_* values.
+		Remarks:
+		  See PCAN_BR_* values.
           * parameter and values must be separated by '='
           * Couples of Parameter/value must be separated by ','
           * Following Parameter must be filled out: f_clock, data_brp, data_sjw, data_tseg1, data_tseg2,
             nom_brp, nom_sjw, nom_tseg1, nom_tseg2.
-          * Following Parameters are optional (not used yet): data_ssp_offset, nom_samp
+          * Following Parameters are optional (not used yet): data_ssp_offset, nom_sam
 
-        Example:
+		Example:
           f_clock=80000000,nom_brp=10,nom_tseg1=5,nom_tseg2=2,nom_sjw=1,data_brp=4,data_tseg1=7,data_tseg2=2,data_sjw=1
 
         Returns:
@@ -656,17 +657,19 @@ class PCANBasic:
             logger.error("Exception on PCANBasic.InitializeFD")
             raise
 
+    #  Uninitializes one or all PCAN Channels initialized by CAN_Initialize
+    #
     def Uninitialize(self, Channel):
 
         """
           Uninitializes one or all PCAN Channels initialized by CAN_Initialize
-
+          
         Remarks:
           Giving the TPCANHandle value "PCAN_NONEBUS", uninitialize all initialized channels
-
+          
         Parameters:
           Channel  : A TPCANHandle representing a PCAN Channel
-
+        
         Returns:
           A TPCANStatus error code
         """
@@ -677,17 +680,19 @@ class PCANBasic:
             logger.error("Exception on PCANBasic.Uninitialize")
             raise
 
+    #  Resets the receive and transmit queues of the PCAN Channel
+    #
     def Reset(self, Channel):
 
         """
           Resets the receive and transmit queues of the PCAN Channel
-
+          
         Remarks:
           A reset of the CAN controller is not performed
-
+          
         Parameters:
           Channel  : A TPCANHandle representing a PCAN Channel
-
+        
         Returns:
           A TPCANStatus error code
         """
@@ -698,14 +703,16 @@ class PCANBasic:
             logger.error("Exception on PCANBasic.Reset")
             raise
 
+    #  Gets the current status of a PCAN Channel
+    #
     def GetStatus(self, Channel):
 
         """
           Gets the current status of a PCAN Channel
-
+          
         Parameters:
           Channel  : A TPCANHandle representing a PCAN Channel
-
+        
         Returns:
           A TPCANStatus error code
         """
@@ -716,62 +723,59 @@ class PCANBasic:
             logger.error("Exception on PCANBasic.GetStatus")
             raise
 
+    # Reads a CAN message from the receive queue of a PCAN Channel
+    #
     def Read(self, Channel):
 
         """
           Reads a CAN message from the receive queue of a PCAN Channel
 
         Remarks:
-          The return value of this method is a 3-touple, where
+          The return value of this method is a 3-touple, where 
           the first value is the result (TPCANStatus) of the method.
           The order of the values are:
           [0]: A TPCANStatus error code
           [1]: A TPCANMsg structure with the CAN message read
           [2]: A TPCANTimestamp structure with the time when a message was read
-
+          
         Parameters:
           Channel  : A TPCANHandle representing a PCAN Channel
-
+        
         Returns:
           A touple with three values
         """
         try:
-            if platform.system() == "Darwin":
-                msg = TPCANMsgMac()
-                timestamp = TPCANTimestampMac()
-            else:
-                msg = TPCANMsg()
-                timestamp = TPCANTimestamp()
+            msg = TPCANMsg()
+            timestamp = TPCANTimestamp()
             res = self.__m_dllBasic.CAN_Read(Channel, byref(msg), byref(timestamp))
             return TPCANStatus(res), msg, timestamp
         except:
             logger.error("Exception on PCANBasic.Read")
             raise
 
+    # Reads a CAN message from the receive queue of a FD capable PCAN Channel
+    #
     def ReadFD(self, Channel):
 
         """
           Reads a CAN message from the receive queue of a FD capable PCAN Channel
 
         Remarks:
-          The return value of this method is a 3-touple, where
+          The return value of this method is a 3-touple, where 
           the first value is the result (TPCANStatus) of the method.
           The order of the values are:
           [0]: A TPCANStatus error code
           [1]: A TPCANMsgFD structure with the CAN message read
           [2]: A TPCANTimestampFD that is the time when a message was read
-
+          
         Parameters:
           Channel  : The handle of a FD capable PCAN Channel
-
+        
         Returns:
           A touple with three values
         """
         try:
-            if platform.system() == "Darwin":
-                msg = TPCANMsgFDMac()
-            else:
-                msg = TPCANMsgFD()
+            msg = TPCANMsgFD()
             timestamp = TPCANTimestampFD()
             res = self.__m_dllBasic.CAN_ReadFD(Channel, byref(msg), byref(timestamp))
             return TPCANStatus(res), msg, timestamp
@@ -779,15 +783,17 @@ class PCANBasic:
             logger.error("Exception on PCANBasic.ReadFD")
             raise
 
+    # Transmits a CAN message
+    #
     def Write(self, Channel, MessageBuffer):
 
         """
-          Transmits a CAN message
-
+          Transmits a CAN message 
+          
         Parameters:
           Channel      : A TPCANHandle representing a PCAN Channel
           MessageBuffer: A TPCANMsg representing the CAN message to be sent
-
+        
         Returns:
           A TPCANStatus error code
         """
@@ -798,15 +804,17 @@ class PCANBasic:
             logger.error("Exception on PCANBasic.Write")
             raise
 
+    # Transmits a CAN message over a FD capable PCAN Channel
+    #
     def WriteFD(self, Channel, MessageBuffer):
 
         """
-          Transmits a CAN message over a FD capable PCAN Channel
-
+          Transmits a CAN message over a FD capable PCAN Channel 
+          
         Parameters:
           Channel      : The handle of a FD capable PCAN Channel
           MessageBuffer: A TPCANMsgFD buffer with the message to be sent
-
+        
         Returns:
           A TPCANStatus error code
         """
@@ -817,6 +825,8 @@ class PCANBasic:
             logger.error("Exception on PCANBasic.WriteFD")
             raise
 
+    # Configures the reception filter
+    #
     def FilterMessages(self, Channel, FromID, ToID, Mode):
 
         """
@@ -825,14 +835,14 @@ class PCANBasic:
         Remarks:
           The message filter will be expanded with every call to this function.
           If it is desired to reset the filter, please use the 'SetValue' function.
-
+        
         Parameters:
           Channel : A TPCANHandle representing a PCAN Channel
           FromID  : A c_uint value with the lowest CAN ID to be received
           ToID    : A c_uint value with the highest CAN ID to be received
-          Mode    : A TPCANMode representing the message type (Standard, 11-bit
+          Mode    : A TPCANMode representing the message type (Standard, 11-bit 
                     identifier, or Extended, 29-bit identifier)
-
+        
         Returns:
           A TPCANStatus error code
         """
@@ -843,6 +853,8 @@ class PCANBasic:
             logger.error("Exception on PCANBasic.FilterMessages")
             raise
 
+    # Retrieves a PCAN Channel value
+    #
     def GetValue(self, Channel, Parameter):
 
         """
@@ -852,35 +864,37 @@ class PCANBasic:
           Parameters can be present or not according with the kind
           of Hardware (PCAN Channel) being used. If a parameter is not available,
           a PCAN_ERROR_ILLPARAMTYPE error will be returned.
-
-          The return value of this method is a 2-touple, where
+          
+          The return value of this method is a 2-touple, where 
           the first value is the result (TPCANStatus) of the method and
-          the second one, the asked value
-
+          the second one, the asked value 
+          
         Parameters:
           Channel   : A TPCANHandle representing a PCAN Channel
           Parameter : The TPCANParameter parameter to get
-
+        
         Returns:
           A touple with 2 values
         """
         try:
-            if Parameter in (
-                PCAN_API_VERSION,
-                PCAN_HARDWARE_NAME,
-                PCAN_CHANNEL_VERSION,
-                PCAN_LOG_LOCATION,
-                PCAN_TRACE_LOCATION,
-                PCAN_BITRATE_INFO_FD,
-                PCAN_IP_ADDRESS,
-                PCAN_FIRMWARE_VERSION,
+            if (
+                Parameter == PCAN_API_VERSION
+                or Parameter == PCAN_HARDWARE_NAME
+                or Parameter == PCAN_CHANNEL_VERSION
+                or Parameter == PCAN_LOG_LOCATION
+                or Parameter == PCAN_TRACE_LOCATION
+                or Parameter == PCAN_BITRATE_INFO_FD
+                or Parameter == PCAN_IP_ADDRESS
+                or Parameter == PCAN_FIRMWARE_VERSION
             ):
                 mybuffer = create_string_buffer(256)
+
             elif Parameter == PCAN_ATTACHED_CHANNELS:
                 res = self.GetValue(Channel, PCAN_ATTACHED_CHANNELS_COUNT)
                 if TPCANStatus(res[0]) != PCAN_ERROR_OK:
                     return (TPCANStatus(res[0]),)
                 mybuffer = (TPCANChannelInformation * res[1])()
+
             else:
                 mybuffer = c_int(0)
 
@@ -895,6 +909,9 @@ class PCANBasic:
             logger.error("Exception on PCANBasic.GetValue")
             raise
 
+    # Returns a descriptive text of a given TPCANStatus
+    # error code, in any desired language
+    #
     def SetValue(self, Channel, Parameter, Buffer):
 
         """
@@ -905,18 +922,22 @@ class PCANBasic:
           Parameters can be present or not according with the kind
           of Hardware (PCAN Channel) being used. If a parameter is not available,
           a PCAN_ERROR_ILLPARAMTYPE error will be returned.
-
+          
         Parameters:
           Channel      : A TPCANHandle representing a PCAN Channel
           Parameter    : The TPCANParameter parameter to set
           Buffer       : Buffer with the value to be set
           BufferLength : Size in bytes of the buffer
-
+        
         Returns:
           A TPCANStatus error code
         """
         try:
-            if Parameter in (PCAN_LOG_LOCATION, PCAN_LOG_TEXT, PCAN_TRACE_LOCATION):
+            if (
+                Parameter == PCAN_LOG_LOCATION
+                or Parameter == PCAN_LOG_TEXT
+                or Parameter == PCAN_TRACE_LOCATION
+            ):
                 mybuffer = create_string_buffer(256)
             else:
                 mybuffer = c_int(0)
@@ -939,16 +960,16 @@ class PCANBasic:
 
           The current languages available for translation are:
           Neutral (0x00), German (0x07), English (0x09), Spanish (0x0A),
-          Italian (0x10) and French (0x0C)
+          Italian (0x10) and French (0x0C)          
 
-          The return value of this method is a 2-touple, where
+          The return value of this method is a 2-touple, where 
           the first value is the result (TPCANStatus) of the method and
           the second one, the error text
-
+          
         Parameters:
           Error    : A TPCANStatus error code
           Language : Indicates a 'Primary language ID' (Default is Neutral(0))
-
+        
         Returns:
           A touple with 2 values
         """
@@ -958,4 +979,30 @@ class PCANBasic:
             return TPCANStatus(res), mybuffer.value
         except:
             logger.error("Exception on PCANBasic.GetErrorText")
+            raise
+
+    def LookUpChannel(self, Parameters):
+
+        """
+            Finds a PCAN-Basic channel that matches with the given parameters
+
+        Remarks:
+
+          The return value of this method is a 2-touple, where 
+          the first value is the result (TPCANStatus) of the method and
+          the second one a TPCANHandle value
+        
+        Parameters:
+            Parameters   : A comma separated string contained pairs of parameter-name/value 
+                           to be matched within a PCAN-Basic channel
+
+        Returns:
+          A touple with 2 values
+        """
+        try:
+            mybuffer = TPCANHandle(0)
+            res = self.__m_dllBasic.CAN_LookUpChannel(Parameters, byref(mybuffer))
+            return TPCANStatus(res), mybuffer
+        except:
+            logger.error("Exception on PCANBasic.LookUpChannel")
             raise

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -281,12 +281,13 @@ class PcanBus(BusABC):
         if result != PCAN_ERROR_OK:
             raise PcanError(self._get_formatted_error(result))
 
-        result = self.m_objPCANBasic.SetValue(
-            self.m_PcanHandle, PCAN_ALLOW_ERROR_FRAMES, PCAN_PARAMETER_ON
-        )
+        if platform.system() != "Darwin":
+            result = self.m_objPCANBasic.SetValue(
+                self.m_PcanHandle, PCAN_ALLOW_ERROR_FRAMES, PCAN_PARAMETER_ON
+            )
 
-        if result != PCAN_ERROR_OK:
-            raise PcanError(self._get_formatted_error(result))
+            if result != PCAN_ERROR_OK:
+                raise PcanError(self._get_formatted_error(result))
 
         if HAS_EVENTS:
             self._recv_event = CreateEvent(None, 0, 0, None)
@@ -503,10 +504,7 @@ class PcanBus(BusABC):
 
         if self.fd:
             # create a TPCANMsg message structure
-            if platform.system() == "Darwin":
-                CANMsg = TPCANMsgFDMac()
-            else:
-                CANMsg = TPCANMsgFD()
+            CANMsg = TPCANMsgFD()
 
             # configure the message. ID, Length of data, message type and data
             CANMsg.ID = msg.arbitration_id
@@ -524,10 +522,7 @@ class PcanBus(BusABC):
 
         else:
             # create a TPCANMsg message structure
-            if platform.system() == "Darwin":
-                CANMsg = TPCANMsgMac()
-            else:
-                CANMsg = TPCANMsg()
+            CANMsg = TPCANMsg()
 
             # configure the message. ID, Length of data, message type and data
             CANMsg.ID = msg.arbitration_id


### PR DESCRIPTION
This PR makes python-can compatible with the latest MacCAN PCBUSB release (0.10).

Uses the latest PCANBasic wrapper from PCAN-Basic API v4.5.2.

This addresses #947, #948, #957.