### PR TITLE
FIX: Try to find libPCBUSB.dylib before loading it

### DIFF
--- a/can/interfaces/pcan/basic.py
+++ b/can/interfaces/pcan/basic.py
@@ -11,6 +11,7 @@ http://www.peak-system.com
 """
 
 from ctypes import *
+from ctypes.util import find_library
 from string import *
 import platform
 import logging
@@ -589,7 +590,7 @@ class PCANBasic:
             # Unfortunately cygwin python has no winreg module, so we can't
             # check for the registry key.
         elif platform.system() == "Darwin":
-            self.__m_dllBasic = cdll.LoadLibrary(util.find_library("libPCBUSB.dylib"))
+            self.__m_dllBasic = cdll.LoadLibrary(find_library("libPCBUSB.dylib"))
         else:
             self.__m_dllBasic = cdll.LoadLibrary("libpcanbasic.so")
         if self.__m_dllBasic is None:


### PR DESCRIPTION
`find_library` need to be imported explicitly.

Seems like path is not always resolved when the lib is installed.
    
On my end the lib was installed under /usr/local/lib/. the only way to get
it imported was to find the library and give the full path to the LoadLibrary call.

    Signed-off-by: Stephane Dorre <stephane.dorre@gmail.com>