### PR TITLE
Fix find_library call in PCAN layer, where PCAN library is loaded on Mac

### DIFF
--- a/can/interfaces/pcan/basic.py
+++ b/can/interfaces/pcan/basic.py
@@ -12,6 +12,7 @@ http://www.peak-system.com
 
 from ctypes import *
 from string import *
+from ctypes.utils import find_library
 import platform
 import logging
 
@@ -589,7 +590,7 @@ class PCANBasic:
             # Unfortunately cygwin python has no winreg module, so we can't
             # check for the registry key.
         elif platform.system() == "Darwin":
-            self.__m_dllBasic = cdll.LoadLibrary(util.find_library("libPCBUSB.dylib"))
+            self.__m_dllBasic = cdll.LoadLibrary(find_library("libPCBUSB.dylib"))
         else:
             self.__m_dllBasic = cdll.LoadLibrary("libpcanbasic.so")
         if self.__m_dllBasic is None:


### PR DESCRIPTION
This PR fixes an issue in the PCAN Interface layer, where the `find_library` function wasn't being referenced properly.