### PR TITLE
pcan: force english error messages (#993)

### DIFF
--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -253,12 +253,12 @@ class PcanBus(BusABC):
                 # Toggle the lowest set bit
                 n ^= masked_value
 
-        stsReturn = self.m_objPCANBasic.GetErrorText(error, 0)
+        stsReturn = self.m_objPCANBasic.GetErrorText(error, 0x9)
         if stsReturn[0] != PCAN_ERROR_OK:
             strings = []
 
             for b in bits(error):
-                stsReturn = self.m_objPCANBasic.GetErrorText(b, 0)
+                stsReturn = self.m_objPCANBasic.GetErrorText(b, 0x9)
                 if stsReturn[0] != PCAN_ERROR_OK:
                     text = "An error occurred. Error-code's text ({0:X}h) couldn't be retrieved".format(
                         error


### PR DESCRIPTION
On non-english Windows systems the "neutral" language causes
an UTF-8 encoding error while trying to log an error/warning.

Force using English error message which will not cause these.