### PR TITLE
Improve code of serial interface

### DIFF
--- a/can/bus.py
+++ b/can/bus.py
@@ -273,7 +273,7 @@ class BusABC(metaclass=ABCMeta):
         )
         return task
 
-    def stop_all_periodic_tasks(self, remove_tasks=True) -> None:
+    def stop_all_periodic_tasks(self, remove_tasks=True):
         """Stop sending any messages that were started using **bus.send_periodic**.
 
         .. note::

--- a/can/bus.py
+++ b/can/bus.py
@@ -151,7 +151,7 @@ class BusABC(metaclass=ABCMeta):
         raise NotImplementedError("Trying to read from a write only bus?")
 
     @abstractmethod
-    def send(self, msg: Message, timeout: Optional[float] = None):
+    def send(self, msg: Message, timeout: Optional[float] = None) -> None:
         """Transmit a message to the CAN bus.
 
         Override this method to enable the transmit path.
@@ -273,7 +273,7 @@ class BusABC(metaclass=ABCMeta):
         )
         return task
 
-    def stop_all_periodic_tasks(self, remove_tasks=True):
+    def stop_all_periodic_tasks(self, remove_tasks=True) -> None:
         """Stop sending any messages that were started using **bus.send_periodic**.
 
         .. note::
@@ -317,7 +317,7 @@ class BusABC(metaclass=ABCMeta):
     def filters(self, filters: Optional[can.typechecking.CanFilters]):
         self.set_filters(filters)
 
-    def set_filters(self, filters: Optional[can.typechecking.CanFilters] = None):
+    def set_filters(self, filters: Optional[can.typechecking.CanFilters] = None) -> None:
         """Apply filtering to all messages received by this Bus.
 
         All messages that match at least one filter are returned.
@@ -342,7 +342,7 @@ class BusABC(metaclass=ABCMeta):
         self._filters = filters or None
         self._apply_filters(self._filters)
 
-    def _apply_filters(self, filters: Optional[can.typechecking.CanFilters]):
+    def _apply_filters(self, filters: Optional[can.typechecking.CanFilters]) -> None:
         """
         Hook for applying the filters to the underlying kernel or
         hardware if supported/implemented by the interface.
@@ -387,10 +387,10 @@ class BusABC(metaclass=ABCMeta):
         # nothing matched
         return False
 
-    def flush_tx_buffer(self):
+    def flush_tx_buffer(self) -> None:
         """Discard every message that may be queued in the output buffer(s)."""
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         """
         Called to carry out any interface specific cleanup required
         in shutting down a bus.

--- a/can/interfaces/serial/serial_can.py
+++ b/can/interfaces/serial/serial_can.py
@@ -3,12 +3,16 @@ A text based interface. For example use over serial ports like
 "/dev/ttyS1" or "/dev/ttyUSB0" on Linux machines or "COM1" on Windows.
 The interface is a simple implementation that has been used for
 recording CAN traces.
+
+See the interface documentation for the format being used.
 """
 
 import logging
 import struct
+from typing import Any, List, Tuple, Optional
 
-from can import BusABC, Message
+from can import BusABC, Message, CanError
+from can.typechecking import AutoDetectedConfig
 
 logger = logging.getLogger("can.serial")
 
@@ -22,62 +26,63 @@ except ImportError:
     serial = None
 
 try:
-    from serial.tools import list_ports
+    from serial.tools.list_ports import comports as list_comports
 except ImportError:
-    list_ports = None
+    # If unavailable on some platform, just return nothing
+    def list_comports() -> List[Any]:
+        return []
 
 
 class SerialBus(BusABC):
     """
     Enable basic can communication over a serial device.
 
-    .. note:: See :meth:`can.interfaces.serial.SerialBus._recv_internal`
-              for some special semantics.
+    .. note:: See :meth:`~_recv_internal` for some special semantics.
 
     """
 
     def __init__(
-        self, channel, baudrate=115200, timeout=0.1, rtscts=False, *args, **kwargs
-    ):
+        self, channel: str, baudrate: int = 115200, timeout: float = 0.1, rtscts: bool = False, *args, **kwargs
+    ) -> None:
         """
-        :param str channel:
+        :param channel:
             The serial device to open. For example "/dev/ttyS1" or
             "/dev/ttyUSB0" on Linux or "COM1" on Windows systems.
 
-        :param int baudrate:
+        :param baudrate:
             Baud rate of the serial device in bit/s (default 115200).
 
             .. warning::
                 Some serial port implementations don't care about the baudrate.
 
-        :param float timeout:
+        :param timeout:
             Timeout for the serial device in seconds (default 0.1).
 
-        :param bool rtscts:
+        :param rtscts:
             turn hardware handshake (RTS/CTS) on and off
 
         """
         if not channel:
             raise ValueError("Must specify a serial port.")
 
-        self.channel_info = "Serial interface: " + channel
-        self.ser = serial.serial_for_url(
+        self.channel_info = f"Serial interface: {channel}"
+        self._ser = serial.serial_for_url(
             channel, baudrate=baudrate, timeout=timeout, rtscts=rtscts
         )
 
-        super().__init__(channel=channel, *args, **kwargs)
+        super().__init__(channel, *args, **kwargs)
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         """
         Close the serial interface.
         """
-        self.ser.close()
+        self._ser.close()
 
-    def send(self, msg, timeout=None):
+    def send(self, msg: Message, timeout: Optional[float] = None) -> None:
         """
         Send a message over the serial device.
 
-        :param can.Message msg:
+        :param msg:
             Message to send.
 
             .. note:: Flags like ``extended_id``, ``is_remote_frame`` and
@@ -91,27 +96,31 @@ class SerialBus(BusABC):
             used instead.
 
         """
+        # Pack timestamp
         try:
             timestamp = struct.pack("<I", int(msg.timestamp * 1000))
         except struct.error:
             raise ValueError("Timestamp is out of range")
+
+        # Pack arbitration ID
         try:
-            a_id = struct.pack("<I", msg.arbitration_id)
+            arbitration_id = struct.pack("<I", msg.arbitration_id)
         except struct.error:
-            raise ValueError("Arbitration Id is out of range")
+            raise ValueError("Arbitration ID is out of range")
+
+        # Assemble message
         byte_msg = bytearray()
         byte_msg.append(0xAA)
-        for i in range(0, 4):
-            byte_msg.append(timestamp[i])
+        byte_msg += timestamp
         byte_msg.append(msg.dlc)
-        for i in range(0, 4):
-            byte_msg.append(a_id[i])
-        for i in range(0, msg.dlc):
-            byte_msg.append(msg.data[i])
+        byte_msg += arbitration_id
+        byte_msg += msg.data
         byte_msg.append(0xBB)
-        self.ser.write(byte_msg)
 
-    def _recv_internal(self, timeout):
+        # Write to serial device
+        self._ser.write(byte_msg)
+
+    def _recv_internal(self, timeout: Optional[float]) -> Tuple[Optional[Message], bool]:
         """
         Read a message from the serial device.
 
@@ -127,55 +136,49 @@ class SerialBus(BusABC):
                 Flags like is_extended_id, is_remote_frame and is_error_frame
                 will not be set over this function, the flags in the return
                 message are the default values.
-
-        :rtype:
-            Tuple[can.Message, Bool]
         """
         try:
-            # ser.read can return an empty string
-            # or raise a SerialException
-            rx_byte = self.ser.read()
-        except serial.SerialException:
-            return None, False
+            rx_byte = self._ser.read()
+            if rx_byte and ord(rx_byte) == 0xAA:
 
-        if rx_byte and ord(rx_byte) == 0xAA:
-            s = bytearray(self.ser.read(4))
-            timestamp = (struct.unpack("<I", s))[0]
-            dlc = ord(self.ser.read())
+                s = self._ser.read(4)
+                timestamp = struct.unpack("<I", s)[0]
+                dlc = ord(self._ser.read())
 
-            s = bytearray(self.ser.read(4))
-            arb_id = (struct.unpack("<I", s))[0]
+                s = self._ser.read(4)
+                arb_id = struct.unpack("<I", s)[0]
 
-            data = self.ser.read(dlc)
+                data = self._ser.read(dlc)
 
-            rxd_byte = ord(self.ser.read())
-            if rxd_byte == 0xBB:
-                # received message data okay
-                msg = Message(
-                    timestamp=timestamp / 1000,
-                    arbitration_id=arb_id,
-                    dlc=dlc,
-                    data=data,
-                )
-                return msg, False
+                rxd_byte = ord(self._ser.read())
+                if rxd_byte == 0xBB:
+                    # received message data okay
+                    msg = Message(
+                        timestamp=timestamp / 1000,
+                        arbitration_id=arb_id,
+                        dlc=dlc,
+                        data=data,
+                    )
+                    return msg, False
 
-        else:
-            return None, False
+                else:
+                    raise RuntimeError(f"TODO, see issue #1000; rxd_byte = {rxd_byte}")  # TODO
 
-    def fileno(self):
-        if hasattr(self.ser, "fileno"):
-            return self.ser.fileno()
+            else:
+                return None, False
+
+        except serial.SerialException as error:
+            raise CanError("could not read from serial") from error
+
+    def fileno(self) -> int:
+        if hasattr(self._ser, "fileno"):
+            return self._ser.fileno()
         # Return an invalid file descriptor on Windows
         return -1
 
     @staticmethod
-    def _detect_available_configs():
-        channels = []
-        serial_ports = []
-
-        if list_ports:
-            serial_ports = list_ports.comports()
-
-        for port in serial_ports:
-            channels.append({"interface": "serial", "channel": port.device})
-        return channels
+    def _detect_available_configs() -> List[AutoDetectedConfig]:
+        return [
+            {"interface": "serial", "channel": port.device}
+            for port in list_comports()
+        ]

--- a/can/interfaces/serial/serial_can.py
+++ b/can/interfaces/serial/serial_can.py
@@ -170,7 +170,9 @@ class SerialBus(BusABC):
                     return msg, False
 
                 else:
-                    raise RuntimeError(f"TODO, see issue #1000; locals = {locals()}")  # TODO
+                    raise RuntimeError(
+                        f"TODO, see issue #1000; locals = {locals()}"
+                    )  # TODO
 
             else:
                 return None, False

--- a/can/interfaces/serial/serial_can.py
+++ b/can/interfaces/serial/serial_can.py
@@ -162,7 +162,7 @@ class SerialBus(BusABC):
                     return msg, False
 
                 else:
-                    raise RuntimeError(f"TODO, see issue #1000; rxd_byte = {rxd_byte}")  # TODO
+                    raise RuntimeError(f"TODO, see issue #1000; locals = {locals()}")  # TODO
 
             else:
                 return None, False

--- a/can/message.py
+++ b/can/message.py
@@ -74,7 +74,7 @@ class Message:
                       Possible problems include the `dlc` field not matching the length of `data`
                       or creating a message with both `is_remote_frame` and `is_error_frame` set to `True`.
 
-        :raises ValueError: iff `check` is set to `True` and one or more arguments were invalid
+        :raises ValueError: if and only if `check` is set to `True` and one or more arguments were invalid
         """
         self.timestamp = timestamp
         self.arbitration_id = arbitration_id
@@ -95,7 +95,7 @@ class Message:
             try:
                 self.data = bytearray(data)
             except TypeError as error:
-                err = "Couldn't create message from {} ({})".format(data, type(data))
+                err = f"Couldn't create message from {data} ({type(data)})"
                 raise TypeError(err) from error
 
         if dlc is None:

--- a/test/serial_test.py
+++ b/test/serial_test.py
@@ -14,6 +14,11 @@ import can
 from can.interfaces.serial.serial_can import SerialBus
 
 from .message_helper import ComparingMessagesTestCase
+from .config import IS_PYPY
+
+
+# Mentioned in #1010
+TIMEOUT = 0.5 if IS_PYPY else 0.1  # 0.1 is the default set in SerialBus
 
 
 class SerialDummy:
@@ -145,7 +150,7 @@ class SimpleSerialTest(unittest.TestCase, SimpleSerialTestBase):
         self.mock_serial.return_value.write = self.serial_dummy.write
         self.mock_serial.return_value.read = self.serial_dummy.read
         self.addCleanup(self.patcher.stop)
-        self.bus = SerialBus("bus")
+        self.bus = SerialBus("bus", timeout=TIMEOUT)
 
     def tearDown(self):
         self.serial_dummy.reset()
@@ -157,7 +162,7 @@ class SimpleSerialLoopTest(unittest.TestCase, SimpleSerialTestBase):
         SimpleSerialTestBase.__init__(self)
 
     def setUp(self):
-        self.bus = SerialBus("loop://")
+        self.bus = SerialBus("loop://", timeout=TIMEOUT)
 
     def tearDown(self):
         self.bus.shutdown()


### PR DESCRIPTION
This PR improves the serial interface:

- add typing annotations
- simplify code
- some more inline docs
- better validation of received messages / more robust (now throws exceptions on faulty data)
- fixes #1000
- fixes [this](https://github.com/hardbyte/python-can/runs/2351273197?check_suite_focus=true#step:5:393) mildly related error, closes #1014