### PR TITLE
Modify Ixxat driver config reading

### DIFF
--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -437,9 +437,9 @@ class IXXATBus(BusABC):
         log.info("Got configuration of: %s", kwargs)
         # Configuration options
         bitrate = kwargs.get("bitrate", 500000)
-        UniqueHardwareId = kwargs.get("uniquehardwareid", None)
-        rxFifoSize = kwargs.get("rxfifosize", 16)
-        txFifoSize = kwargs.get("txfifosize", 16)
+        UniqueHardwareId = kwargs.get("UniqueHardwareId", None)
+        rxFifoSize = kwargs.get("rxFifoSize", 16)
+        txFifoSize = kwargs.get("txFifoSize", 16)
         self._receive_own_messages = kwargs.get("receive_own_messages", False)
         # Usually comes as a string from the config file
         channel = int(channel)

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -437,9 +437,9 @@ class IXXATBus(BusABC):
         log.info("Got configuration of: %s", kwargs)
         # Configuration options
         bitrate = kwargs.get("bitrate", 500000)
-        UniqueHardwareId = kwargs.get("UniqueHardwareId", None)
-        rxFifoSize = kwargs.get("rxFifoSize", 16)
-        txFifoSize = kwargs.get("txFifoSize", 16)
+        UniqueHardwareId = kwargs.get("uniquehardwareid", None)
+        rxFifoSize = kwargs.get("rxfifosize", 16)
+        txFifoSize = kwargs.get("txfifosize", 16)
         self._receive_own_messages = kwargs.get("receive_own_messages", False)
         # Usually comes as a string from the config file
         channel = int(channel)


### PR DESCRIPTION
Fix for getting the configuration settings for ixxat.

The names of the configuration entries are not case sensitive, but the previous code tried to get them with CamelCase configuration names, which did not work.
Ixxat configuration entries are now read with lowercase names.

Closes #702