### PR TITLE
Bump version to 4.0.0-dev2

### DIFF
--- a/can/__init__.py
+++ b/can/__init__.py
@@ -9,7 +9,7 @@ import logging
 
 from typing import Dict, Any
 
-__version__ = "4.0.0-dev"
+__version__ = "4.0.0-dev.2"
 
 log = logging.getLogger("can")
 


### PR DESCRIPTION
Part of releasing `4.0.0-dev2`.

Brought up in #1022.