### PR TITLE
Log suppressed error in notifier

### DIFF
--- a/can/listener.py
+++ b/can/listener.py
@@ -52,6 +52,7 @@ class Listener(metaclass=ABCMeta):
 
         :param exc: The exception causing the thread to stop
         """
+        raise NotImplementedError()
 
     def stop(self) -> None:
         """

--- a/can/notifier.py
+++ b/can/notifier.py
@@ -145,7 +145,7 @@ class Notifier:
     def _on_error(self, exc: Exception) -> bool:
         """Calls ``on_error()`` for all listeners if they implement it.
 
-        :returns: ``True`` if and only if at least one handler was called
+        :returns: ``True`` if at least one error handler was called.
         """
         was_handled = False
 


### PR DESCRIPTION
Currently, the default implementation is very silent since `can.Listener` already overrides `on_error()` and causes the exception to be suppressed.

Came up due to #1039.