### PR TITLE
Add CAN FD support to canutils reader and writer

### DIFF
--- a/can/io/canutils.py
+++ b/can/io/canutils.py
@@ -21,6 +21,7 @@ CAN_ERR_DLC = 8
 CANFD_BRS = 0x01
 CANFD_ESI = 0x02
 
+
 class CanutilsLogReader(BaseIOHandler):
     """
     Iterator over CAN messages from a .log Logging File (candump -L).

--- a/can/io/canutils.py
+++ b/can/io/canutils.py
@@ -131,26 +131,16 @@ class CanutilsLogWriter(BaseIOHandler, Listener):
                 "(%f) %s %08X#0000000000000000\n"
                 % (timestamp, channel, CAN_ERR_FLAG | CAN_ERR_BUSERROR)
             )
-
-        elif msg.is_remote_frame:
-            if msg.is_extended_id:
-                self.file.write(
-                    "(%f) %s %08X#R\n" % (timestamp, channel, msg.arbitration_id)
-                )
-            else:
-                self.file.write(
-                    "(%f) %s %03X#R\n" % (timestamp, channel, msg.arbitration_id)
-                )
-
         else:
-            data = ["{:02X}".format(byte) for byte in msg.data]
-            if msg.is_extended_id:
+            arbitration_id_str = ("%08X" if msg.is_extended_id else "%03X") % msg.arbitration_id
+
+            if msg.is_remote_frame:
                 self.file.write(
-                    "(%f) %s %08X#%s\n"
-                    % (timestamp, channel, msg.arbitration_id, "".join(data))
+                    "(%f) %s %s#R\n" % (timestamp, channel, arbitration_id_str)
                 )
             else:
+                data = ["{:02X}".format(byte) for byte in msg.data]
                 self.file.write(
-                    "(%f) %s %03X#%s\n"
-                    % (timestamp, channel, msg.arbitration_id, "".join(data))
+                    "(%f) %s %s#%s\n"
+                    % (timestamp, channel, arbitration_id_str, "".join(data))
                 )

--- a/can/io/canutils.py
+++ b/can/io/canutils.py
@@ -139,8 +139,7 @@ class CanutilsLogWriter(BaseIOHandler, Listener):
                     "(%f) %s %s#R\n" % (timestamp, channel, arbitration_id_str)
                 )
             else:
-                data = ["{:02X}".format(byte) for byte in msg.data]
                 self.file.write(
                     "(%f) %s %s#%s\n"
-                    % (timestamp, channel, arbitration_id_str, "".join(data))
+                    % (timestamp, channel, arbitration_id_str, msg.data.hex().upper())
                 )

--- a/test/data/example_data.py
+++ b/test/data/example_data.py
@@ -112,8 +112,6 @@ TEST_MESSAGES_CAN_FD = sort_messages(
     [
         Message(is_fd=True, data=range(64)),
         Message(is_fd=True, data=range(8)),
-        Message(is_fd=True, bitrate_switch=True, is_remote_frame=True),
-        Message(is_fd=True, error_state_indicator=True, is_remote_frame=True),
         Message(is_fd=True, data=range(8), bitrate_switch=True),
         Message(is_fd=True, data=range(8), error_state_indicator=True),
     ]

--- a/test/logformats_test.py
+++ b/test/logformats_test.py
@@ -662,7 +662,7 @@ class TestCanutilsFileFormat(ReaderWriterTest):
         super()._setup_instance_helper(
             can.CanutilsLogWriter,
             can.CanutilsLogReader,
-            check_fd=False,
+            check_fd=True,
             test_append=True,
             check_comments=False,
             preserves_channel=False,


### PR DESCRIPTION
This PR adds CAN FD support to the canutils reader and writer. I also sneaked in a small formatting improvement to use bytes.hex instead of the str/list/join-thing.