### PR TITLE
Fix CI timeout

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ deps =
     pytest~=5.3
     pytest-timeout~=1.3
     pytest-cov~=2.8
-    coverage<5
-    codecov~=2.0
+    coverage==4.5.*
+    codecov==2.1.10
     hypothesis~=4.56
     pyserial~=3.0
 
@@ -19,6 +19,7 @@ recreate = True
 passenv =
     CI
     GITHUB_*
+    CODECOV_*
     PY_COLORS
 
 commands_post =
@@ -29,6 +30,7 @@ passenv =
     CI
     TRAVIS
     TRAVIS_*
+    CODECOV_*
     TEST_SOCKETCAN
 
 commands_post =


### PR DESCRIPTION
Constrain dependency versions so the pip resolver can finish in adequate time. Otherwise GHA runs into timeout [as seen here](https://github.com/hardbyte/python-can/pull/1056/checks?check_run_id=2708990832#step:5:11)