### PR TITLE
Preserve capitalization when reading config files

### DIFF
--- a/can/util.py
+++ b/can/util.py
@@ -52,6 +52,10 @@ def load_file_config(
         name of the section to read configuration from.
     """
     config = ConfigParser()
+
+    # make sure to not transform the entries such that capitalization is preserved
+    config.optionxform = lambda entry: entry  # type: ignore
+
     if path is None:
         config.read([os.path.expanduser(path) for path in CONFIG_FILES])
     else:


### PR DESCRIPTION
This change was discussed in #1020, where @cranium-xx worked on a fix for #702. Previously, all parameters were converted to lower case, and some parameters with upper case naming could therefore not be set. This is fixed by this PR.

Fix #702.