### PR TITLE
Test on 3.10.0-beta.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         experimental: [false]
         python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
         include:
-          - python-version: 3.10.0-alpha.7  # Newest: https://github.com/actions/python-versions/blob/main/versions-manifest.json
+          - python-version: 3.10.0-beta.2  # Newest: https://github.com/actions/python-versions/blob/main/versions-manifest.json
             os: ubuntu-latest
             experimental: true
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,10 @@ jobs:
     - name: Test with pytest via tox
       run: |
         tox -e gh
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: true
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         experimental: [false]
         python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
         include:
-          - python-version: 3.10.0-beta.2  # Newest: https://github.com/actions/python-versions/blob/main/versions-manifest.json
+          - python-version: 3.10.0-beta.4  # Newest: https://github.com/actions/python-versions/blob/main/versions-manifest.json
             os: ubuntu-latest
             experimental: true
       fail-fast: false

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@
 deps =
     pytest==6.2.*,>=6.2.4
     pytest-timeout==1.4.*
-    pytest-cov~=2.8
-    coverage==4.5.*
+    pytest-cov==2.12.*
+    coverage==5.5
     codecov==2.1.10
     hypothesis~=4.56
     pyserial~=3.0
@@ -20,11 +20,7 @@ recreate = True
 passenv =
     CI
     GITHUB_*
-    CODECOV_*
     PY_COLORS
-
-commands_post =
-    codecov -X gcov
 
 [testenv:travis]
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands_post =
 
 [pytest]
 testpaths = test
-addopts = -v --timeout=300 --cov=can --cov-append --cov-report=term
+addopts = -v --timeout=300 --cov=can --cov-config=tox.ini --cov-report=xml --cov-report=term
 
 
 [coverage:run]

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 
 [testenv]
 deps =
-    pytest~=5.3
-    pytest-timeout~=1.3
+    pytest==6.2.*,>=6.2.4
+    pytest-timeout==1.4.*
     pytest-cov~=2.8
     coverage==4.5.*
     codecov==2.1.10


### PR DESCRIPTION
Pytest update was necessary due to https://github.com/pytest-dev/pytest/pull/8540

<details><summary>Trace</summary>
<p>

```
GLOB sdist-make: /home/runner/work/python-can/python-can/setup.py
gh create: /home/runner/work/python-can/python-can/.tox/gh
gh installdeps: pytest~=5.3, pytest-timeout~=1.3, pytest-cov~=2.8, coverage==4.5.*, codecov==2.1.10, hypothesis~=4.56, pyserial~=3.0
gh inst: /home/runner/work/python-can/python-can/.tox/.tmp/package/1/python-can-4.0.0.dev2.zip
gh installed: attrs==21.2.0,certifi==2021.5.30,chardet==4.0.0,codecov==2.1.10,coverage==4.5.4,hypothesis==4.57.1,idna==2.10,more-itertools==8.8.0,msgpack==1.0.2,mypy-extensions==0.4.3,packaging==20.9,pluggy==0.13.1,py==1.10.0,pyparsing==2.4.7,pyserial==3.5,pytest==5.4.3,pytest-cov==2.10.1,pytest-timeout==1.4.2,python-can @ file:///home/runner/work/python-can/python-can/.tox/.tmp/package/1/python-can-4.0.0.dev2.zip,requests==2.25.1,sortedcontainers==2.4.0,urllib3==1.26.5,wcwidth==0.2.5,wrapt==1.12.1
gh run-test-pre: PYTHONHASHSEED='4019826288'
gh run-test: commands[0] | pytest
Traceback (most recent call last):
  File "/home/runner/work/python-can/python-can/.tox/gh/bin/pytest", line 8, in <module>
    sys.exit(main())
  File "/home/runner/work/python-can/python-can/.tox/gh/lib/python3.10/site-packages/_pytest/config/__init__.py", line 105, in main
    config = _prepareconfig(args, plugins)
  File "/home/runner/work/python-can/python-can/.tox/gh/lib/python3.10/site-packages/_pytest/config/__init__.py", line 257, in _prepareconfig
    return pluginmanager.hook.pytest_cmdline_parse(
  File "/home/runner/work/python-can/python-can/.tox/gh/lib/python3.10/site-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/home/runner/work/python-can/python-can/.tox/gh/lib/python3.10/site-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/home/runner/work/python-can/python-can/.tox/gh/lib/python3.10/site-packages/pluggy/manager.py", line 84, in <lambda>
    self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
  File "/home/runner/work/python-can/python-can/.tox/gh/lib/python3.10/site-packages/pluggy/callers.py", line 203, in _multicall
    gen.send(outcome)
  File "/home/runner/work/python-can/python-can/.tox/gh/lib/python3.10/site-packages/_pytest/helpconfig.py", line 90, in pytest_cmdline_parse
    config = outcome.get_result()
  File "/home/runner/work/python-can/python-can/.tox/gh/lib/python3.10/site-packages/pluggy/callers.py", line 80, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/home/runner/work/python-can/python-can/.tox/gh/lib/python3.10/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/home/runner/work/python-can/python-can/.tox/gh/lib/python3.10/site-packages/_pytest/config/__init__.py", line 836, in pytest_cmdline_parse
    self.parse(args)
  File "/home/runner/work/python-can/python-can/.tox/gh/lib/python3.10/site-packages/_pytest/config/__init__.py", line 1044, in parse
    self._preparse(args, addopts=addopts)
  File "/home/runner/work/python-can/python-can/.tox/gh/lib/python3.10/site-packages/_pytest/config/__init__.py", line 992, in _preparse
    self.pluginmanager.load_setuptools_entrypoints("pytest11")
  File "/home/runner/work/python-can/python-can/.tox/gh/lib/python3.10/site-packages/pluggy/manager.py", line 299, in load_setuptools_entrypoints
    plugin = ep.load()
  File "/opt/hostedtoolcache/Python/3.10.0-beta.2/x64/lib/python3.10/importlib/metadata/__init__.py", line 162, in load
    module = import_module(match.group('module'))
  File "/opt/hostedtoolcache/Python/3.10.0-beta.2/x64/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "/home/runner/work/python-can/python-can/.tox/gh/lib/python3.10/site-packages/_pytest/assertion/rewrite.py", line 143, in exec_module
    source_stat, co = _rewrite_test(fn, self.config)
  File "/home/runner/work/python-can/python-can/.tox/gh/lib/python3.10/site-packages/_pytest/assertion/rewrite.py", line 330, in _rewrite_test
    co = compile(tree, fn, "exec", dont_inherit=True)
TypeError: required field "lineno" missing from alias
ERROR: InvocationError for command /home/runner/work/python-can/python-can/.tox/gh/bin/pytest (exited with code 1)
```

</p>
</details>