### PR TITLE
Remove remaining encoding comments

### DIFF
--- a/can/interfaces/gs_usb.py
+++ b/can/interfaces/gs_usb.py
@@ -1,4 +1,4 @@
-from typing import cast, Any, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Optional, Tuple
 
 from gs_usb.gs_usb import GsUsb
 from gs_usb.gs_usb_frame import GsUsbFrame

--- a/can/interfaces/nixnet.py
+++ b/can/interfaces/nixnet.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 
 """
 NI-XNET interface module.

--- a/can/interfaces/nixnet.py
+++ b/can/interfaces/nixnet.py
@@ -1,4 +1,3 @@
-
 """
 NI-XNET interface module.
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,2 +1,1 @@
 #!/usr/bin/env python
-# coding: utf-8

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 """
 This module tests two buses attached to each other.

--- a/test/config.py
+++ b/test/config.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 """
 This module contains various configuration for the tests.

--- a/test/contextmanager_test.py
+++ b/test/contextmanager_test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 """
 This module tests the context manager of Bus and Notifier classes

--- a/test/data/__init__.py
+++ b/test/data/__init__.py
@@ -1,2 +1,1 @@
 #!/usr/bin/env python
-# coding: utf-8

--- a/test/data/example_data.py
+++ b/test/data/example_data.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 """
 This module contains some example data, like messages of different

--- a/test/listener_test.py
+++ b/test/listener_test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 """
 """

--- a/test/logformats_test.py
+++ b/test/logformats_test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 """
 This test module test the separate reader/writer combinations of the can.io.*

--- a/test/message_helper.py
+++ b/test/message_helper.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 """
 This module contains a helper for writing test cases that need to compare messages.

--- a/test/network_test.py
+++ b/test/network_test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 
 import unittest

--- a/test/notifier_test.py
+++ b/test/notifier_test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 import unittest
 import time

--- a/test/serial_test.py
+++ b/test/serial_test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 """
 This module is testing the serial interface.

--- a/test/simplecyclic_test.py
+++ b/test/simplecyclic_test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 """
 This module tests cyclic send tasks.

--- a/test/test_kvaser.py
+++ b/test/test_kvaser.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 """
 """


### PR DESCRIPTION
As already done in most of the code  base, this removs a few leftover encoding comments. [They are not required in Python 3](https://stackoverflow.com/questions/14083111/should-i-use-encoding-declaration-in-python-3) any more.

Also removes a few unused imports that I stumbled upon.