### PR TITLE
Supress 'SystemError: DeviceNotFound' in cantact detect_available_configs()

### DIFF
--- a/can/interfaces/cantact.py
+++ b/can/interfaces/cantact.py
@@ -25,7 +25,7 @@ class CantactBus(BusABC):
     def _detect_available_configs():
         try:
             interface = cantact.Interface()
-        except NameError:
+        except (NameError, SystemError):
             # couldn't import cantact, so no configurations are available
             return []
 


### PR DESCRIPTION
This only occurs if the `cantact` library is installed but no device is present.