### PR TITLE
ICSOperationError base exception class should be CanOperationError

### DIFF
--- a/can/interfaces/ics_neovi/neovi_bus.py
+++ b/can/interfaces/ics_neovi/neovi_bus.py
@@ -113,7 +113,7 @@ class ICSInitializationError(ICSApiError, CanInitializationError):
     pass
 
 
-class ICSOperationError(ICSApiError, CanInitializationError):
+class ICSOperationError(ICSApiError, CanOperationError):
     pass
 
 


### PR DESCRIPTION
Fix for #1073