### PR TITLE
Typing annotations for VectorBus.__init__(...) are missing

### DIFF
--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -150,7 +150,9 @@ class VectorBus(BusABC):
         elif isinstance(channel, Sequence):
             self.channels = channel
         else:
-            raise TypeError(f"Invalid type for channels parameter: {type(channel).__name__}")
+            raise TypeError(
+                f"Invalid type for channels parameter: {type(channel).__name__}"
+            )
 
         self._app_name = app_name.encode() if app_name is not None else b""
         self.channel_info = "Application %s: %s" % (

--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -107,7 +107,7 @@ class VectorBus(BusABC):
             CAN: range `16…32768`
             CAN-FD: range `8192…524288`
         :param app_name:
-            Name of application in the hardware config.
+            Name of application in Vector Hardware Configuration.
             If set to `None`, the channel should be a global channel index.
         :param serial:
             Serial number of the hardware to be used.

--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -107,13 +107,13 @@ class VectorBus(BusABC):
             CAN: range `16…32768`
             CAN-FD: range `8192…524288`
         :param app_name:
-            Name of application in Vector Hardware Configuration.
+            Name of application in *Vector Hardware Config*.
             If set to `None`, the channel should be a global channel index.
         :param serial:
             Serial number of the hardware to be used.
             If set, the channel parameter refers to the channels ONLY on the specified hardware.
-            If set, the app_name does not have to be previously defined in Vector Hardware
-            Configuration.
+            If set, the `app_name` does not have to be previously defined in
+            *Vector Hardware Config*.
         :param fd:
             If CAN-FD frames should be supported.
         :param data_bitrate:

--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -112,8 +112,8 @@ class VectorBus(BusABC):
         :param serial:
             Serial number of the hardware to be used.
             If set, the channel parameter refers to the channels ONLY on the specified hardware.
-            If set, the app_name does not have to be previously defined in the Vector hardware
-            config.
+            If set, the app_name does not have to be previously defined in Vector Hardware
+            Configuration.
         :param fd:
             If CAN-FD frames should be supported.
         :param data_bitrate:


### PR DESCRIPTION
Implements #1082. Features:
- more complete docstring (parameters were missing)
- actual typing annotations
- more general type for `channel` and better parsing
- small doc formatting improvements