### PR TITLE
Supress exception occuring in NIXNET _detect_available_configs()

### DIFF
--- a/can/interfaces/nixnet.py
+++ b/can/interfaces/nixnet.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 if sys.platform == "win32":
     try:
-        from nixnet import session, types, constants, errors, system, database
+        from nixnet import session, types, constants, errors, system, database, XnetError
     except ImportError:
         logger.error("Error, NIXNET python module cannot be loaded.")
         raise ImportError()
@@ -239,7 +239,7 @@ class NiXNETcanBus(BusABC):
                             == constants.CanTermCap.YES,
                         }
                     )
-        except XnetNotFoundError as error:
+        except XnetError as error:
             logger.debug("An error occured while searching for configs: %s", str(error))
 
         return configs

--- a/can/interfaces/nixnet.py
+++ b/can/interfaces/nixnet.py
@@ -225,18 +225,23 @@ class NiXNETcanBus(BusABC):
     @staticmethod
     def _detect_available_configs():
         configs = []
-        nixnet_system = system.System()
-        for can_intf in nixnet_system.intf_refs_can:
-            logger.info("Channel index %d: %s", can_intf.port_num, str(can_intf))
-            configs.append(
-                {
-                    "interface": "nixnet",
-                    "channel": str(can_intf),
-                    "can_term_available": can_intf.can_term_cap
-                    == constants.CanTermCap.YES,
-                }
-            )
-        nixnet_system.close()
+
+        try:
+            with system.System() as nixnet_system:
+                for interface in nixnet_system.intf_refs_can:
+                    cahnnel = str(interface)
+                    logger.debug("Found channel index %d: %s", interface.port_num, cahnnel)
+                    configs.append(
+                        {
+                            "interface": "nixnet",
+                            "channel": cahnnel,
+                            "can_term_available": interface.can_term_cap
+                            == constants.CanTermCap.YES,
+                        }
+                    )
+        except XnetNotFoundError as error:
+            logger.debug("An error occured while searching for configs: %s", str(error))
+
         return configs
 
 

--- a/can/interfaces/nixnet.py
+++ b/can/interfaces/nixnet.py
@@ -19,7 +19,15 @@ logger = logging.getLogger(__name__)
 
 if sys.platform == "win32":
     try:
-        from nixnet import session, types, constants, errors, system, database, XnetError
+        from nixnet import (
+            session,
+            types,
+            constants,
+            errors,
+            system,
+            database,
+            XnetError,
+        )
     except ImportError:
         logger.error("Error, NIXNET python module cannot be loaded.")
         raise ImportError()


### PR DESCRIPTION
Similar to #1077: If the python `nixnet` package is installed but not the DLL, the following error would be thrown:

```
nixnet._lib.XnetNotFoundError:
Could not find an installation of NI-XNET.
Please ensure that NI-XNET is installed on this machine or contact National Instruments for support.
```

Also uses a context manager for more safety.