### PR TITLE
Improve PCAN installation procedure

### DIFF
--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -4,6 +4,7 @@ Enable basic CAN over a PCAN USB device.
 
 import logging
 import time
+from datetime import datetime
 
 from typing import Optional
 from can import CanError, Message, BusABC
@@ -11,16 +12,24 @@ from can.bus import BusState
 from can.util import len2dlc, dlc2len
 from .basic import *
 
+
+# Set up logging
+log = logging.getLogger("can.pcan")
+
+
 try:
     # use the "uptime" library if available
     import uptime
-    import datetime
 
     # boottime() and fromtimestamp() are timezone offset, so the difference is not.
     boottimeEpoch = (
-        uptime.boottime() - datetime.datetime.fromtimestamp(0)
+        uptime.boottime() - datetime.fromtimestamp(0)
     ).total_seconds()
-except ImportError:
+except ImportError as error:
+    log.warning(
+        "uptime library not available, timestamps are relative to boot time and not to Epoch UTC",
+        exc_info=True,
+    )
     boottimeEpoch = 0
 
 try:
@@ -39,9 +48,6 @@ except ImportError:
     except ImportError:
         # Use polling instead
         HAS_EVENTS = False
-
-# Set up logging
-log = logging.getLogger("can.pcan")
 
 
 pcan_bitrate_objs = {

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -22,9 +22,7 @@ try:
     import uptime
 
     # boottime() and fromtimestamp() are timezone offset, so the difference is not.
-    boottimeEpoch = (
-        uptime.boottime() - datetime.fromtimestamp(0)
-    ).total_seconds()
+    boottimeEpoch = (uptime.boottime() - datetime.fromtimestamp(0)).total_seconds()
 except ImportError as error:
     log.warning(
         "uptime library not available, timestamps are relative to boot time and not to Epoch UTC",

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -29,25 +29,24 @@ Kvaser
 
 To install ``python-can`` using the Kvaser CANLib SDK as the backend:
 
-1. Install the `latest stable release of
-   Python <http://python.org/download/>`__.
+1. Install `Kvaser's latest Windows CANLib drivers <https://www.kvaser.com/download/>`__.
 
-2. Install `Kvaser's latest Windows CANLib
-   drivers <http://www.kvaser.com/en/downloads.html>`__.
-
-3. Test that Kvaser's own tools work to ensure the driver is properly
+2. Test that Kvaser's own tools work to ensure the driver is properly
    installed and that the hardware is working.
 
 PCAN
 ~~~~
 
-Download and install the latest driver for your interface from
-`PEAK-System's download page <http://www.peak-system.com/Support.55.0.html?&L=1>`__.
+Download and install the latest driver for your interface:
+
+- `Windows <https://www.peak-system.com/Downloads.76.0.html?&L=1>`__ (also supported on *Cygwin*)
+- `Linux <https://www.peak-system.com/Downloads.76.0.html?&L=1>`__ (`also works without <https://www.peak-system.com/fileadmin/media/linux/index.htm>`__, see also :ref:`pcandoc linux installation`)
+- `macOS <https://www.mac-can.com>`__
 
 Note that PCANBasic API timestamps count seconds from system startup. To
 convert these to epoch times, the uptime library is used. If it is not
 available, the times are returned as number of seconds from system
-startup. To install the uptime library, run ``pip install uptime``.
+startup. To install the uptime library, run ``pip install python-can[pcan]``.
 
 This library can take advantage of the `Python for Windows Extensions
 <https://github.com/mhammond/pywin32>`__ library if installed.
@@ -69,7 +68,7 @@ NI-CAN
 ~~~~~~
 
 Download and install the NI-CAN drivers from
-`National Instruments <http://www.ni.com/downloads/ni-drivers/>`__.
+`National Instruments <https://www.ni.com/de-de/support/downloads/drivers>`__.
 
 Currently the driver only supports 32-bit Python on Windows.
 
@@ -102,7 +101,7 @@ If ``python-can`` is already installed, the CANtact backend can be installed sep
 
 ``python3 -m pip install cantact``
 
-Additional CANtact documentation is available at https://cantact.io.
+Additional CANtact documentation is available at `cantact.io <https://cantact.io>`__.
 
 Installing python-can in development mode
 -----------------------------------------
@@ -114,5 +113,4 @@ reinstall. Download or clone the source repository then:
 ::
 
     python setup.py develop
-
 

--- a/doc/interfaces/pcan.rst
+++ b/doc/interfaces/pcan.rst
@@ -5,12 +5,6 @@ PCAN Basic API
 
 Interface to `Peak-System <https://www.peak-system.com/?&L=1/>`__'s PCAN-Basic API.
 
-The required drivers can be downloaded here:
-
-- `Windows <https://www.peak-system.com/Downloads.76.0.html?&L=1>`__ (also supported on *Cygwin*)
-- `Linux <https://www.peak-system.com/Downloads.76.0.html?&L=1>`__ (`also works without <https://www.peak-system.com/fileadmin/media/linux/index.htm>`__, see also :ref:`pcandoc linux installation`)
-- `macOS <http://www.mac-can.com>`__
-
 Configuration
 -------------
 
@@ -24,11 +18,11 @@ Here is an example configuration file for using `PCAN-USB <https://www.peak-syst
     state = can.bus.BusState.PASSIVE
     bitrate = 500000
 
-``channel``: (default PCAN_USBBUS1) CAN interface name
+``channel``: (default ``"PCAN_USBBUS1"``) CAN interface name
 
-``state``: (default can.bus.BusState.ACTIVE) BusState of the channel
+``state``: (default ``can.bus.BusState.ACTIVE``) BusState of the channel
 
-``bitrate``: (default 500000) Channel bitrate
+``bitrate``: (default ``500000``) Channel bitrate
 
 Valid ``channel`` values:
 
@@ -41,14 +35,14 @@ Valid ``channel`` values:
     PCAN_PCCBUSx
     PCAN_LANBUSx
 
-Where ``x`` should be replaced with the desired channel number starting at 1.
+Where ``x`` should be replaced with the desired channel number starting at ``1``.
 
 .. _pcandoc linux installation:
 
 Linux installation
 ------------------
 
-Kernels >= 3.4 supports the PCAN adapters natively via :doc:`/interfaces/socketcan`, refer to: :ref:`socketcan-pcan`.
+Beginning with version 3.4, Linux kernels support the PCAN adapters natively via :doc:`/interfaces/socketcan`, refer to: :ref:`socketcan-pcan`.
 
 Bus
 ---

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ extras_require = {
     "cantact": ["cantact>=0.0.7"],
     "gs_usb": ["gs_usb>=0.2.1"],
     "nixnet": ["nixnet>=0.3.1"],
+    "pcan": ["uptime~=3.0.1"],
 }
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ deps =
     hypothesis~=4.56
     pyserial~=3.0
     parameterized~=0.8
-    uptime~=3.0.1
 
 commands =
     pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
     hypothesis~=4.56
     pyserial~=3.0
     parameterized~=0.8
+    uptime~=3.0.1
 
 commands =
     pytest {posargs}


### PR DESCRIPTION
Fixes #1053.

This PR:
- prints a warning is `uptime` is missing in PCAN
- Adds a `setup.py`-extra to be able to easily install it
- Changes the documentation accordingly
- Fixes some small documentation issues like old links, non-HTTPS links and formatting