### PR TITLE
Update docstring of can.io.generic.FileIOMessageWriter

### DIFF
--- a/can/io/generic.py
+++ b/can/io/generic.py
@@ -73,7 +73,7 @@ class MessageWriter(BaseIOHandler, can.Listener, metaclass=ABCMeta):
 
 # pylint: disable=abstract-method,too-few-public-methods
 class FileIOMessageWriter(MessageWriter, metaclass=ABCMeta):
-    """The base class for all writers."""
+    """A specialized base class for all writers with file descriptors."""
 
     file: Union[TextIO, BinaryIO]
 


### PR DESCRIPTION
The old one was just copied from `MessageWriter`.