### PR TITLE
Handle case where uptime is imported successfully but returns None

### DIFF
--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -22,7 +22,10 @@ try:
     import uptime
 
     # boottime() and fromtimestamp() are timezone offset, so the difference is not.
-    boottimeEpoch = (uptime.boottime() - datetime.fromtimestamp(0)).total_seconds()
+    if uptime.boottime() is None:
+        boottimeEpoch = 0
+    else:
+        boottimeEpoch = (uptime.boottime() - datetime.fromtimestamp(0)).total_seconds()
 except ImportError as error:
     log.warning(
         "uptime library not available, timestamps are relative to boot time and not to Epoch UTC",


### PR DESCRIPTION
See Issue https://github.com/hardbyte/python-can/issues/1102