### PR TITLE
canalystii: Fix transmitting onto a busy bus

### DIFF
--- a/can/interfaces/canalystii.py
+++ b/can/interfaces/canalystii.py
@@ -32,6 +32,9 @@ class VCI_CAN_OBJ(Structure):
     ]
 
 
+SENDTYPE_ALLOW_RETRY = 0  # Retry send if there is bus contention
+SENDTYPE_ONE_SHOT = 1  # Drop the message if transmission fails first time
+
 VCI_USBCAN2 = 4
 
 STATUS_OK = 0x01
@@ -145,7 +148,7 @@ class CANalystIIBus(BusABC):
             msg.arbitration_id,
             0,
             0,
-            1,
+            SENDTYPE_ALLOW_RETRY,
             msg.is_remote_frame,
             extern_flag,
             msg.dlc,

--- a/doc/interfaces/canalystii.rst
+++ b/doc/interfaces/canalystii.rst
@@ -4,6 +4,9 @@ CANalyst-II
 CANalyst-II(+) is a USB to CAN Analyzer. The controlcan library is originally developed by
 `ZLG ZHIYUAN Electronics`_.
 
+.. note::
+
+   Use of this interface requires the ``ControlCAN.dll`` (Windows) or ``libcontrolcan.so`` vendor library to be placed in the Python working directory.
 
 Bus
 ---


### PR DESCRIPTION
This is to fix the issue that the CANalystIIBus interface works fine in a quiet setup (like a loopback test) but randomly fails to send messages if the bus is busy.

The "SendType" field has at least two possible values, and value `1` causes the firmware to drop the message if there is bus contention when sending it.

I can make this into a configuration parameter if you prefer, just let me know. I was going to do this but then I couldn't really think of a use case for unreliable transmission. (With `SendType 1`, there isn't anything in the protocol to tell the software that the message was dropped, it's just silently dropped!)

Also made a small addition in the docs to note the binary library dependency.

Thanks for maintaining this library, it's been a pleasure to work with! (Well, after I worked out why I was randomly losing messages! :laughing:)