### PR TITLE
fix(ctypesutil): correctly apply wrapped lib function as CLibrary member

### DIFF
--- a/can/ctypesutil.py
+++ b/can/ctypesutil.py
@@ -55,13 +55,13 @@ class CLibrary(_LibBase):  # type: ignore
         else:
             prototype = _FUNCTION_TYPE(restype)
         try:
-            self.func_name = prototype((func_name, self))
+            func = prototype((func_name, self))
         except AttributeError:
             raise ImportError(
                 f'Could not map function "{func_name}" from library {self._name}'
             ) from None
 
-        self.func_name._name = func_name  # pylint: disable=protected-access
+        func._name = func_name  # pylint: disable=protected-access
         log.debug(
             'Wrapped function "%s", result type: %s, error_check %s',
             func_name,
@@ -70,9 +70,10 @@ class CLibrary(_LibBase):  # type: ignore
         )
 
         if errcheck is not None:
-            self.func_name.errcheck = errcheck
+            func.errcheck = errcheck
 
-        return self.func_name
+        setattr(self, func_name, func)
+        return func
 
 
 if sys.platform == "win32":


### PR DESCRIPTION
While using the IXXAT driver we observed that the errcheck function `can.interfaces.ixxat.canlib.__check_status` is never called after library function calls, preventing the detection of timeouts etc. by the caller. The root cause is that the original library function instead of the wrapped function is called.