### PR TITLE
Finds USB2CAN Serial Number by USB Name

### DIFF
--- a/can/interfaces/usb2can/serial_selector.py
+++ b/can/interfaces/usb2can/serial_selector.py
@@ -40,7 +40,7 @@ def WMIDateStringToDate(dtmDate) -> str:
     return strDateTime
 
 
-def find_serial_devices(serial_matcher: str = "ED") -> List[str]:
+def find_serial_devices(serial_matcher: str = "") -> List[str]:
     """
     Finds a list of USB devices where the serial number (partially) matches the given string.
 
@@ -49,6 +49,9 @@ def find_serial_devices(serial_matcher: str = "ED") -> List[str]:
     """
     objWMIService = win32com.client.Dispatch("WbemScripting.SWbemLocator")
     objSWbemServices = objWMIService.ConnectServer(".", "root\\cimv2")
-    items = objSWbemServices.ExecQuery("SELECT * FROM Win32_USBControllerDevice")
-    ids = (item.Dependent.strip('"')[-8:] for item in items)
-    return [e for e in ids if e.startswith(serial_matcher)]
+    query = "SELECT * FROM CIM_LogicalDevice where Name LIKE '%USB2CAN%'"
+    usbs = objSWbemServices.ExecQuery(query)
+    serial_numbers = [usb.DeviceID.split("\\")[-1] for usb in usbs]
+    if serial_matcher:
+        return [sn for sn in serial_numbers if serial_matcher in sn]
+    return serial_numbers

--- a/can/interfaces/usb2can/serial_selector.py
+++ b/can/interfaces/usb2can/serial_selector.py
@@ -50,8 +50,8 @@ def find_serial_devices(serial_matcher: str = "") -> List[str]:
     objWMIService = win32com.client.Dispatch("WbemScripting.SWbemLocator")
     objSWbemServices = objWMIService.ConnectServer(".", "root\\cimv2")
     query = "SELECT * FROM CIM_LogicalDevice where Name LIKE '%USB2CAN%'"
-    usbs = objSWbemServices.ExecQuery(query)
-    serial_numbers = [usb.DeviceID.split("\\")[-1] for usb in usbs]
+    devices = objSWbemServices.ExecQuery(query)
+    serial_numbers = [device.DeviceID.split("\\")[-1] for device in devices]
     if serial_matcher:
         return [sn for sn in serial_numbers if serial_matcher in sn]
     return serial_numbers


### PR DESCRIPTION
PR changes the method of finding USB2CAN devices from querying all `USB_ControllerDevices` whose serial numbers start with "ED" to querying all `CIM_LogicalDevices` that contains the name "USB2CAN".

Background:
I recently bought a USB2CAN dongle from 8devices and it didn't show up in python-can. After looking through the source code, I realized it's because my dongle's serial number didn't start with "ED" (but did end with it) which is how python-can determines if a USB2CAN dongle is connected.

To make things more robust, I changed the query to find all devices that contain "USB2CAN" in their name and return the serial number by parsing the `DeviceID` which is in the format `USB\<VID><PID>\<SERIAL_NUMBER>`. I also kept the serial matching argument so users can select one if multiple are connected. I can also switch this to use the VID/PID of the dongle if that's more robust than the USB name.