### PR TITLE
socketcand Backend for python-can

### DIFF
--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -25,6 +25,7 @@ BACKENDS = {
     "gs_usb": ("can.interfaces.gs_usb", "GsUsbBus"),
     "nixnet": ("can.interfaces.nixnet", "NiXNETcanBus"),
     "neousys": ("can.interfaces.neousys", "NeousysBus"),
+    "socketcand": ("can.interfaces.socketcand", "SocketCanDaemonBus"),
 }
 
 try:

--- a/can/interfaces/socketcand/__init__.py
+++ b/can/interfaces/socketcand/__init__.py
@@ -1,0 +1,9 @@
+"""
+Interface to socketcand
+see https://github.com/linux-can/socketcand
+
+Copyright (C) 2021  DOMOLOGIC GmbH
+http://www.domologic.de
+"""
+
+from .socketcand import SocketCanDaemonBus

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -6,21 +6,6 @@ Authors: Marvin Seiler, Gerrit Telkamp
 
 Copyright (C) 2021  DOMOLOGIC GmbH
 http://www.domologic.de
-
-
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 3 of the License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with this program; if not, write to the Free Software Foundation,
-Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
 import can
 import socket

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -18,8 +18,6 @@ import traceback
 from collections import deque
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.INFO)
-
 
 def convert_ascii_message_to_can_message(ascii_message: str) -> can.Message:
     if not ascii_message.startswith("< frame ") or not ascii_message.endswith(" >"):

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -32,6 +32,7 @@ from collections import deque
 
 log = logging.getLogger(__name__)
 
+
 def convert_ascii_message_to_can_message(ascii_msg: str) -> can.Message:
     if not ascii_msg.startswith("< frame ") or not ascii_msg.endswith(" >"):
         log.warning(f"Could not parse ascii message: {ascii_msg}")
@@ -86,7 +87,7 @@ class SocketCanDaemonBus(can.BusABC):
         self.__receive_buffer = ""  # i know string is not the most efficient here
         connect_to_server(self.__socket, self.__host, self.__port)
         self._expect_msg("< hi >")
-        
+
         log.info(
             f"SocketCanDaemonBus: connected with address {self.__socket.getsockname()}"
         )
@@ -170,24 +171,18 @@ class SocketCanDaemonBus(can.BusABC):
             log.error(f"Failed to receive: {exc}  {traceback.format_exc()}")
             raise can.CanError(f"Failed to receive: {exc}  {traceback.format_exc()}")
 
-
     def _tcp_send(self, msg: str):
         log.debug(f"Sending TCP Message: '{msg}'")
         self.__socket.sendall(msg.encode("ascii"))
 
-
     def _expect_msg(self, msg):
-        ascii_msg = self.__socket.recv(256).decode(
-            "ascii"
-        )
+        ascii_msg = self.__socket.recv(256).decode("ascii")
         if not ascii_msg == msg:
             raise can.CanError(f"{msg} message expected!")
-
 
     def send(self, msg, timeout=None):
         ascii_msg = convert_can_message_to_ascii_message(msg)
         self._tcp_send(ascii_msg)
-
 
     def shutdown(self):
         self.stop_all_periodic_tasks()

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -2,10 +2,25 @@
 Interface to socketcand
 see https://github.com/linux-can/socketcand
 
-Author: Marvin Seiler, Gerrit Telkamp
+Authors: Marvin Seiler, Gerrit Telkamp
 
 Copyright (C) 2021  DOMOLOGIC GmbH
 http://www.domologic.de
+
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
 import can
 import socket

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -4,8 +4,6 @@ see https://github.com/linux-can/socketcand
 
 Author: Marvin Seiler
 
-Language: Python 3.7
-
 Copyright (C) 2021  DOMOLOGIC GmbH
 http://www.domologic.de
 """

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -1,0 +1,169 @@
+"""
+Interface to socketcand
+see https://github.com/linux-can/socketcand
+
+Author: Marvin Seiler
+
+Language: Python 3.7
+
+Copyright (C) 2021  DOMOLOGIC GmbH
+http://www.domologic.de
+"""
+import can
+import socket
+import select
+import logging
+import time
+import traceback
+from collections import deque
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
+
+def convert_ascii_message_to_can_message(ascii_message: str) -> can.Message:
+    if not ascii_message.startswith("< frame ") or not ascii_message.endswith(" >"):
+        log.warning(f"Could not parse ascii message: {ascii_message}")
+        return None
+    else:
+        # frame_string = ascii_message.removeprefix("< frame ").removesuffix(" >")
+        frame_string = ascii_message[8:-2]
+        parts = frame_string.split(" ", 3)
+        can_id, timestamp = int(parts[0], 16), float(parts[1])
+
+        data = bytearray.fromhex(parts[2])
+        can_dlc = len(data)
+        can_message = can.Message(
+            timestamp=timestamp, arbitration_id=can_id, data=data, dlc=can_dlc
+        )
+        return can_message
+
+
+def convert_can_message_to_ascii_message(can_message: can.Message) -> str:
+    # Note: socketcan bus adds extended flag, remote_frame_flag & error_flag to id
+    # not sure if that is necessary here
+    can_id = can_message.arbitration_id
+    # Note: seems like we cannot add CANFD_BRS (bitrate_switch) and CANFD_ESI (error_state_indicator) flags
+    data = can_message.data
+    length = can_message.dlc
+    bytes_string = " ".join("{:x}".format(x) for x in data[0:length])
+    ascii_message = f"< send {can_id:X} {length:X} {bytes_string} >"
+    return ascii_message
+
+
+def connect_to_server(s, host, port):
+    timeout_ms = 10000
+    now = time.time() * 1000
+    end_time = now + timeout_ms
+    while now < end_time:
+        try:
+            s.connect((host, port))
+            return
+        except Exception as e:
+            log.warning(f"Failed to connect to server: {type(e)} Message: {e}")
+            now = time.time() * 1000
+    raise TimeoutError(
+        f"connect_to_server: Failed to connect server for {timeout_ms} ms"
+    )
+
+
+class SocketCanDaemonBus(can.BusABC):
+    def __init__(self, channel, host, port, can_filters=None, **kwargs):
+        self.__host = host
+        self.__port = port
+        self.__socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.__message_buffer = deque()
+        self.__receive_buffer = ""  # i know string is not the most efficient here
+        connect_to_server(self.__socket, self.__host, self.__port)
+        log.info(
+            f"SocketCanDaemonBus: connected with address {self.__socket.getsockname()}"
+        )
+        self._tcp_send(f"< open {channel} >")
+        self._tcp_send(f"< rawmode >")
+        super().__init__(channel=channel, can_filters=can_filters)
+
+    def _recv_internal(self, timeout):
+        if len(self.__message_buffer) != 0:
+            can_message = self.__message_buffer.popleft()
+            return can_message, False
+
+        try:
+            # get all sockets that are ready (can be a list with a single value
+            # being self.socket or an empty list if self.socket is not ready)
+            ready_receive_sockets, _, _ = select.select(
+                [self.__socket], [], [], timeout
+            )
+        except socket.error as exc:
+            # something bad happened (e.g. the interface went down)
+            log.error(f"Failed to receive: {exc}")
+            raise can.CanError(f"Failed to receive: {exc}")
+
+        try:
+            if not ready_receive_sockets:
+                # socket wasn't readable or timeout occurred
+                log.debug("Socket not ready")
+                return None, False
+
+            ascii_message = self.__socket.recv(1024).decode(
+                "ascii"
+            )  # may contain multiple messages
+            self.__receive_buffer += ascii_message
+            log.debug(f"Received Ascii Message: {ascii_message}")
+            buffer_view = self.__receive_buffer
+            chars_processed_successfully = 0
+            while True:
+                if len(buffer_view) == 0:
+                    break
+
+                start = buffer_view.find("<")
+                if start == -1:
+                    log.warning(
+                        f"Bad data: No opening < found => discarding entire buffer '{buffer_view}'"
+                    )
+                    chars_processed_successfully = len(self.__receive_buffer)
+                    break
+                end = buffer_view.find(">")
+                if end == -1:
+                    log.warning("Got incomplete message => waiting for more data")
+                    if len(buffer_view) > 200:
+                        log.warning(
+                            "Incomplete message exceeds 200 chars => Discarding"
+                        )
+                        chars_processed_successfully = len(self.__receive_buffer)
+                    break
+                chars_processed_successfully += end + 1
+                single_message = buffer_view[start : end + 1]
+                parsed_can_message = convert_ascii_message_to_can_message(
+                    single_message
+                )
+                if parsed_can_message is None:
+                    log.warning(f"Invalid Frame: {single_message}")
+                else:
+                    self.__message_buffer.append(parsed_can_message)
+                buffer_view = buffer_view[end + 1 :]
+
+            self.__receive_buffer = self.__receive_buffer[
+                chars_processed_successfully + 1 :
+            ]
+            can_message = (
+                None
+                if len(self.__message_buffer) == 0
+                else self.__message_buffer.popleft()
+            )
+            return can_message, False
+
+        except Exception as exc:
+            log.error(f"Failed to receive: {exc}  {traceback.format_exc()}")
+            raise can.CanError(f"Failed to receive: {exc}  {traceback.format_exc()}")
+
+    def _tcp_send(self, message: str):
+        log.debug(f"Sending Tcp Message: '{message}'")
+        self.__socket.sendall(message.encode("ascii"))
+
+    def send(self, message, timeout=None):
+        ascii_message = convert_can_message_to_ascii_message(message)
+        self._tcp_send(ascii_message)
+
+    def shutdown(self):
+        self.stop_all_periodic_tasks()
+        self.__socket.close()

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -43,8 +43,7 @@ def convert_can_message_to_ascii_message(can_message: can.Message) -> str:
     data = can_message.data
     length = can_message.dlc
     bytes_string = " ".join("{:x}".format(x) for x in data[0:length])
-    ascii_msg = f"< send {can_id:X} {length:X} {bytes_string} >"
-    return ascii_msg
+    return f"< send {can_id:X} {length:X} {bytes_string} >"
 
 
 def connect_to_server(s, host, port):

--- a/doc/interfaces/socketcand.rst
+++ b/doc/interfaces/socketcand.rst
@@ -1,0 +1,112 @@
+.. _socketcand_doc:
+
+socketcand Interface
+====================
+`Socketcand <https://github.com/linux-can/socketcand>`__ is part of the 
+`Linux-CAN <https://github.com/linux-can>`__ project, providing a 
+Network-to-CAN bridge as Linux damon. It implements a specific TCP/IP 
+based communication `protocol <https://github.com/linux-can/socketcand/blob/master/doc/protocol.md>`__
+to transfer CAN frames and control commands via TCP/IP.
+
+The main advantage compared to UDP-based protocols (e.g. virtual interface)
+is, that TCP guarantees delivery and that the message order is kept.
+
+Here is a small example dumping all can messages received by a socketcand 
+daemon running on a remote Raspberry Pi:
+
+.. code-block:: python
+    import can
+
+    bus = can.interface.Bus(bustype='socketcand', host="10.0.16.15", port=29536, channel="can0")
+
+    # loop until Ctrl-C
+    try:
+      while True:
+        msg = bus.recv()
+        print (msg)
+    except KeyboardInterrupt:
+      pass
+
+The output may look like this:
+::
+    Timestamp: 1637791111.209224    ID: 000006fd    X Rx                DLC:  8    c4 10 e3 2d 96 ff 25 6b
+    Timestamp: 1637791111.233951    ID: 000001ad    X Rx                DLC:  4    4d 47 c7 64
+    Timestamp: 1637791111.409415    ID: 000005f7    X Rx                DLC:  8    86 de e6 0f 42 55 5d 39
+    Timestamp: 1637791111.434377    ID: 00000665    X Rx                DLC:  8    97 96 51 0f 23 25 fc 28
+    Timestamp: 1637791111.609763    ID: 0000031d    X Rx                DLC:  8    16 27 d8 3d fe d8 31 24
+    Timestamp: 1637791111.634630    ID: 00000587    X Rx                DLC:  8    4e 06 85 23 6f 81 2b 65
+
+The following section will show how to get the stuff installed on a Raspberry Pi with a MCP2515-based
+CAN interface, e.g. available from Waveshare: https://www.waveshare.com/rs485-can-hat.htm .
+
+Install CAN Interface for a MCP2515 based interface on a Raspberry Pi
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Add the following lines to ``/boot/config.txt``. Please take care on the frequencsy of the crystal on your MCP2515 board:
+::
+    dtparam=spi=on
+    dtoverlay=mcp2515-can0,oscillator=12000000,interrupt=25,spimaxfrequency=1000000
+
+Reboot after ``/boot/config.txt`` has been modified.
+
+
+Enable socketcan for can0
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create config file for systemd-networkd to start the socketcan interface automatically:
+
+.. code-block:: bash
+
+    cat >/etc/systemd/network/80-can.network <<'EOT'
+    [Match]
+    Name=can0
+    [CAN]
+    BitRate=250K
+    RestartSec=100ms
+    EOT
+
+Enable ``systemd-networkd`` on reboot and start it immediately (if it was not already startet):
+
+.. code-block:: bash
+
+    sudo systemctl enable systemd-networkd
+    sudo systemctl start systemd-networkd
+
+
+Build socketcand from source
+::::::::::::::::::::::::::::
+
+.. code-block:: bash
+
+    # autoconf is needed to build socketcand
+    sudo apt-get install -y autoconf
+    # clone & build sources
+    git clone https://github.com/linux-can/socketcand.git
+    cd socketcand
+    ./autogen.sh
+    ./configure
+    make
+
+
+Install socketcand
+::::::::::::::::::
+.. code-block:: bash
+
+    make install
+
+
+Run socketcand
+::::::::::::::
+.. code-block:: bash
+
+    ./socketcand -v -i can0
+
+During start, socketcand will prompt its IP address and port it listens to:
+::
+    Verbose output activated
+
+    Using network interface 'eth0'
+    Listen adress is 10.0.16.15
+    Broadcast adress is 10.0.255.255
+    creating broadcast thread...
+    binding socket to 10.0.16.15:29536

--- a/doc/interfaces/socketcand.rst
+++ b/doc/interfaces/socketcand.rst
@@ -41,7 +41,8 @@ Socketcand Quickstart
 ---------------------
 
 The following section will show how to get the stuff installed on a Raspberry Pi with a MCP2515-based
-CAN interface, e.g. available from Waveshare: https://www.waveshare.com/rs485-can-hat.htm .
+CAN interface, e.g. available from `Waveshare <https://www.waveshare.com/rs485-can-hat.htm>`__.
+However, it will also work with any other socketcan device.
 
 Install CAN Interface for a MCP2515 based interface on a Raspberry Pi
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/interfaces/socketcand.rst
+++ b/doc/interfaces/socketcand.rst
@@ -37,13 +37,16 @@ The output may look like this:
     Timestamp: 1637791111.609763    ID: 0000031d    X Rx                DLC:  8    16 27 d8 3d fe d8 31 24
     Timestamp: 1637791111.634630    ID: 00000587    X Rx                DLC:  8    4e 06 85 23 6f 81 2b 65
 
+Socketcand Quickstart
+---------------------
+
 The following section will show how to get the stuff installed on a Raspberry Pi with a MCP2515-based
 CAN interface, e.g. available from Waveshare: https://www.waveshare.com/rs485-can-hat.htm .
 
 Install CAN Interface for a MCP2515 based interface on a Raspberry Pi
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Add the following lines to ``/boot/config.txt``. Please take care on the frequencsy of the crystal on your MCP2515 board:
+Add the following lines to ``/boot/config.txt``. Please take care on the frequency of the crystal on your MCP2515 board:
 ::
     dtparam=spi=on
     dtoverlay=mcp2515-can0,oscillator=12000000,interrupt=25,spimaxfrequency=1000000
@@ -75,7 +78,7 @@ Enable ``systemd-networkd`` on reboot and start it immediately (if it was not al
 
 
 Build socketcand from source
-::::::::::::::::::::::::::::
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -90,14 +93,14 @@ Build socketcand from source
 
 
 Install socketcand
-::::::::::::::::::
+~~~~~~~~~~~~~~~~~~
 .. code-block:: bash
 
     make install
 
 
 Run socketcand
-::::::::::::::
+~~~~~~~~~~~~~~
 .. code-block:: bash
 
     ./socketcand -v -i can0

--- a/doc/interfaces/socketcand.rst
+++ b/doc/interfaces/socketcand.rst
@@ -15,7 +15,8 @@ Here is a small example dumping all can messages received by a socketcand
 daemon running on a remote Raspberry Pi:
 
 .. code-block:: python
-    import can
+
+	import can
 
     bus = can.interface.Bus(bustype='socketcand', host="10.0.16.15", port=29536, channel="can0")
 

--- a/doc/interfaces/socketcand.rst
+++ b/doc/interfaces/socketcand.rst
@@ -4,9 +4,9 @@ socketcand Interface
 ====================
 `Socketcand <https://github.com/linux-can/socketcand>`__ is part of the 
 `Linux-CAN <https://github.com/linux-can>`__ project, providing a 
-Network-to-CAN bridge as Linux damon. It implements a specific TCP/IP 
-based communication `protocol <https://github.com/linux-can/socketcand/blob/master/doc/protocol.md>`__
-to transfer CAN frames and control commands via TCP/IP.
+Network-to-CAN bridge as Linux damon. It implements a specific
+`TCP/IP based communication protocol <https://github.com/linux-can/socketcand/blob/master/doc/protocol.md>`__
+to transfer CAN frames and control commands.
 
 The main advantage compared to UDP-based protocols (e.g. virtual interface)
 is, that TCP guarantees delivery and that the message order is kept.

--- a/doc/interfaces/socketcand.rst
+++ b/doc/interfaces/socketcand.rst
@@ -16,7 +16,7 @@ daemon running on a remote Raspberry Pi:
 
 .. code-block:: python
 
-	import can
+    import can
 
     bus = can.interface.Bus(bustype='socketcand', host="10.0.16.15", port=29536, channel="can0")
 


### PR DESCRIPTION
We are using a Raspberry PI with MCP2515-based CAN-HAT, running a a [socketcand](https://github.com/linux-can/socketcand) as "IP-to-CAN-Gateway damon". For this, we have implemented a new backend.
socketcand uses an TCP-based ASCII protocol to represent the CAN frames. The most relevant advantage against an UDP-based protocol is that the order of messages is guaranteed.

It would be nice if you could merge this into your repository. Please let me know if we have something to add before you can merge the code.

