### PR TITLE
Update Mergify rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 queue_rules:
   - name: default
     conditions:
-      - "status-success=Travis CI - Pull Request"
+      - "status-success=test,format"  # "GitHub Actions works slightly differently [...], only the job name is used."
 
 pull_request_rules:
   - name: Automatic merge passing PR on up to date branch with approving CR
@@ -10,7 +10,7 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
-      - "status-success=Travis CI - Pull Request"
+      - "status-success=test,format"
       - "label!=work-in-progress"
     actions:
       queue:


### PR DESCRIPTION
This change was required due to [the deprection of our current setup](https://blog.mergify.io/strict-mode-deprecation/). It was shown [in the mergify results tab on our PRs](https://github.com/hardbyte/python-can/pull/1142/checks?check_run_id=4001545821) and would cause the Mergify setup to fail from December on. I hope that I nowconfigured everything correctly.