### PR TITLE
Improve IO class hierarchy + Allow to use SizedRotatingLogger as a context manager

### DIFF
--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -23,7 +23,7 @@ from ..message import Message
 from ..listener import Listener
 from ..util import len2dlc, dlc2len, channel2int
 from ..typechecking import AcceptedIOType
-from .generic import BaseIOHandler
+from .generic import BaseIOHandler, FileIOMessageWriter
 
 
 class BLFParseError(Exception):
@@ -139,7 +139,7 @@ class BLFReader(BaseIOHandler):
     silently ignored.
     """
 
-    def __init__(self, file):
+    def __init__(self, file: AcceptedIOType) -> None:
         """
         :param file: a path-like object or as file-like object to read from
                      If this is a file-like object, is has to opened in binary
@@ -347,7 +347,7 @@ class BLFReader(BaseIOHandler):
             pos = next_pos
 
 
-class BLFWriter(BaseIOHandler, Listener):
+class BLFWriter(FileIOMessageWriter, Listener):
     """
     Logs CAN data to a Binary Logging File compatible with Vector's tools.
     """

--- a/can/io/canutils.py
+++ b/can/io/canutils.py
@@ -8,8 +8,8 @@ import logging
 
 from can.message import Message
 from can.listener import Listener
-from .generic import BaseIOHandler
-
+from .generic import BaseIOHandler, FileIOMessageWriter
+from ..typechecking import AcceptedIOType
 
 log = logging.getLogger("can.io.canutils")
 
@@ -32,7 +32,7 @@ class CanutilsLogReader(BaseIOHandler):
         ``(0.0) vcan0 001#8d00100100820100``
     """
 
-    def __init__(self, file):
+    def __init__(self, file: AcceptedIOType) -> None:
         """
         :param file: a path-like object or as file-like object to read from
                      If this is a file-like object, is has to opened in text
@@ -105,7 +105,7 @@ class CanutilsLogReader(BaseIOHandler):
         self.stop()
 
 
-class CanutilsLogWriter(BaseIOHandler, Listener):
+class CanutilsLogWriter(FileIOMessageWriter, Listener):
     """Logs CAN data to an ASCII log file (.log).
     This class is is compatible with "candump -L".
 
@@ -114,7 +114,7 @@ class CanutilsLogWriter(BaseIOHandler, Listener):
     It the first message does not have a timestamp, it is set to zero.
     """
 
-    def __init__(self, file, channel="vcan0", append=False):
+    def __init__(self, file: AcceptedIOType, channel="vcan0", append=False):
         """
         :param file: a path-like object or as file-like object to write to
                      If this is a file-like object, is has to opened in text

--- a/can/io/generic.py
+++ b/can/io/generic.py
@@ -77,6 +77,13 @@ class FileIOMessageWriter(MessageWriter, metaclass=ABCMeta):
 
     file: Union[TextIO, BinaryIO]
 
+    def __init__(self, file: Union[can.typechecking.FileLike, TextIO, BinaryIO], mode: str = "rt") -> None:
+        # Not possible with the type signature, but be verbose for user friendliness
+        if file is None:
+            raise ValueError("The given file cannot be None")
+
+        super().__init__(file, mode)
+
 
 # pylint: disable=too-few-public-methods
 class MessageReader(BaseIOHandler, Iterable, metaclass=ABCMeta):

--- a/can/io/generic.py
+++ b/can/io/generic.py
@@ -30,7 +30,9 @@ class BaseIOHandler(ContextManager, metaclass=ABCMeta):
 
     file: Optional[can.typechecking.FileLike]
 
-    def __init__(self, file: can.typechecking.AcceptedIOType, mode: str = "rt") -> None:
+    def __init__(
+        self, file: Optional[can.typechecking.AcceptedIOType], mode: str = "rt"
+    ) -> None:
         """
         :param file: a path-like object to open a file, a file-like object
                      to be used as a file or `None` to not use a file at all
@@ -77,7 +79,9 @@ class FileIOMessageWriter(MessageWriter, metaclass=ABCMeta):
 
     file: Union[TextIO, BinaryIO]
 
-    def __init__(self, file: Union[can.typechecking.FileLike, TextIO, BinaryIO], mode: str = "rt") -> None:
+    def __init__(
+        self, file: Union[can.typechecking.FileLike, TextIO, BinaryIO], mode: str = "rt"
+    ) -> None:
         # Not possible with the type signature, but be verbose for user friendliness
         if file is None:
             raise ValueError("The given file cannot be None")

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -202,13 +202,15 @@ class BaseRotatingLogger(Listener, BaseIOHandler, ABC):
         if self._writer is not None:
             self._writer.stop()
 
-        logger = Logger(
-            filename, *self.writer_args, **self.writer_kwargs
-        )
+        logger = Logger(filename, *self.writer_args, **self.writer_kwargs)
         if isinstance(logger, FileIOMessageWriter):
             return logger
+        elif isinstance(logger, Printer) and logger.file is not None:
+            return cast(FileIOMessageWriter, logger)
         else:
-            raise Exception("The Logger corresponding to the arguments is not a FileIOMessageWriter")
+            raise Exception(
+                "The Logger corresponding to the arguments is not a FileIOMessageWriter or can.Printer"
+            )
 
     def stop(self) -> None:
         """Stop handling new messages.

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -234,7 +234,7 @@ class SizedRotatingLogger(BaseRotatingLogger):
     by adding a timestamp and the rollover count. A new log file is then
     created and written to.
 
-    This behavior can be customized by setting the ´namer´ and `rotator`
+    This behavior can be customized by setting the `namer` and `rotator`
     attribute.
 
     Example::
@@ -259,7 +259,8 @@ class SizedRotatingLogger(BaseRotatingLogger):
       * .log :class:`can.CanutilsLogWriter`
       * .txt :class:`can.Printer`
 
-    The log files may be incomplete until `stop()` is called due to buffering.
+    The log files on disk may be incomplete until :meth:`~can.Listener.stop`
+    is called due to buffering.
     """
 
     def __init__(

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -6,7 +6,15 @@ import os
 import pathlib
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, cast, Callable, Optional
+from typing import (
+    Any,
+    Optional,
+    Callable,
+    cast,
+    Type,
+)
+from types import TracebackType
+
 
 from pkg_resources import iter_entry_points
 
@@ -86,64 +94,58 @@ class Logger(BaseIOHandler, Listener):  # pylint: disable=abstract-method
             ) from None
 
 
-class BaseRotatingLogger(Listener, ABC):
+class BaseRotatingLogger(Listener, BaseIOHandler, ABC):
     """
     Base class for rotating CAN loggers. This class is not meant to be
-    instantiated directly. Subclasses must implement the `should_rollover`
+    instantiated directly. Subclasses must implement the :attr:`should_rollover`
     and `do_rollover` methods according to their rotation strategy.
 
     The rotation behavior can be further customized by the user by setting
-    the `namer` and `rotator´ attributes after instantiating the subclass.
+    the :attr:`namer` and :attr:`rotator` attributes after instantiating the subclass.
 
     These attributes as well as the methods `rotation_filename` and `rotate`
     and the corresponding docstrings are carried over from the python builtin
     `BaseRotatingHandler`.
 
-    :attr Optional[Callable] namer:
-        If this attribute is set to a callable, the rotation_filename() method
+    Subclasses must set the `_writer` attribute upon initialization.
+
+    :attr namer:
+        If this attribute is set to a callable, the :meth:`rotation_filename` method
         delegates to this callable. The parameters passed to the callable are
-        those passed to rotation_filename().
-    :attr Optional[Callable] rotator:
-        If this attribute is set to a callable, the rotate() method delegates
+        those passed to :meth:`rotation_filename`.
+    :attr rotator:
+        If this attribute is set to a callable, the :meth:`rotate` method delegates
         to this callable. The parameters passed to the callable are those
-        passed to rotate().
-    :attr int rollover_count:
+        passed to :meth:`rotate`.
+    :attr rollover_count:
         An integer counter to track the number of rollovers.
-    :attr FileIOMessageWriter writer:
-        This attribute holds an instance of a writer class which manages the
-        actual file IO.
     """
 
-    supported_writers = {
-        ".asc": ASCWriter,
-        ".blf": BLFWriter,
-        ".csv": CSVWriter,
-        ".log": CanutilsLogWriter,
-        ".txt": Printer,
-    }
     namer: Optional[Callable[[StringPathLike], StringPathLike]] = None
     rotator: Optional[Callable[[StringPathLike, StringPathLike], None]] = None
     rollover_count: int = 0
-    _writer: Optional[FileIOMessageWriter] = None
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        Listener.__init__(self)
+        BaseIOHandler.__init__(self, None)
+
         self.writer_args = args
         self.writer_kwargs = kwargs
 
+        self._writer: FileIOMessageWriter = None  # type: ignore  # Expected to be set by the subclass
+
     @property
     def writer(self) -> FileIOMessageWriter:
-        if not self._writer:
-            raise ValueError("Attempt to access writer failed.")
-
+        """This attribute holds an instance of a writer class which manages the actual file IO."""
         return self._writer
 
     def rotation_filename(self, default_name: StringPathLike) -> StringPathLike:
         """Modify the filename of a log file when rotating.
 
         This is provided so that a custom filename can be provided.
-        The default implementation calls the 'namer' attribute of the
+        The default implementation calls the :attr:`namer` attribute of the
         handler, if it's callable, passing the default name to
-        it. If the attribute isn't callable (the default is None), the name
+        it. If the attribute isn't callable (the default is `None`), the name
         is returned unchanged.
 
         :param default_name:
@@ -157,17 +159,17 @@ class BaseRotatingLogger(Listener, ABC):
     def rotate(self, source: StringPathLike, dest: StringPathLike) -> None:
         """When rotating, rotate the current log.
 
-        The default implementation calls the 'rotator' attribute of the
+        The default implementation calls the :attr:`rotator` attribute of the
         handler, if it's callable, passing the source and dest arguments to
-        it. If the attribute isn't callable (the default is None), the source
+        it. If the attribute isn't callable (the default is `None`), the source
         is simply renamed to the destination.
 
         :param source:
             The source filename. This is normally the base
-            filename, e.g. 'test.log'
+            filename, e.g. `"test.log"`
         :param dest:
             The destination filename. This is normally
-            what the source is rotated to, e.g. 'test_#001.log'.
+            what the source is rotated to, e.g. `"test_#001.log"`.
         """
         if not callable(self.rotator):
             if os.path.exists(source):
@@ -187,8 +189,8 @@ class BaseRotatingLogger(Listener, ABC):
 
         self.writer.on_message_received(msg)
 
-    def get_new_writer(self, filename: StringPathLike) -> None:
-        """Instantiate a new writer.
+    def _get_new_writer(self, filename: StringPathLike) -> FileIOMessageWriter:
+        """Instantiate a new writer after stopping the old one.
 
         :param filename:
             Path-like object that specifies the location and name of the log file.
@@ -196,18 +198,17 @@ class BaseRotatingLogger(Listener, ABC):
         :return:
             An instance of a writer class.
         """
-        suffix = pathlib.Path(filename).suffix.lower()
-        try:
-            writer_class = self.supported_writers[suffix]
-        except KeyError:
-            raise ValueError(
-                f'Log format with suffix"{suffix}" is '
-                f"not supported by {self.__class__.__name__}."
-            )
+        # Close the old writer first
+        if self._writer is not None:
+            self._writer.stop()
+
+        logger = Logger(
+            filename, *self.writer_args, **self.writer_kwargs
+        )
+        if isinstance(logger, FileIOMessageWriter):
+            return logger
         else:
-            self._writer = writer_class(
-                filename, *self.writer_args, **self.writer_kwargs
-            )
+            raise Exception("The Logger corresponding to the arguments is not a FileIOMessageWriter")
 
     def stop(self) -> None:
         """Stop handling new messages.
@@ -216,6 +217,17 @@ class BaseRotatingLogger(Listener, ABC):
         data is persisted and cleanup any open resources.
         """
         self.writer.stop()
+
+    def __enter__(self) -> "BaseRotatingLogger":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> bool:
+        return self._writer.__exit__(exc_type, exc_val, exc_tb)
 
     @abstractmethod
     def should_rollover(self, msg: Message) -> bool:
@@ -234,8 +246,8 @@ class SizedRotatingLogger(BaseRotatingLogger):
     by adding a timestamp and the rollover count. A new log file is then
     created and written to.
 
-    This behavior can be customized by setting the `namer` and `rotator`
-    attribute.
+    This behavior can be customized by setting the :attr:`namer` and
+    :attr:`rotator` attribute.
 
     Example::
 
@@ -257,10 +269,13 @@ class SizedRotatingLogger(BaseRotatingLogger):
       * .blf :class:`can.BLFWriter`
       * .csv: :class:`can.CSVWriter`
       * .log :class:`can.CanutilsLogWriter`
-      * .txt :class:`can.Printer`
+      * .txt :class:`can.Printer` (if pointing to a file)
 
-    The log files on disk may be incomplete until :meth:`~can.Listener.stop`
-    is called due to buffering.
+    .. note::
+        The :class:`can.SqliteWriter` is not supported yet.
+
+    The log files on disk may be incomplete due to buffering until
+    :meth:`~can.Listener.stop` is called.
     """
 
     def __init__(
@@ -278,12 +293,12 @@ class SizedRotatingLogger(BaseRotatingLogger):
             The size threshold at which a new log file shall be created. If set to 0, no
             rollover will be performed.
         """
-        super(SizedRotatingLogger, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.base_filename = os.path.abspath(base_filename)
         self.max_bytes = max_bytes
 
-        self.get_new_writer(self.base_filename)
+        self._writer = self._get_new_writer(self.base_filename)
 
     def should_rollover(self, msg: Message) -> bool:
         if self.max_bytes <= 0:
@@ -302,7 +317,7 @@ class SizedRotatingLogger(BaseRotatingLogger):
         dfn = self.rotation_filename(self._default_name())
         self.rotate(sfn, dfn)
 
-        self.get_new_writer(self.base_filename)
+        self._writer = self._get_new_writer(self.base_filename)
 
     def _default_name(self) -> StringPathLike:
         """Generate the default rotation filename."""

--- a/can/io/printer.py
+++ b/can/io/printer.py
@@ -4,8 +4,12 @@ This Listener simply prints to stdout / the terminal or a file.
 
 import logging
 
-from can.listener import Listener
+from typing import Optional
+
+from ..message import Message
+from ..listener import Listener
 from .generic import BaseIOHandler
+from ..typechecking import AcceptedIOType
 
 log = logging.getLogger("can.io.printer")
 
@@ -16,24 +20,26 @@ class Printer(BaseIOHandler, Listener):
     any messages it receives to the terminal (stdout). A message is turned into a
     string using :meth:`~can.Message.__str__`.
 
-    :attr bool write_to_file: `True` if this instance prints to a file instead of
-                              standard out
+    :attr write_to_file: `True` if this instance prints to a file instead of
+                         standard out
     """
 
-    def __init__(self, file=None, append=False):
+    def __init__(
+        self, file: Optional[AcceptedIOType] = None, append: bool = False
+    ) -> None:
         """
         :param file: An optional path-like object or a file-like object to "print"
                      to instead of writing to standard out (stdout).
                      If this is a file-like object, is has to be opened in text
                      write mode, not binary write mode.
-        :param bool append: if set to `True` messages are appended to
-                            the file, else the file is truncated
+        :param append: If set to `True` messages, are appended to the file,
+                       else the file is truncated
         """
         self.write_to_file = file is not None
         mode = "a" if append else "w"
         super().__init__(file, mode=mode)
 
-    def on_message_received(self, msg):
+    def on_message_received(self, msg: Message) -> None:
         if self.write_to_file:
             self.file.write(str(msg) + "\n")
         else:

--- a/can/typechecking.py
+++ b/can/typechecking.py
@@ -29,7 +29,7 @@ Channel = typing.Union[ChannelInt, ChannelStr]
 # Used by the IO module
 FileLike = typing.IO[typing.Any]
 StringPathLike = typing.Union[str, "os.PathLike[str]"]
-AcceptedIOType = typing.Optional[typing.Union[FileLike, StringPathLike]]
+AcceptedIOType = typing.Union[FileLike, StringPathLike]
 
 BusConfig = typing.NewType("BusConfig", typing.Dict[str, typing.Any])
 

--- a/test/test_rotating_loggers.py
+++ b/test/test_rotating_loggers.py
@@ -130,7 +130,9 @@ class TestBaseRotatingLogger:
     def test_stop(self, tmp_path):
         """Test if stop() method of writer is called."""
         with self._get_instance(tmp_path) as logger_instance:
-            logger_instance._writer = logger_instance._get_new_writer(tmp_path / "file.ASC")
+            logger_instance._writer = logger_instance._get_new_writer(
+                tmp_path / "file.ASC"
+            )
 
             # replace stop method of writer with Mock
             original_stop = logger_instance.writer.stop

--- a/test/test_rotating_loggers.py
+++ b/test/test_rotating_loggers.py
@@ -45,7 +45,6 @@ class TestBaseRotatingLogger:
         assert hasattr(can.io.BaseRotatingLogger, "rotation_filename")
         assert hasattr(can.io.BaseRotatingLogger, "rotate")
         assert hasattr(can.io.BaseRotatingLogger, "on_message_received")
-        assert hasattr(can.io.BaseRotatingLogger, "get_new_writer")
         assert hasattr(can.io.BaseRotatingLogger, "stop")
         assert hasattr(can.io.BaseRotatingLogger, "should_rollover")
         assert hasattr(can.io.BaseRotatingLogger, "do_rollover")

--- a/test/test_rotating_loggers.py
+++ b/test/test_rotating_loggers.py
@@ -17,9 +17,13 @@ from .data.example_data import generate_message
 
 class TestBaseRotatingLogger:
     @staticmethod
-    def _get_instance(*args, **kwargs) -> can.io.BaseRotatingLogger:
+    def _get_instance(path, *args, **kwargs) -> can.io.BaseRotatingLogger:
         class SubClass(can.io.BaseRotatingLogger):
             """Subclass that implements abstract methods for testing."""
+
+            def __init__(self, *args, **kwargs) -> None:
+                super().__init__(*args, **kwargs)
+                self._writer = can.Printer(file=path / "__unused.txt")
 
             def should_rollover(self, msg: can.Message) -> bool:
                 return False
@@ -34,7 +38,6 @@ class TestBaseRotatingLogger:
 
     def test_attributes(self):
         assert issubclass(can.io.BaseRotatingLogger, can.Listener)
-        assert hasattr(can.io.BaseRotatingLogger, "supported_writers")
         assert hasattr(can.io.BaseRotatingLogger, "namer")
         assert hasattr(can.io.BaseRotatingLogger, "rotator")
         assert hasattr(can.io.BaseRotatingLogger, "rollover_count")
@@ -47,44 +50,31 @@ class TestBaseRotatingLogger:
         assert hasattr(can.io.BaseRotatingLogger, "should_rollover")
         assert hasattr(can.io.BaseRotatingLogger, "do_rollover")
 
-    def test_supported_writers(self):
-        supported_writers = can.io.BaseRotatingLogger.supported_writers
-        assert supported_writers[".asc"] == can.ASCWriter
-        assert supported_writers[".blf"] == can.BLFWriter
-        assert supported_writers[".csv"] == can.CSVWriter
-        assert supported_writers[".log"] == can.CanutilsLogWriter
-        assert supported_writers[".txt"] == can.Printer
+    def test_get_new_writer(self, tmp_path):
+        logger_instance = self._get_instance(tmp_path)
 
-    def test_get_new_writer(self):
-        logger_instance = self._get_instance()
+        writer = logger_instance._get_new_writer(tmp_path / "file.ASC")
+        assert isinstance(writer, can.ASCWriter)
+        writer.stop()
 
-        # access to non existing writer shall raise ValueError
-        with pytest.raises(ValueError):
-            _ = logger_instance.writer
+        writer = logger_instance._get_new_writer(tmp_path / "file.BLF")
+        assert isinstance(writer, can.BLFWriter)
+        writer.stop()
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            logger_instance.get_new_writer(os.path.join(temp_dir, "file.ASC"))
-            assert isinstance(logger_instance.writer, can.ASCWriter)
-            logger_instance.stop()
+        writer = logger_instance._get_new_writer(tmp_path / "file.CSV")
+        assert isinstance(writer, can.CSVWriter)
+        writer.stop()
 
-            logger_instance.get_new_writer(os.path.join(temp_dir, "file.BLF"))
-            assert isinstance(logger_instance.writer, can.BLFWriter)
-            logger_instance.stop()
+        writer = logger_instance._get_new_writer(tmp_path / "file.LOG")
+        assert isinstance(writer, can.CanutilsLogWriter)
+        writer.stop()
 
-            logger_instance.get_new_writer(os.path.join(temp_dir, "file.CSV"))
-            assert isinstance(logger_instance.writer, can.CSVWriter)
-            logger_instance.stop()
+        writer = logger_instance._get_new_writer(tmp_path / "file.TXT")
+        assert isinstance(writer, can.Printer)
+        writer.stop()
 
-            logger_instance.get_new_writer(os.path.join(temp_dir, "file.LOG"))
-            assert isinstance(logger_instance.writer, can.CanutilsLogWriter)
-            logger_instance.stop()
-
-            logger_instance.get_new_writer(os.path.join(temp_dir, "file.TXT"))
-            assert isinstance(logger_instance.writer, can.Printer)
-            logger_instance.stop()
-
-    def test_rotation_filename(self):
-        logger_instance = self._get_instance()
+    def test_rotation_filename(self, tmp_path):
+        logger_instance = self._get_instance(tmp_path)
 
         default_name = "default"
         assert logger_instance.rotation_filename(default_name) == "default"
@@ -92,58 +82,58 @@ class TestBaseRotatingLogger:
         logger_instance.namer = lambda x: x + "_by_namer"
         assert logger_instance.rotation_filename(default_name) == "default_by_namer"
 
-    def test_rotate(self):
-        logger_instance = self._get_instance()
+    def test_rotate_without_rotator(self, tmp_path):
+        logger_instance = self._get_instance(tmp_path)
 
-        # test without rotator
-        with tempfile.TemporaryDirectory() as temp_dir:
-            source = os.path.join(temp_dir, "source.txt")
-            dest = os.path.join(temp_dir, "dest.txt")
+        source = str(tmp_path / "source.txt")
+        dest = str(tmp_path / "dest.txt")
 
-            assert os.path.exists(source) is False
-            assert os.path.exists(dest) is False
+        assert os.path.exists(source) is False
+        assert os.path.exists(dest) is False
 
-            logger_instance.get_new_writer(source)
-            logger_instance.stop()
+        logger_instance._get_new_writer(source)
+        logger_instance.stop()
 
-            assert os.path.exists(source) is True
-            assert os.path.exists(dest) is False
+        assert os.path.exists(source) is True
+        assert os.path.exists(dest) is False
 
-            logger_instance.rotate(source, dest)
+        logger_instance.rotate(source, dest)
 
-            assert os.path.exists(source) is False
-            assert os.path.exists(dest) is True
+        assert os.path.exists(source) is False
+        assert os.path.exists(dest) is True
 
-        # test with rotator
+    def test_rotate_with_rotator(self, tmp_path):
+        logger_instance = self._get_instance(tmp_path)
+
         rotator_func = Mock()
         logger_instance.rotator = rotator_func
-        with tempfile.TemporaryDirectory() as temp_dir:
-            source = os.path.join(temp_dir, "source.txt")
-            dest = os.path.join(temp_dir, "dest.txt")
 
-            assert os.path.exists(source) is False
-            assert os.path.exists(dest) is False
+        source = str(tmp_path / "source.txt")
+        dest = str(tmp_path / "dest.txt")
 
-            logger_instance.get_new_writer(source)
-            logger_instance.stop()
+        assert os.path.exists(source) is False
+        assert os.path.exists(dest) is False
 
-            assert os.path.exists(source) is True
-            assert os.path.exists(dest) is False
+        logger_instance._get_new_writer(source)
+        logger_instance.stop()
 
-            logger_instance.rotate(source, dest)
-            rotator_func.assert_called_with(source, dest)
+        assert os.path.exists(source) is True
+        assert os.path.exists(dest) is False
 
-            # assert that no rotation was performed since rotator_func
-            # does not do anything
-            assert os.path.exists(source) is True
-            assert os.path.exists(dest) is False
+        logger_instance.rotate(source, dest)
+        rotator_func.assert_called_with(source, dest)
 
-    def test_stop(self):
+        # assert that no rotation was performed since rotator_func
+        # does not do anything
+        assert os.path.exists(source) is True
+        assert os.path.exists(dest) is False
+
+    def test_stop(self, tmp_path):
         """Test if stop() method of writer is called."""
-        logger_instance = self._get_instance()
+        logger_instance = self._get_instance(tmp_path)
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            logger_instance.get_new_writer(os.path.join(temp_dir, "file.ASC"))
+            logger_instance._get_new_writer(os.path.join(temp_dir, "file.ASC"))
 
             # replace stop method of writer with Mock
             org_stop = logger_instance.writer.stop
@@ -156,46 +146,45 @@ class TestBaseRotatingLogger:
             # close file.ASC to enable cleanup of temp_dir
             org_stop()
 
-    def test_on_message_received(self):
-        logger_instance = self._get_instance()
+    def test_on_message_received(self, tmp_path):
+        logger_instance = self._get_instance(tmp_path)
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            logger_instance.get_new_writer(os.path.join(temp_dir, "file.ASC"))
+        logger_instance._writer = logger_instance._get_new_writer(tmp_path / "file.ASC")
 
-            # Test without rollover
-            should_rollover = Mock(return_value=False)
-            do_rollover = Mock()
-            writers_on_message_received = Mock()
+        # Test without rollover
+        should_rollover = Mock(return_value=False)
+        do_rollover = Mock()
+        writers_on_message_received = Mock()
 
-            logger_instance.should_rollover = should_rollover
-            logger_instance.do_rollover = do_rollover
-            logger_instance.writer.on_message_received = writers_on_message_received
+        logger_instance.should_rollover = should_rollover
+        logger_instance.do_rollover = do_rollover
+        logger_instance.writer.on_message_received = writers_on_message_received
 
-            msg = generate_message(0x123)
-            logger_instance.on_message_received(msg)
+        msg = generate_message(0x123)
+        logger_instance.on_message_received(msg)
 
-            should_rollover.assert_called_with(msg)
-            do_rollover.assert_not_called()
-            writers_on_message_received.assert_called_with(msg)
+        should_rollover.assert_called_with(msg)
+        do_rollover.assert_not_called()
+        writers_on_message_received.assert_called_with(msg)
 
-            # Test with rollover
-            should_rollover = Mock(return_value=True)
-            do_rollover = Mock()
-            writers_on_message_received = Mock()
+        # Test with rollover
+        should_rollover = Mock(return_value=True)
+        do_rollover = Mock()
+        writers_on_message_received = Mock()
 
-            logger_instance.should_rollover = should_rollover
-            logger_instance.do_rollover = do_rollover
-            logger_instance.writer.on_message_received = writers_on_message_received
+        logger_instance.should_rollover = should_rollover
+        logger_instance.do_rollover = do_rollover
+        logger_instance.writer.on_message_received = writers_on_message_received
 
-            msg = generate_message(0x123)
-            logger_instance.on_message_received(msg)
+        msg = generate_message(0x123)
+        logger_instance.on_message_received(msg)
 
-            should_rollover.assert_called_with(msg)
-            do_rollover.assert_called()
-            writers_on_message_received.assert_called_with(msg)
+        should_rollover.assert_called_with(msg)
+        do_rollover.assert_called()
+        writers_on_message_received.assert_called_with(msg)
 
-            # stop writer to enable cleanup of temp_dir
-            logger_instance.stop()
+        # stop writer to enable cleanup of temp_dir
+        logger_instance.stop()
 
 
 class TestSizedRotatingLogger:
@@ -205,7 +194,6 @@ class TestSizedRotatingLogger:
 
     def test_attributes(self):
         assert issubclass(can.SizedRotatingLogger, can.io.BaseRotatingLogger)
-        assert hasattr(can.SizedRotatingLogger, "supported_writers")
         assert hasattr(can.SizedRotatingLogger, "namer")
         assert hasattr(can.SizedRotatingLogger, "rotator")
         assert hasattr(can.SizedRotatingLogger, "should_rollover")
@@ -281,5 +269,3 @@ class TestSizedRotatingLogger:
 
                 for file_path in os.listdir(temp_dir):
                     assert os.path.getsize(os.path.join(temp_dir, file_path)) <= 1100
-
-                logger_instance.stop()

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,13 @@
 
 [testenv]
 deps =
-    pytest==6.2.*,>=6.2.4
-    pytest-timeout==1.4.*
-    pytest-cov==2.12.*
-    coverage==5.5
-    codecov==2.1.10
+    pytest==6.2.*,>=6.2.5
+    pytest-timeout==2.0.1
+    pytest-cov==3.0.0
+    coverage==6.0.2
+    codecov==2.1.12
     hypothesis~=6.24.0
-    pyserial~=3.0
+    pyserial~=3.5
     parameterized~=0.8
 
 commands =


### PR DESCRIPTION
This PR

- Allows to use all `BaseRotatingLogger` instances to be used as context managers
- Adds a test for `SizedRotatingLogger` as a context manager and cleans up some other tests
- Therefore, it allows to finish #1072
- Makes `BaseRotatingLogger::_get_new_writer` private since it should only be used internally (else, one could have forgotten to close the old file)
- Small documentation improvements
- Reworks the type hierachy: Now most IO readers correctly subclass `FileIOMessageWriter` (previously, it was unused). Now `BaseRotatingLogger::_get_new_writer` looks for that class in order to determine whether the file is supported or not
- Adds some missing types here and there (`can.typechecking.AcceptedIOType` is not an `Optional` any more; its usages in `can.util` were changed accordingly)
- Bumps the CI tool versions