### PR TITLE
Tiny: Fix the way CI status conditions are specified for Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,8 @@
 queue_rules:
   - name: default
     conditions:
-      - "status-success=test,format"  # "GitHub Actions works slightly differently [...], only the job name is used."
+      - "status-success=test"  # "GitHub Actions works slightly differently [...], only the job name is used."
+      - "status-success=format"
 
 pull_request_rules:
   - name: Automatic merge passing PR on up to date branch with approving CR
@@ -10,7 +11,8 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
-      - "status-success=test,format"
+      - "status-success=test"
+      - "status-success=format"
       - "label!=work-in-progress"
     actions:
       queue:


### PR DESCRIPTION
Apparently [our setup does not work](https://github.com/hardbyte/python-can/runs/4006357753).
Instead, we should do it [like in this repo](https://github.com/Mergifyio/mergify-engine/blob/main/.mergify.yml#L14-L19).