### PR TITLE
Make setuptools a package dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,9 +83,7 @@ setup(
     # see https://www.python.org/dev/peps/pep-0345/#version-specifiers
     python_requires=">=3.6",
     install_requires=[
-        # Note setuptools provides pkg_resources which python-can makes use of,
-        # but we assume it is already installed.
-        # "setuptools",
+        "setuptools",
         "wrapt~=1.10",
         'windows-curses;platform_system=="Windows" and platform_python_implementation=="CPython"',
         "typing_extensions>=3.10.0.0",


### PR DESCRIPTION
Fixes https://github.com/hardbyte/python-can/issues/1150

@felixdivo you said

> It's probably best to link to this issue from the setup.py.

Given the source code is under version control, one can track the change to the PR and further to the fixed issue, so I didn't feel like adding redundant comment in the `setup.py` itself, but happy to do so if you insist. As I see it, the `pkg_resources` is being used in the code, thus `setuptools` must be declared as a dependency -- this shouldn't be any different to any other dependency :)