### PR TITLE
Silently ignore system variables found in blf file

### DIFF
--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -235,6 +235,8 @@ class BLFReader(BaseIOHandler):
             if signature != b"LOBJ":
                 if signature != b"BJ \x00" and signature != b"ANoe":
                     raise BLFParseError()
+                else:
+                    continue
 
             # Calculate position of next object
             next_pos = pos + obj_size

--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -233,7 +233,8 @@ class BLFReader(BaseIOHandler):
             # print(header)
             signature, _, header_version, obj_size, obj_type = header
             if signature != b"LOBJ":
-                raise BLFParseError()
+                if signature != b"BJ \x00" and signature != b"ANoe":
+                    raise BLFParseError()
 
             # Calculate position of next object
             next_pos = pos + obj_size


### PR DESCRIPTION
These are observed in logs created by CANoe 10.0 SP7