### PR TITLE
Fix formatter and bump ci tools

### DIFF
--- a/can/__init__.py
+++ b/can/__init__.py
@@ -12,7 +12,7 @@ __version__ = "4.0.0-dev.2"
 
 log = logging.getLogger("can")
 
-rc: Dict[str, Any] = dict()
+rc: Dict[str, Any] = {}
 
 from .listener import Listener, BufferedReader, RedirectReader, AsyncBufferedReader
 

--- a/can/interfaces/canalystii.py
+++ b/can/interfaces/canalystii.py
@@ -53,7 +53,7 @@ class CANalystIIBus(BusABC):
         elif isinstance(channel, int):
             self.channels = [channel]
         else:  # Sequence[int]
-            self.channels = [c for c in channel]
+            self.channels = list(channel)
 
         self.rx_queue = collections.deque(
             maxlen=rx_queue_size

--- a/can/interfaces/cantact.py
+++ b/can/interfaces/cantact.py
@@ -39,7 +39,7 @@ class CantactBus(BusABC):
 
         channels = []
         for i in range(0, interface.channel_count()):
-            channels.append({"interface": "cantact", "channel": "ch:%d" % i})
+            channels.append({"interface": "cantact", "channel": f"ch:{i}"})
         return channels
 
     def __init__(

--- a/can/interfaces/ics_neovi/neovi_bus.py
+++ b/can/interfaces/ics_neovi/neovi_bus.py
@@ -226,8 +226,8 @@ class NeoViBus(BusABC):
                 channel = getattr(ics, netid)
             else:
                 raise ValueError(
-                    "channel must be an integer or " "a valid ICS channel name"
-                )
+                    "channel must be an integer or a valid ICS channel name"
+                ) from None
         return channel
 
     @staticmethod

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -604,12 +604,12 @@ class IXXATBus(BusABC):
             return 1
 
     def flush_tx_buffer(self):
-        """ Flushes the transmit buffer on the IXXAT """
+        """Flushes the transmit buffer on the IXXAT"""
         # TODO #64: no timeout?
         _canlib.canChannelWaitTxEvent(self._channel_handle, constants.INFINITE)
 
     def _recv_internal(self, timeout):
-        """ Read a message from IXXAT device. """
+        """Read a message from IXXAT device."""
 
         # TODO: handling CAN error messages?
         data_received = False

--- a/can/interfaces/ixxat/exceptions.py
+++ b/can/interfaces/ixxat/exceptions.py
@@ -21,15 +21,15 @@ __all__ = [
 
 
 class VCITimeout(CanTimeoutError):
-    """ Wraps the VCI_E_TIMEOUT error """
+    """Wraps the VCI_E_TIMEOUT error"""
 
 
 class VCIError(CanOperationError):
-    """ Try to display errors that occur within the wrapped C library nicely. """
+    """Try to display errors that occur within the wrapped C library nicely."""
 
 
 class VCIRxQueueEmptyError(VCIError):
-    """ Wraps the VCI_E_RXQUEUE_EMPTY error """
+    """Wraps the VCI_E_RXQUEUE_EMPTY error"""
 
     def __init__(self):
         super().__init__("Receive queue is empty")

--- a/can/interfaces/kvaser/canlib.py
+++ b/can/interfaces/kvaser/canlib.py
@@ -713,11 +713,7 @@ def get_channel_info(channel):
         ctypes.sizeof(number),
     )
 
-    return "%s, S/N %d (#%d)" % (
-        name.value.decode("ascii"),
-        serial.value,
-        number.value + 1,
-    )
+    return f"{name.value.decode('ascii')}, S/N {serial.value} (#{number.value + 1})"
 
 
 init_kvaser_library()

--- a/can/interfaces/neousys/neousys.py
+++ b/can/interfaces/neousys/neousys.py
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 
 
 class NeousysCanSetup(Structure):
-    """ C CAN Setup struct """
+    """C CAN Setup struct"""
 
     _fields_ = [
         ("bitRate", c_uint),
@@ -58,7 +58,7 @@ class NeousysCanSetup(Structure):
 
 
 class NeousysCanMsg(Structure):
-    """ C CAN Message struct """
+    """C CAN Message struct"""
 
     _fields_ = [
         ("id", c_uint),
@@ -75,7 +75,7 @@ class NeousysCanMsg(Structure):
 # valid:1~4, Resynchronization Jump Width in time quanta
 # valid:1~1023, CAN_CLK divider used to determine time quanta
 class NeousysCanBitClk(Structure):
-    """ C CAN BIT Clock struct """
+    """C CAN BIT Clock struct"""
 
     _fields_ = [
         ("syncPropPhase1Seg", c_ushort),

--- a/can/interfaces/nixnet.py
+++ b/can/interfaces/nixnet.py
@@ -30,7 +30,7 @@ if sys.platform == "win32":
         )
     except ImportError:
         logger.error("Error, NIXNET python module cannot be loaded.")
-        raise ImportError()
+        raise
 else:
     logger.error("NI-XNET interface is only available on Windows systems")
     raise NotImplementedError("NiXNET is not supported on not Win32 platforms")

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -151,7 +151,7 @@ class PcanBus(BusABC):
         state=BusState.ACTIVE,
         bitrate=500000,
         *args,
-        **kwargs
+        **kwargs,
     ):
         """A PCAN USB interface to CAN.
 
@@ -251,7 +251,7 @@ class PcanBus(BusABC):
         ioport = 0x02A0
         interrupt = 11
 
-        if type(channel) != int:
+        if isinstance(channel, int):
             channel = pcan_channel_names[channel]
 
         self.m_objPCANBasic = PCANBasic()
@@ -265,12 +265,12 @@ class PcanBus(BusABC):
         if self.fd:
             f_clock_val = kwargs.get("f_clock", None)
             if f_clock_val is None:
-                f_clock = "{}={}".format("f_clock_mhz", kwargs.get("f_clock_mhz", None))
+                f_clock = f"f_clock_mhz={kwargs.get('f_clock_mhz', None)}"
             else:
-                f_clock = "{}={}".format("f_clock", kwargs.get("f_clock", None))
+                f_clock = f"f_clock={f_clock_val}"
 
             fd_parameters_values = [f_clock] + [
-                "{}={}".format(key, kwargs.get(key, None))
+                f"{key}={kwargs.get(key, None)}"
                 for key in pcan_fd_parameter_list
                 if kwargs.get(key, None) is not None
             ]
@@ -299,7 +299,8 @@ class PcanBus(BusABC):
                 # TODO Remove Filter when MACCan actually supports it:
                 #  https://github.com/mac-can/PCBUSB-Library/
                 log.debug(
-                    "Ignoring error. PCAN_ALLOW_ERROR_FRAMES is still unsupported by OSX Library PCANUSB v0.10"
+                    "Ignoring error. PCAN_ALLOW_ERROR_FRAMES is still unsupported by OSX Library "
+                    "PCANUSB v0.10"
                 )
 
         if HAS_EVENTS:
@@ -341,8 +342,9 @@ class PcanBus(BusABC):
             for b in bits(error):
                 stsReturn = self.m_objPCANBasic.GetErrorText(b, 0x9)
                 if stsReturn[0] != PCAN_ERROR_OK:
-                    text = "An error occurred. Error-code's text ({0:X}h) couldn't be retrieved".format(
-                        error
+                    text = (
+                        f"An error occurred. Error-code's text ({error:X}h) couldn't be"
+                        f" retrieved"
                     )
                 else:
                     text = stsReturn[1].decode("utf-8", errors="replace")

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -151,7 +151,7 @@ class PcanBus(BusABC):
         state=BusState.ACTIVE,
         bitrate=500000,
         *args,
-        **kwargs,
+        **kwargs
     ):
         """A PCAN USB interface to CAN.
 
@@ -251,7 +251,7 @@ class PcanBus(BusABC):
         ioport = 0x02A0
         interrupt = 11
 
-        if isinstance(channel, int):
+        if type(channel) != int:
             channel = pcan_channel_names[channel]
 
         self.m_objPCANBasic = PCANBasic()
@@ -265,12 +265,12 @@ class PcanBus(BusABC):
         if self.fd:
             f_clock_val = kwargs.get("f_clock", None)
             if f_clock_val is None:
-                f_clock = f"f_clock_mhz={kwargs.get('f_clock_mhz', None)}"
+                f_clock = "{}={}".format("f_clock_mhz", kwargs.get("f_clock_mhz", None))
             else:
-                f_clock = f"f_clock={f_clock_val}"
+                f_clock = "{}={}".format("f_clock", kwargs.get("f_clock", None))
 
             fd_parameters_values = [f_clock] + [
-                f"{key}={kwargs.get(key, None)}"
+                "{}={}".format(key, kwargs.get(key, None))
                 for key in pcan_fd_parameter_list
                 if kwargs.get(key, None) is not None
             ]
@@ -299,8 +299,7 @@ class PcanBus(BusABC):
                 # TODO Remove Filter when MACCan actually supports it:
                 #  https://github.com/mac-can/PCBUSB-Library/
                 log.debug(
-                    "Ignoring error. PCAN_ALLOW_ERROR_FRAMES is still unsupported by OSX Library "
-                    "PCANUSB v0.10"
+                    "Ignoring error. PCAN_ALLOW_ERROR_FRAMES is still unsupported by OSX Library PCANUSB v0.10"
                 )
 
         if HAS_EVENTS:
@@ -342,9 +341,8 @@ class PcanBus(BusABC):
             for b in bits(error):
                 stsReturn = self.m_objPCANBasic.GetErrorText(b, 0x9)
                 if stsReturn[0] != PCAN_ERROR_OK:
-                    text = (
-                        f"An error occurred. Error-code's text ({error:X}h) couldn't be"
-                        f" retrieved"
+                    text = "An error occurred. Error-code's text ({0:X}h) couldn't be retrieved".format(
+                        error
                     )
                 else:
                     text = stsReturn[1].decode("utf-8", errors="replace")

--- a/can/interfaces/seeedstudio/seeedstudio.py
+++ b/can/interfaces/seeedstudio/seeedstudio.py
@@ -113,7 +113,7 @@ class SeeedBus(BusABC):
                 "could not create the serial device"
             ) from error
 
-        super(SeeedBus, self).__init__(channel=channel, *args, **kwargs)
+        super().__init__(channel=channel, *args, **kwargs)
         self.init_frame()
 
     def shutdown(self):

--- a/can/interfaces/socketcan/utils.py
+++ b/can/interfaces/socketcan/utils.py
@@ -11,7 +11,7 @@ import subprocess
 from typing import cast, Iterable, Optional
 
 from can.interfaces.socketcan.constants import CAN_EFF_FLAG
-import can.typechecking as typechecking
+from can import typechecking
 
 log = logging.getLogger(__name__)
 

--- a/can/interfaces/systec/structures.py
+++ b/can/interfaces/systec/structures.py
@@ -268,7 +268,7 @@ class HardwareInfoEx(Structure):
     ]
 
     def __init__(self):
-        super(HardwareInfoEx, self).__init__(sizeof(HardwareInfoEx))
+        super().__init__(sizeof(HardwareInfoEx))
 
     def __eq__(self, other):
         if not isinstance(other, HardwareInfoEx):

--- a/can/interfaces/udp_multicast/bus.py
+++ b/can/interfaces/udp_multicast/bus.py
@@ -121,13 +121,13 @@ class UdpMulticastBus(BusABC):
 
         return can_message, False
 
-    def send(self, message: can.Message, timeout: Optional[float] = None) -> None:
-        if not self.is_fd and message.is_fd:
+    def send(self, msg: can.Message, timeout: Optional[float] = None) -> None:
+        if not self.is_fd and msg.is_fd:
             raise can.CanOperationError(
                 "cannot send FD message over bus with CAN FD disabled"
             )
 
-        data = pack_message(message)
+        data = pack_message(msg)
         self._multicast.send(data, timeout)
 
     def fileno(self) -> int:
@@ -186,8 +186,9 @@ class GeneralPurposeUdpMulticastBus:
                 sock = self._create_socket(address_family)
             except OSError as error:
                 log.info(
-                    f"could not connect to the multicast IP network of candidate %s; reason: {error}",
+                    "could not connect to the multicast IP network of candidate %s; reason: %s",
                     connection_candidates,
+                    error,
                 )
         if sock is not None:
             self._socket = sock

--- a/can/interfaces/virtual.py
+++ b/can/interfaces/virtual.py
@@ -67,7 +67,7 @@ class VirtualBus(BusABC):
 
         # the channel identifier may be an arbitrary object
         self.channel_id = channel
-        self.channel_info = "Virtual bus channel {}".format(self.channel_id)
+        self.channel_info = f"Virtual bus channel {self.channel_id}"
         self.receive_own_messages = receive_own_messages
         self._open = True
 

--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -228,7 +228,7 @@ class BLFReader(BaseIOHandler):
                 if pos + 8 > max_pos:
                     # Not enough data in container
                     return
-                raise BLFParseError("Could not find next object")
+                raise BLFParseError("Could not find next object") from None
             header = unpack_obj_header_base(data, pos)
             # print(header)
             signature, _, header_version, obj_size, obj_type = header
@@ -258,7 +258,7 @@ class BLFReader(BaseIOHandler):
             factor = 1e-5 if flags == 1 else 1e-9
             timestamp = timestamp * factor + start_timestamp
 
-            if obj_type == CAN_MESSAGE or obj_type == CAN_MESSAGE2:
+            if obj_type in (CAN_MESSAGE, CAN_MESSAGE2):
                 channel, flags, dlc, can_id, can_data = unpack_can_msg(data, pos)
                 yield Message(
                     timestamp=timestamp,

--- a/can/io/generic.py
+++ b/can/io/generic.py
@@ -43,6 +43,7 @@ class BaseIOHandler(ContextManager, metaclass=ABCMeta):
             # file is None or some file-like object
             self.file = cast(Optional[can.typechecking.FileLike], file)
         else:
+            # pylint: disable=consider-using-with
             # file is some path-like object
             self.file = open(cast(can.typechecking.StringPathLike, file), mode)
 

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -132,7 +132,8 @@ class BaseRotatingLogger(Listener, BaseIOHandler, ABC):
         self.writer_args = args
         self.writer_kwargs = kwargs
 
-        self._writer: FileIOMessageWriter = None  # type: ignore  # Expected to be set by the subclass
+        # Expected to be set by the subclass
+        self._writer: FileIOMessageWriter = None  # type: ignore
 
     @property
     def writer(self) -> FileIOMessageWriter:
@@ -209,7 +210,8 @@ class BaseRotatingLogger(Listener, BaseIOHandler, ABC):
             return cast(FileIOMessageWriter, logger)
         else:
             raise Exception(
-                "The Logger corresponding to the arguments is not a FileIOMessageWriter or can.Printer"
+                "The Logger corresponding to the arguments is not a FileIOMessageWriter or "
+                "can.Printer"
             )
 
     def stop(self) -> None:
@@ -283,8 +285,8 @@ class SizedRotatingLogger(BaseRotatingLogger):
     def __init__(
         self,
         base_filename: StringPathLike,
-        max_bytes: int = 0,
         *args: Any,
+        max_bytes: int = 0,
         **kwargs: Any,
     ) -> None:
         """

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -46,9 +46,7 @@ class SqliteReader(BaseIOHandler):
         self.table_name = table_name
 
     def __iter__(self):
-        for frame_data in self._cursor.execute(
-            "SELECT * FROM {}".format(self.table_name)
-        ):
+        for frame_data in self._cursor.execute(f"SELECT * FROM {self.table_name}"):
             yield SqliteReader._assemble_message(frame_data)
 
     @staticmethod
@@ -66,7 +64,7 @@ class SqliteReader(BaseIOHandler):
 
     def __len__(self):
         # this might not run in constant time
-        result = self._cursor.execute("SELECT COUNT(*) FROM {}".format(self.table_name))
+        result = self._cursor.execute(f"SELECT COUNT(*) FROM {self.table_name}")
         return int(result.fetchone()[0])
 
     def read_all(self):
@@ -74,9 +72,7 @@ class SqliteReader(BaseIOHandler):
 
         :rtype: Generator[can.Message]
         """
-        result = self._cursor.execute(
-            "SELECT * FROM {}".format(self.table_name)
-        ).fetchall()
+        result = self._cursor.execute(f"SELECT * FROM {self.table_name}").fetchall()
         return (SqliteReader._assemble_message(frame) for frame in result)
 
     def stop(self):
@@ -164,20 +160,16 @@ class SqliteWriter(BaseIOHandler, BufferedReader):
 
         # create table structure
         self._conn.cursor().execute(
-            """
-        CREATE TABLE IF NOT EXISTS {}
-        (
-          ts REAL,
-          arbitration_id INTEGER,
-          extended INTEGER,
-          remote INTEGER,
-          error INTEGER,
-          dlc INTEGER,
-          data BLOB
-        )
-        """.format(
-                self.table_name
-            )
+            f"""CREATE TABLE IF NOT EXISTS {self.table_name}
+            (
+              ts REAL,
+              arbitration_id INTEGER,
+              extended INTEGER,
+              remote INTEGER,
+              error INTEGER,
+              dlc INTEGER,
+              data BLOB
+            )"""
         )
         self._conn.commit()
 
@@ -209,9 +201,9 @@ class SqliteWriter(BaseIOHandler, BufferedReader):
                         or len(messages) > self.MAX_BUFFER_SIZE_BEFORE_WRITES
                     ):
                         break
-                    else:
-                        # just go on
-                        msg = self.get_message(self.GET_MESSAGE_TIMEOUT)
+
+                    # just go on
+                    msg = self.get_message(self.GET_MESSAGE_TIMEOUT)
 
                 count = len(messages)
                 if count > 0:

--- a/can/listener.py
+++ b/can/listener.py
@@ -142,7 +142,7 @@ class AsyncBufferedReader(Listener):
     def __init__(self, **kwargs: Any) -> None:
         self.buffer: "asyncio.Queue[Message]"
 
-        if "loop" in kwargs.keys():
+        if "loop" in kwargs:
             warnings.warn(
                 "The 'loop' argument is deprecated since python-can 4.0.0 "
                 "and has no effect starting with Python 3.10",

--- a/can/message.py
+++ b/can/message.py
@@ -109,11 +109,11 @@ class Message:  # pylint: disable=too-many-instance-attributes; OK for a datacla
             self._check()
 
     def __str__(self) -> str:
-        field_strings = ["Timestamp: {0:>15.6f}".format(self.timestamp)]
+        field_strings = [f"Timestamp: {self.timestamp:>15.6f}"]
         if self.is_extended_id:
-            arbitration_id_string = "ID: {0:08x}".format(self.arbitration_id)
+            arbitration_id_string = f"ID: {self.arbitration_id:08x}"
         else:
-            arbitration_id_string = "ID: {0:04x}".format(self.arbitration_id)
+            arbitration_id_string = f"ID: {self.arbitration_id:04x}"
         field_strings.append(arbitration_id_string.rjust(12, " "))
 
         flag_string = " ".join(
@@ -130,22 +130,22 @@ class Message:  # pylint: disable=too-many-instance-attributes; OK for a datacla
 
         field_strings.append(flag_string)
 
-        field_strings.append("DLC: {0:2d}".format(self.dlc))
+        field_strings.append("DLC: {self.dlc:2d}")
         data_strings = []
         if self.data is not None:
             for index in range(0, min(self.dlc, len(self.data))):
-                data_strings.append("{0:02x}".format(self.data[index]))
+                data_strings.append(f"{self.data[index]:02x}")
         if data_strings:  # if not empty
             field_strings.append(" ".join(data_strings).ljust(24, " "))
         else:
             field_strings.append(" " * 24)
 
         if (self.data is not None) and (self.data.isalnum()):
-            field_strings.append("'{}'".format(self.data.decode("utf-8", "replace")))
+            field_strings.append(f"'{self.data.decode('utf-8', 'replace')}'")
 
         if self.channel is not None:
             try:
-                field_strings.append("Channel: {}".format(self.channel))
+                field_strings.append(f"Channel: {self.channel}")
             except UnicodeEncodeError:
                 pass
 
@@ -160,32 +160,32 @@ class Message:  # pylint: disable=too-many-instance-attributes; OK for a datacla
 
     def __repr__(self) -> str:
         args = [
-            "timestamp={}".format(self.timestamp),
-            "arbitration_id={:#x}".format(self.arbitration_id),
-            "is_extended_id={}".format(self.is_extended_id),
+            f"timestamp={self.timestamp}",
+            f"arbitration_id={self.arbitration_id:#x}",
+            f"is_extended_id={self.is_extended_id}",
         ]
 
         if not self.is_rx:
             args.append("is_rx=False")
 
         if self.is_remote_frame:
-            args.append("is_remote_frame={}".format(self.is_remote_frame))
+            args.append(f"is_remote_frame={self.is_remote_frame}")
 
         if self.is_error_frame:
-            args.append("is_error_frame={}".format(self.is_error_frame))
+            args.append(f"is_error_frame={self.is_error_frame}")
 
         if self.channel is not None:
-            args.append("channel={!r}".format(self.channel))
+            args.append(f"channel={self.channel!r}")
 
-        data = ["{:#02x}".format(byte) for byte in self.data]
-        args += ["dlc={}".format(self.dlc), "data=[{}]".format(", ".join(data))]
+        data = [f"{byte:#02x}" for byte in self.data]
+        args += [f"dlc={self.dlc}", f"data=[{', '.join(data)}]"]
 
         if self.is_fd:
             args.append("is_fd=True")
-            args.append("bitrate_switch={}".format(self.bitrate_switch))
-            args.append("error_state_indicator={}".format(self.error_state_indicator))
+            args.append(f"bitrate_switch={self.bitrate_switch}")
+            args.append(f"error_state_indicator={self.error_state_indicator}")
 
-        return "can.Message({})".format(", ".join(args))
+        return f"can.Message({', '.join(args)})"
 
     def __format__(self, format_spec: Optional[str]) -> str:
         if not format_spec:

--- a/can/notifier.py
+++ b/can/notifier.py
@@ -76,7 +76,7 @@ class Notifier:
             reader_thread = threading.Thread(
                 target=self._rx_thread,
                 args=(bus,),
-                name='can.notifier for bus "{}"'.format(bus.channel_info),
+                name=f'can.notifier for bus "{bus.channel_info}"',
             )
             reader_thread.daemon = True
             reader_thread.start()

--- a/can/util.py
+++ b/can/util.py
@@ -339,7 +339,7 @@ def _rename_kwargs(
                     )
                 kwargs[new] = value
             else:
-                warnings.warn("{} is deprecated".format(alias), DeprecationWarning)
+                warnings.warn(f"{alias} is deprecated", DeprecationWarning)
 
 
 def time_perfcounter_correlation() -> Tuple[float, float]:

--- a/can/viewer.py
+++ b/can/viewer.py
@@ -290,7 +290,7 @@ class CanViewer:
     def redraw_screen(self):
         # Trigger a complete redraw
         self.draw_header()
-        for ids, key in self.ids.items():
+        for key, ids in self.ids.items():
             self.draw_can_bus_message(ids["msg"])
 
 

--- a/can/viewer.py
+++ b/can/viewer.py
@@ -167,7 +167,7 @@ class CanViewer:
 
                 return values
 
-        raise ValueError("Unknown command: 0x{:02X}".format(cmd))
+        raise ValueError(f"Unknown command: 0x{cmd:02X}")
 
     def draw_can_bus_message(self, msg, sorting=False):
         # Use the CAN-Bus ID as the key in the dict
@@ -233,12 +233,10 @@ class CanViewer:
         self.draw_line(
             self.ids[key]["row"],
             8,
-            "{0:.6f}".format(self.ids[key]["msg"].timestamp - self.start_time),
+            f"{self.ids[key]['msg'].timestamp - self.start_time:.6f}",
             color,
         )
-        self.draw_line(
-            self.ids[key]["row"], 23, "{0:.6f}".format(self.ids[key]["dt"]), color
-        )
+        self.draw_line(self.ids[key]["row"], 23, f"{self.ids[key]['dt']:.6f}", color)
         self.draw_line(self.ids[key]["row"], 35, arbitration_id_string, color)
         self.draw_line(self.ids[key]["row"], 47, str(msg.dlc), color)
         for i, b in enumerate(msg.data):
@@ -247,7 +245,7 @@ class CanViewer:
                 # Data does not fit
                 self.draw_line(self.ids[key]["row"], col - 4, "...", color)
                 break
-            text = "{:02X}".format(b)
+            text = f"{b:02X}"
             self.draw_line(self.ids[key]["row"], col, text, color)
 
         if self.data_structs:
@@ -257,7 +255,7 @@ class CanViewer:
                     msg.arbitration_id, self.data_structs, msg.data
                 ):
                     if isinstance(x, float):
-                        values_list.append("{0:.6f}".format(x))
+                        values_list.append(f"{x:.6f}")
                     else:
                         values_list.append(str(x))
                 values_string = " ".join(values_list)
@@ -292,8 +290,8 @@ class CanViewer:
     def redraw_screen(self):
         # Trigger a complete redraw
         self.draw_header()
-        for key in self.ids:
-            self.draw_can_bus_message(self.ids[key]["msg"])
+        for ids, key in self.ids.items():
+            self.draw_can_bus_message(ids["msg"])
 
 
 class SmartFormatter(argparse.HelpFormatter):
@@ -305,12 +303,12 @@ class SmartFormatter(argparse.HelpFormatter):
         return super()._format_usage(usage, actions, groups, "Usage: ")
 
     def _format_args(self, action, default_metavar):
-        if action.nargs != argparse.REMAINDER and action.nargs != argparse.ONE_OR_MORE:
+        if action.nargs not in (argparse.REMAINDER, argparse.ONE_OR_MORE):
             return super()._format_args(action, default_metavar)
 
         # Use the metavar if "REMAINDER" or "ONE_OR_MORE" is set
         get_metavar = self._metavar_formatter(action, default_metavar)
-        return "%s" % get_metavar(1)
+        return str(get_metavar(1))
 
     def _format_action_invocation(self, action):
         if not action.option_strings or action.nargs == 0:
@@ -323,9 +321,9 @@ class SmartFormatter(argparse.HelpFormatter):
             args_string = self._format_args(action, default)
             for i, option_string in enumerate(action.option_strings):
                 if i == len(action.option_strings) - 1:
-                    parts.append("%s %s" % (option_string, args_string))
+                    parts.append(f"{option_string} {args_string}")
                 else:
-                    parts.append("%s" % option_string)
+                    parts.append(str(option_string))
             return ", ".join(parts)
 
     def _split_lines(self, text, width):
@@ -371,7 +369,7 @@ def parse_args(args):
         "--version",
         action="version",
         help="Show program's version number and exit",
-        version="%(prog)s (version {version})".format(version=__version__),
+        version=f"%(prog)s (version {__version__})",
     )
 
     # Copied from: can/logger.py
@@ -493,7 +491,7 @@ def parse_args(args):
     ] = {}
     if parsed_args.decode:
         if os.path.isfile(parsed_args.decode[0]):
-            with open(parsed_args.decode[0], "r") as f:
+            with open(parsed_args.decode[0], "r", encoding="utf-8") as f:
                 structs = f.readlines()
         else:
             structs = parsed_args.decode

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,7 +25,7 @@ import can  # pylint: disable=wrong-import-position
 # built documents.
 #
 # The short X.Y version.
-version = can.__version__.split("-")[0]
+version = can.__version__.split("-", maxsplit=1)[0]
 release = can.__version__
 
 # General information about the project.

--- a/examples/serial_com.py
+++ b/examples/serial_com.py
@@ -42,7 +42,7 @@ def receive(bus, stop_event):
     while not stop_event.is_set():
         rx_msg = bus.recv(1)
         if rx_msg is not None:
-            print("rx: {}".format(rx_msg))
+            print(f"rx: {rx_msg}")
     print("Stopped receiving messages")
 
 

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,4 +1,4 @@
-pylint==2.7.4
-black==20.8b1
-mypy==0.812
+pylint==2.11.1
+black==21.10b0
+mypy==0.910
 mypy-extensions==0.4.3

--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,12 @@ from setuptools import setup, find_packages
 
 logging.basicConfig(level=logging.WARNING)
 
-with open("can/__init__.py", "r") as fd:
+with open("can/__init__.py", "r", encoding="utf-8") as fd:
     version = re.search(
         r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', fd.read(), re.MULTILINE
     ).group(1)
 
-with open("README.rst", "r") as f:
+with open("README.rst", "r", encoding="utf-8") as f:
     long_description = f.read()
 
 # Dependencies


### PR DESCRIPTION
Firstly, the `black` formatter [failed recently](https://github.com/hardbyte/python-can/runs/4180378756?check_suite_focus=true#step:5:14). Bumping the version solves this problem (see [here](https://github.com/python/typed_ast/issues/169#issuecomment-964360487)).

Secondly, bumping the other CI tools made some more changes nessesary. I suppose none of them are really controversial or interesting. As the linters are somehow not executed any more, not all linter issues are fixed by this (there are quite a few that have accumulated).