### PR TITLE
Allowing for extra config arguments in can.logger

### DIFF
--- a/can/logger.py
+++ b/can/logger.py
@@ -61,7 +61,7 @@ def _create_base_argument_parser(parser: argparse.ArgumentParser) -> None:
         "extra_args",
         nargs=argparse.REMAINDER,
         help="""\
-        The remainding arguments will be use for the interface initialisation.
+        The remainding arguments will be used for the interface initialisation.
         For example, `-i vector -c 1 --app-name=MyCanApp` is the equivalent to 
         opening the bus with `Bus('vector', channel=1, app_name='MyCanApp')`
         """,

--- a/can/logger.py
+++ b/can/logger.py
@@ -57,10 +57,7 @@ def _create_base_argument_parser(parser: argparse.ArgumentParser) -> None:
         help="Bitrate to use for the data phase in case of CAN-FD.",
     )
 
-    parser.add_argument(
-        "--app_name",
-        help="""App name can be necessary in the initializer. For example with Vector.""",
-    )
+    parser.add_argument("extra_args", nargs=argparse.REMAINDER)
 
 
 def _append_filter_argument(
@@ -102,8 +99,6 @@ def _create_bus(parsed_args: Any, **kwargs: Any) -> can.Bus:
         config["fd"] = True
     if parsed_args.data_bitrate:
         config["data_bitrate"] = parsed_args.data_bitrate
-    if parsed_args.app_name:
-        config["app_name"] = parsed_args.app_name
 
     return Bus(parsed_args.channel, **config)  # type: ignore
 
@@ -127,6 +122,19 @@ def _parse_filters(parsed_args: Any) -> CanFilters:
             can_filters.append({"can_id": can_id, "can_mask": can_mask})
 
     return can_filters
+
+
+def _parse_additonal_config(unknown_args):
+    additional_config = dict(
+        (
+            (
+                arg.split("=", 1)[0].lstrip("--").replace("-", "_"),
+                arg.split("=", 1)[1],
+            )
+            for arg in unknown_args
+        )
+    )
+    return additional_config
 
 
 def main() -> None:
@@ -179,9 +187,9 @@ def main() -> None:
         parser.print_help(sys.stderr)
         raise SystemExit(errno.EINVAL)
 
-    results = parser.parse_args()
-
-    bus = _create_bus(results, can_filters=_parse_filters(results))
+    results, unknown_args = parser.parse_known_args()
+    additional_config = _parse_additonal_config(unknown_args)
+    bus = _create_bus(results, can_filters=_parse_filters(results), **additional_config)
 
     if results.active:
         bus.state = BusState.ACTIVE

--- a/can/logger.py
+++ b/can/logger.py
@@ -125,16 +125,10 @@ def _parse_filters(parsed_args: Any) -> CanFilters:
 
 
 def _parse_additonal_config(unknown_args):
-    additional_config = dict(
-        (
-            (
-                arg.split("=", 1)[0].lstrip("--").replace("-", "_"),
-                arg.split("=", 1)[1],
-            )
-            for arg in unknown_args
-        )
+    return dict(
+        (arg.split("=", 1)[0].lstrip("--").replace("-", "_"), arg.split("=", 1)[1])
+        for arg in unknown_args
     )
-    return additional_config
 
 
 def main() -> None:

--- a/can/logger.py
+++ b/can/logger.py
@@ -57,7 +57,15 @@ def _create_base_argument_parser(parser: argparse.ArgumentParser) -> None:
         help="Bitrate to use for the data phase in case of CAN-FD.",
     )
 
-    parser.add_argument("extra_args", nargs=argparse.REMAINDER)
+    parser.add_argument(
+        "extra_args",
+        nargs=argparse.REMAINDER,
+        help="""\
+        The remainding arguments will be use for the interface initialisation.
+        For example, `-i vector -c 1 --app-name=MyCanApp` is the equivalent to 
+        opening the bus with `Bus('vector', channel=1, app_name='MyCanApp')`
+        """,
+    )
 
 
 def _append_filter_argument(

--- a/can/viewer.py
+++ b/can/viewer.py
@@ -36,6 +36,7 @@ from .logger import (
     _parse_filters,
     _append_filter_argument,
     _create_base_argument_parser,
+    _parse_additonal_config,
 )
 
 
@@ -480,7 +481,7 @@ def parse_args(args):
         parser.print_help(sys.stderr)
         raise SystemExit(errno.EINVAL)
 
-    parsed_args = parser.parse_args(args)
+    parsed_args, unknown_args = parser.parse_known_args(args)
 
     can_filters = _parse_filters(parsed_args)
 
@@ -534,13 +535,15 @@ def parse_args(args):
             else:
                 data_structs[key] = struct.Struct(fmt)
 
-    return parsed_args, can_filters, data_structs
+    additional_config = _parse_additonal_config(unknown_args)
+    return parsed_args, can_filters, data_structs, additional_config
 
 
 def main() -> None:
-    parsed_args, can_filters, data_structs = parse_args(sys.argv[1:])
+    parsed_args, can_filters, data_structs, additional_config = parse_args(sys.argv[1:])
 
-    additional_config = {"can_filters": can_filters} if can_filters else {}
+    if can_filters:
+        additional_config.update({"can_filters": can_filters})
     bus = _create_bus(parsed_args, **additional_config)
     # print(f"Connected to {bus.__class__.__name__}: {bus.channel_info}")
 

--- a/test/test_viewer.py
+++ b/test/test_viewer.py
@@ -381,19 +381,19 @@ class CanViewerTest(unittest.TestCase):
             )
 
     def test_parse_args(self):
-        parsed_args, _, _ = parse_args(["-b", "250000"])
+        parsed_args, _, _, _ = parse_args(["-b", "250000"])
         self.assertEqual(parsed_args.bitrate, 250000)
 
-        parsed_args, _, _ = parse_args(["--bitrate", "500000"])
+        parsed_args, _, _, _ = parse_args(["--bitrate", "500000"])
         self.assertEqual(parsed_args.bitrate, 500000)
 
-        parsed_args, _, _ = parse_args(["-c", "can0"])
+        parsed_args, _, _, _ = parse_args(["-c", "can0"])
         self.assertEqual(parsed_args.channel, "can0")
 
-        parsed_args, _, _ = parse_args(["--channel", "PCAN_USBBUS1"])
+        parsed_args, _, _, _ = parse_args(["--channel", "PCAN_USBBUS1"])
         self.assertEqual(parsed_args.channel, "PCAN_USBBUS1")
 
-        parsed_args, _, data_structs = parse_args(["-d", "100:<L"])
+        parsed_args, _, data_structs, _ = parse_args(["-d", "100:<L"])
         self.assertEqual(parsed_args.decode, ["100:<L"])
 
         self.assertIsInstance(data_structs, dict)
@@ -406,7 +406,7 @@ class CanViewerTest(unittest.TestCase):
         f = open("test.txt", "w")
         f.write("100:<BB\n101:<HH\n")
         f.close()
-        parsed_args, _, data_structs = parse_args(["-d", "test.txt"])
+        parsed_args, _, data_structs, _ = parse_args(["-d", "test.txt"])
 
         self.assertIsInstance(data_structs, dict)
         self.assertEqual(len(data_structs), 2)
@@ -420,7 +420,7 @@ class CanViewerTest(unittest.TestCase):
         self.assertEqual(data_structs[0x101].size, 4)
         os.remove("test.txt")
 
-        parsed_args, _, data_structs = parse_args(
+        parsed_args, _, data_structs, _ = parse_args(
             ["--decode", "100:<LH:10.:100.", "101:<ff", "102:<Bf:1:57.3"]
         )
         self.assertEqual(
@@ -453,14 +453,14 @@ class CanViewerTest(unittest.TestCase):
         self.assertEqual(data_structs[0x102][1], 1)
         self.assertAlmostEqual(data_structs[0x102][2], 57.3)
 
-        parsed_args, can_filters, _ = parse_args(["-f", "100:7FF"])
+        parsed_args, can_filters, _, _ = parse_args(["-f", "100:7FF"])
         self.assertEqual(parsed_args.filter, ["100:7FF"])
         self.assertIsInstance(can_filters, list)
         self.assertIsInstance(can_filters[0], dict)
         self.assertEqual(can_filters[0]["can_id"], 0x100)
         self.assertEqual(can_filters[0]["can_mask"], 0x7FF)
 
-        parsed_args, can_filters, _ = parse_args(["-f", "101:7FF", "102:7FC"])
+        parsed_args, can_filters, _, _ = parse_args(["-f", "101:7FF", "102:7FC"])
         self.assertEqual(parsed_args.filter, ["101:7FF", "102:7FC"])
         self.assertIsInstance(can_filters, list)
         self.assertIsInstance(can_filters[0], dict)
@@ -473,17 +473,17 @@ class CanViewerTest(unittest.TestCase):
         with self.assertRaises(argparse.ArgumentError):
             parse_args(["-f", "101,7FF"])
 
-        parsed_args, can_filters, _ = parse_args(["--filter", "100~7FF"])
+        parsed_args, can_filters, _, _ = parse_args(["--filter", "100~7FF"])
         self.assertEqual(parsed_args.filter, ["100~7FF"])
         self.assertIsInstance(can_filters, list)
         self.assertIsInstance(can_filters[0], dict)
         self.assertEqual(can_filters[0]["can_id"], 0x100 | 0x20000000)
         self.assertEqual(can_filters[0]["can_mask"], 0x7FF & 0x20000000)
 
-        parsed_args, _, _ = parse_args(["-i", "socketcan"])
+        parsed_args, _, _, _ = parse_args(["-i", "socketcan"])
         self.assertEqual(parsed_args.interface, "socketcan")
 
-        parsed_args, _, _ = parse_args(["--interface", "pcan"])
+        parsed_args, _, _, _ = parse_args(["--interface", "pcan"])
         self.assertEqual(parsed_args.interface, "pcan")
 
         # Make sure it exits with the correct error code when displaying the help page


### PR DESCRIPTION
I do not believe that interface/backend specific optional configuration should be added to `can.logger` itself.

It is actually very useful to be able to use those interface optional configuration and this change allows to use them in `can.logger`.

This change should also be backward compatible with #1142.

The other option/enhancement, is to define interface specific sub-parsers.