### PR TITLE
Calling stop_all_periodic_tasks() in BusABC

### DIFF
--- a/can/bus.py
+++ b/can/bus.py
@@ -411,6 +411,7 @@ class BusABC(metaclass=ABCMeta):
         Called to carry out any interface specific cleanup required
         in shutting down a bus.
         """
+        self.stop_all_periodic_tasks()
 
     def __enter__(self):
         return self

--- a/can/interfaces/canalystii.py
+++ b/can/interfaces/canalystii.py
@@ -204,6 +204,7 @@ class CANalystIIBus(BusABC):
                 self.device.flush_tx_buffer(ch, float("infinity"))
 
     def shutdown(self) -> None:
+        super().shutdown()
         for channel in self.channels:
             self.device.stop(channel)
         self.device = None

--- a/can/interfaces/cantact.py
+++ b/can/interfaces/cantact.py
@@ -131,6 +131,7 @@ class CantactBus(BusABC):
             )
 
     def shutdown(self):
+        super().shutdown()
         with error_check("Cannot shutdown interface"):
             self.interface.stop()
 

--- a/can/interfaces/gs_usb.py
+++ b/can/interfaces/gs_usb.py
@@ -112,4 +112,5 @@ class GsUsbBus(can.BusABC):
         return msg, False
 
     def shutdown(self):
+        super().shutdown()
         self.gs_usb.stop()

--- a/can/interfaces/iscan.py
+++ b/can/interfaces/iscan.py
@@ -152,6 +152,7 @@ class IscanBus(BusABC):
         iscan.isCAN_TransmitMessageEx(self.channel, ctypes.byref(raw_msg))
 
     def shutdown(self) -> None:
+        super().shutdown()
         iscan.isCAN_CloseDevice(self.channel)
 
 

--- a/can/interfaces/kvaser/canlib.py
+++ b/can/interfaces/kvaser/canlib.py
@@ -643,6 +643,7 @@ class KvaserBus(BusABC):
             log.error("Could not flash LEDs (%s)", e)
 
     def shutdown(self):
+        super().shutdown()
         # Wait for transmit queue to be cleared
         try:
             canWriteSync(self._write_handle, 100)

--- a/can/interfaces/neousys/neousys.py
+++ b/can/interfaces/neousys/neousys.py
@@ -233,6 +233,7 @@ class NeousysBus(BusABC):
         logger.info("%s _neousys_status_cb: %d", self.init_config, status)
 
     def shutdown(self):
+        super().shutdown()
         NEOUSYS_CANLIB.CAN_Stop(self.channel)
 
     @staticmethod

--- a/can/interfaces/nican.py
+++ b/can/interfaces/nican.py
@@ -375,4 +375,5 @@ class NicanBus(BusABC):
 
     def shutdown(self) -> None:
         """Close object."""
+        super().shutdown()
         nican.ncCloseObject(self.handle)

--- a/can/interfaces/nixnet.py
+++ b/can/interfaces/nixnet.py
@@ -221,6 +221,7 @@ class NiXNETcanBus(BusABC):
 
     def shutdown(self):
         """Close object."""
+        super().shutdown()
         self.__session_send.flush()
         self.__session_receive.flush()
 

--- a/can/interfaces/robotell.py
+++ b/can/interfaces/robotell.py
@@ -367,6 +367,7 @@ class robotellBus(BusABC):
         )
 
     def shutdown(self):
+        super().shutdown()
         self.serialPortOrig.close()
 
     def fileno(self):

--- a/can/interfaces/seeedstudio/seeedstudio.py
+++ b/can/interfaces/seeedstudio/seeedstudio.py
@@ -120,6 +120,7 @@ class SeeedBus(BusABC):
         """
         Close the serial interface.
         """
+        super().shutdown()
         self.ser.close()
 
     def init_frame(self, timeout=None):

--- a/can/interfaces/serial/serial_can.py
+++ b/can/interfaces/serial/serial_can.py
@@ -100,6 +100,7 @@ class SerialBus(BusABC):
         """
         Close the serial interface.
         """
+        super().shutdown()
         self._ser.close()
 
     def send(self, msg: Message, timeout: Optional[float] = None) -> None:

--- a/can/interfaces/slcan.py
+++ b/can/interfaces/slcan.py
@@ -264,6 +264,7 @@ class slcanBus(BusABC):
         self._write(sendStr)
 
     def shutdown(self) -> None:
+        super().shutdown()
         self.close()
         with error_check("Could not close serial socket"):
             self.serialPortOrig.close()

--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -696,7 +696,7 @@ class SocketcanBus(BusABC):
 
     def shutdown(self) -> None:
         """Stops all active periodic tasks and closes the socket."""
-        self.stop_all_periodic_tasks()
+        super().shutdown()
         for channel, bcm_socket in self._bcm_sockets.items():
             log.debug("Closing bcm socket for channel %s", channel)
             bcm_socket.close()

--- a/can/interfaces/systec/ucanbus.py
+++ b/can/interfaces/systec/ucanbus.py
@@ -312,6 +312,7 @@ class UcanBus(BusABC):
         """
         Shuts down all CAN interfaces and hardware interface.
         """
+        super().shutdown()
         try:
             self._ucan.shutdown()
         except Exception as exception:

--- a/can/interfaces/udp_multicast/bus.py
+++ b/can/interfaces/udp_multicast/bus.py
@@ -139,6 +139,7 @@ class UdpMulticastBus(BusABC):
 
         Never throws errors and only logs them.
         """
+        super().shutdown()
         self._multicast.shutdown()
 
     @staticmethod

--- a/can/interfaces/usb2can/usb2canInterface.py
+++ b/can/interfaces/usb2can/usb2canInterface.py
@@ -165,6 +165,7 @@ class Usb2canBus(BusABC):
 
         :raise cam.CanOperationError: is closing the connection did not work
         """
+        super().shutdown()
         status = self.can.close(self.handle)
 
         if status != CanalError.SUCCESS:

--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -614,6 +614,7 @@ class VectorBus(BusABC):
         xldriver.xlCanFlushTransmitQueue(self.port_handle, self.mask)
 
     def shutdown(self) -> None:
+        super().shutdown()
         xldriver.xlDeactivateChannel(self.port_handle, self.mask)
         xldriver.xlClosePort(self.port_handle)
         xldriver.xlCloseDriver()

--- a/can/interfaces/virtual.py
+++ b/can/interfaces/virtual.py
@@ -122,6 +122,7 @@ class VirtualBus(BusABC):
             raise CanOperationError("Could not send message to one or more recipients")
 
     def shutdown(self) -> None:
+        super().shutdown()
         if self._open:
             self._open = False
 


### PR DESCRIPTION
Currently, only socketcan is calling stop_all_periodic_tasks() on shutdown and respecting the fact that periodic tasks should be stopped on Bus instance shutdown (according to BusABC.send_periodic docstring).