### PR TITLE
Implement check for minimum version of pcan library

### DIFF
--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -212,12 +212,7 @@ class PcanBus(BusABC):
         self.m_objPCANBasic = PCANBasic()
         self.m_PcanHandle = channel
 
-        apv = self.get_api_version()
-        if apv < MIN_PCAN_API_VERSION:
-            raise CanInitializationError(
-                f"Minimum version of pcan api is {MIN_PCAN_API_VERSION}."
-                f" Installed version is {apv}. Consider upgrade of pcan basic package"
-            )
+        self.check_api_version()
 
         if state is BusState.ACTIVE or state is BusState.PASSIVE:
             self.state = state
@@ -323,6 +318,14 @@ class PcanBus(BusABC):
             raise CanInitializationError(f"Failed to read pcan basic api version")
 
         return version.parse(value.decode("ascii"))
+
+    def check_api_version(self):
+        apv = self.get_api_version()
+        if apv < MIN_PCAN_API_VERSION:
+            raise CanInitializationError(
+                f"Minimum version of pcan api is {MIN_PCAN_API_VERSION}."
+                f" Installed version is {apv}. Consider upgrade of pcan basic package"
+            )
 
     def status(self):
         """

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -322,7 +322,7 @@ class PcanBus(BusABC):
     def check_api_version(self):
         apv = self.get_api_version()
         if apv < MIN_PCAN_API_VERSION:
-            raise CanInitializationError(
+            log.warning(
                 f"Minimum version of pcan api is {MIN_PCAN_API_VERSION}."
                 f" Installed version is {apv}. Consider upgrade of pcan basic package"
             )

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -212,11 +212,7 @@ class PcanBus(BusABC):
         self.m_objPCANBasic = PCANBasic()
         self.m_PcanHandle = channel
 
-        error, value = self.m_objPCANBasic.GetValue(PCAN_NONEBUS, PCAN_API_VERSION)
-        if error != PCAN_ERROR_OK:
-            raise CanInitializationError(f"Failed to read pcan basic api version")
-
-        apv = version.parse(value.decode("ascii"))
+        apv = self.get_api_version()
         if apv < MIN_PCAN_API_VERSION:
             raise CanInitializationError(
                 f"Minimum version of pcan api is {MIN_PCAN_API_VERSION}."
@@ -320,6 +316,13 @@ class PcanBus(BusABC):
             complete_text = stsReturn[1].decode("utf-8", errors="replace")
 
         return complete_text
+
+    def get_api_version(self):
+        error, value = self.m_objPCANBasic.GetValue(PCAN_NONEBUS, PCAN_API_VERSION)
+        if error != PCAN_ERROR_OK:
+            raise CanInitializationError(f"Failed to read pcan basic api version")
+
+        return version.parse(value.decode("ascii"))
 
     def status(self):
         """

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -106,7 +106,7 @@ class PcanBus(BusABC):
         state=BusState.ACTIVE,
         bitrate=500000,
         *args,
-        **kwargs
+        **kwargs,
     ):
         """A PCAN USB interface to CAN.
 
@@ -214,15 +214,13 @@ class PcanBus(BusABC):
 
         error, value = self.m_objPCANBasic.GetValue(PCAN_NONEBUS, PCAN_API_VERSION)
         if error != PCAN_ERROR_OK:
-            raise CanInitializationError(
-                F"Failed to read pcan basic api version"
-            )
+            raise CanInitializationError(f"Failed to read pcan basic api version")
 
-        apv = version.parse(value.decode('ascii'))
+        apv = version.parse(value.decode("ascii"))
         if apv < MIN_PCAN_API_VERSION:
             raise CanInitializationError(
-                F"Minimum version of pcan api is {MIN_PCAN_API_VERSION}."
-                F" Installed version is {apv}. Consider upgrade of pcan basic package"
+                f"Minimum version of pcan api is {MIN_PCAN_API_VERSION}."
+                f" Installed version is {apv}. Consider upgrade of pcan basic package"
             )
 
         if state is BusState.ACTIVE or state is BusState.PASSIVE:

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ setup(
         "typing_extensions>=3.10.0.0",
         'pywin32;platform_system=="Windows" and platform_python_implementation=="CPython"',
         'msgpack~=1.0.0;platform_system!="Windows"',
+        "packaging",
     ],
     extras_require=extras_require,
 )

--- a/test/test_pcan.py
+++ b/test/test_pcan.py
@@ -12,6 +12,7 @@ from parameterized import parameterized
 
 import can
 from can.bus import BusState
+from can.exceptions import CanInitializationError
 from can.interfaces.pcan.basic import *
 from can.interfaces.pcan import PcanBus, PcanError
 
@@ -64,6 +65,11 @@ class TestPCANBus(unittest.TestCase):
         self.MockPCANBasic.assert_called_once()
         self.mock_pcan.Initialize.assert_not_called()
         self.mock_pcan.InitializeFD.assert_called_once()
+
+    def test_api_version_error(self) -> None:
+        self.PCAN_API_VERSION_SIM = "1.0"
+        with self.assertRaises(CanInitializationError):
+            self.bus = can.Bus(bustype="pcan")
 
     @parameterized.expand(
         [

--- a/test/test_pcan.py
+++ b/test/test_pcan.py
@@ -68,8 +68,16 @@ class TestPCANBus(unittest.TestCase):
 
     def test_api_version_low(self) -> None:
         self.PCAN_API_VERSION_SIM = "1.0"
-        with self.assertLogs('can.pcan', level='WARNING') as cm:
+        with self.assertLogs("can.pcan", level="WARNING") as cm:
             self.bus = can.Bus(bustype="pcan")
+            found_version_warning = False
+            for i in cm.output:
+                if "version" in i and "pcan" in i:
+                    found_version_warning = True
+            self.assertTrue(
+                found_version_warning,
+                f"No warning was logged for incompatible api version {cm.output}",
+            )
 
     def test_api_version_read_fail(self) -> None:
         self.mock_pcan.GetValue = Mock(return_value=(PCAN_ERROR_ILLOPERATION, None))

--- a/test/test_pcan.py
+++ b/test/test_pcan.py
@@ -37,15 +37,15 @@ class TestPCANBus(unittest.TestCase):
             self.bus.shutdown()
             self.bus = None
 
-    def _mockGetValue(self, Channel, Parameter):
+    def _mockGetValue(self, channel, parameter):
         """
         This method is used as mock for GetValue method of PCANBasic object.
         Only a subset of parameters are supported.
         """
-        if Parameter == PCAN_API_VERSION:
+        if parameter == PCAN_API_VERSION:
             return PCAN_ERROR_OK, self.PCAN_API_VERSION_SIM.encode("ascii")
         raise NotImplementedError(
-            f"No mock return value specified for parameter {Parameter}"
+            f"No mock return value specified for parameter {parameter}"
         )
 
     def test_bus_creation(self) -> None:

--- a/test/test_pcan.py
+++ b/test/test_pcan.py
@@ -27,6 +27,7 @@ class TestPCANBus(unittest.TestCase):
         self.mock_pcan.InitializeFD = Mock(return_value=PCAN_ERROR_OK)
         self.mock_pcan.SetValue = Mock(return_value=PCAN_ERROR_OK)
         self.mock_pcan.GetValue = self._mockGetValue
+        self.PCAN_API_VERSION_SIM = "4.2"
 
         self.bus = None
 
@@ -41,7 +42,7 @@ class TestPCANBus(unittest.TestCase):
         Only a subset of parameters are supported.
         """
         if Parameter == PCAN_API_VERSION:
-            return PCAN_ERROR_OK, "4.2".encode("ascii")
+            return PCAN_ERROR_OK, self.PCAN_API_VERSION_SIM.encode("ascii")
         raise NotImplementedError(
             f"No mock return value specified for parameter {Parameter}"
         )

--- a/test/test_pcan.py
+++ b/test/test_pcan.py
@@ -26,6 +26,7 @@ class TestPCANBus(unittest.TestCase):
         self.mock_pcan.Initialize.return_value = PCAN_ERROR_OK
         self.mock_pcan.InitializeFD = Mock(return_value=PCAN_ERROR_OK)
         self.mock_pcan.SetValue = Mock(return_value=PCAN_ERROR_OK)
+        self.mock_pcan.GetValue = self._mockGetValue
 
         self.bus = None
 
@@ -33,6 +34,17 @@ class TestPCANBus(unittest.TestCase):
         if self.bus:
             self.bus.shutdown()
             self.bus = None
+
+    def _mockGetValue(self, Channel, Parameter):
+        """
+        This method is used as mock for GetValue method of PCANBasic object.
+        Only a subset of parameters are supported.
+        """
+        if Parameter == PCAN_API_VERSION:
+            return PCAN_ERROR_OK, "4.2".encode("ascii")
+        raise NotImplementedError(
+            f"No mock return value specified for parameter {Parameter}"
+        )
 
     def test_bus_creation(self) -> None:
         self.bus = can.Bus(bustype="pcan")

--- a/test/test_pcan.py
+++ b/test/test_pcan.py
@@ -66,9 +66,9 @@ class TestPCANBus(unittest.TestCase):
         self.mock_pcan.Initialize.assert_not_called()
         self.mock_pcan.InitializeFD.assert_called_once()
 
-    def test_api_version_error(self) -> None:
+    def test_api_version_low(self) -> None:
         self.PCAN_API_VERSION_SIM = "1.0"
-        with self.assertRaises(CanInitializationError):
+        with self.assertLogs('can.pcan', level='WARNING') as cm:
             self.bus = can.Bus(bustype="pcan")
 
     def test_api_version_read_fail(self) -> None:

--- a/test/test_pcan.py
+++ b/test/test_pcan.py
@@ -71,6 +71,11 @@ class TestPCANBus(unittest.TestCase):
         with self.assertRaises(CanInitializationError):
             self.bus = can.Bus(bustype="pcan")
 
+    def test_api_version_read_fail(self) -> None:
+        self.mock_pcan.GetValue = Mock(return_value=(PCAN_ERROR_ILLOPERATION, None))
+        with self.assertRaises(CanInitializationError):
+            self.bus = can.Bus(bustype="pcan")
+
     @parameterized.expand(
         [
             ("no_error", PCAN_ERROR_OK, PCAN_ERROR_OK, "some ok text 1"),

--- a/test/test_pcan.py
+++ b/test/test_pcan.py
@@ -120,8 +120,11 @@ class TestPCANBus(unittest.TestCase):
     )
     def test_get_device_number(self, name, status, expected_result) -> None:
         with self.subTest(name):
-            self.mock_pcan.GetValue = Mock(return_value=(status, 1))
             self.bus = can.Bus(bustype="pcan", fd=True)
+            # Mock GetValue after creation of bus to use first mock of
+            # GetValue in constructor
+            self.mock_pcan.GetValue = Mock(return_value=(status, 1))
+
             self.assertEqual(self.bus.get_device_number(), expected_result)
             self.mock_pcan.GetValue.assert_called_once_with(
                 PCAN_USBBUS1, PCAN_DEVICE_NUMBER


### PR DESCRIPTION
Hello there,

while using this library for a long time now i experienced some issues in the past that the initialization was not working. I checked and found out that there was a parameter set during initialization:
```python
        result = self.m_objPCANBasic.SetValue(
            self.m_PcanHandle, PCAN_ALLOW_ERROR_FRAMES, PCAN_PARAMETER_ON
        )
```
Checking documentation from peak, this parameter is only available with version `4.2` or higher. My version was `4.1.0.96`

To make it easier for others to solve this issue i implemented a version check here.

Open questions:
1.  Should there be a parameter to avoid version check or similar?
2.  Should it be possible to avoid set of this parameter to make this work with older versions?