### PR TITLE
[TINY] Fix syntax highlighting in bus.rst

### DIFF
--- a/doc/bus.rst
+++ b/doc/bus.rst
@@ -80,7 +80,9 @@ This thread safe version of the :class:`~can.BusABC` class can be used by multip
 Sending and receiving is locked separately to avoid unnecessary delays.
 Conflicting calls are executed by blocking until the bus is accessible.
 
-It can be used exactly like the normal :class:`~can.BusABC`::
+It can be used exactly like the normal :class:`~can.BusABC`:
+
+.. code-block:: python
 
     # 'socketcan' is only an example interface, it works with all the others too
     my_bus = can.ThreadSafeBus(interface='socketcan', channel='vcan0')


### PR DESCRIPTION
It currently looks bad:

![image](https://user-images.githubusercontent.com/4403130/146812254-44f122e0-7725-4aa7-a500-45c086176b8e.png)
