### PR TITLE
Update workflow versions, platforms, library and tool versions + README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         experimental: [false]
         python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7", "pypy-3.8"]
-        include:
+        # Do not test on Python 3.11 pre-releases since wrapt causes problems: https://github.com/GrahamDumpleton/wrapt/issues/196
+        # include:
           # Only test on a single configuration while there are just pre-releases
-          - os: ubuntu-latest
-            experimental: true
-            python-version: "3.11.0-alpha.3"
+          # - os: ubuntu-latest
+          #  experimental: true
+          #  python-version: "3.11.0-alpha.3"
       fail-fast: false
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,16 +13,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         experimental: [false]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "pypy-3.7"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7", "pypy-3.8"]
         include:
-          # Skipping Py 3.10 on Windows until windows-curses has a cp310 wheel,
-          # see https://github.com/zephyrproject-rtos/windows-curses/issues/26
+          # Only test on a single configuration while there are just pre-releases
           - os: ubuntu-latest
-            experimental: false
-            python-version: "3.10"
-          - os: macos-latest
-            experimental: false
-            python-version: "3.10"
+            experimental: true
+            python-version: "3.11.0-alpha.3"
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
@@ -38,7 +34,7 @@ jobs:
       run: |
         tox -e gh
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: true
 
@@ -46,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: "3.10"

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -22,10 +22,7 @@ jobs:
       run: |
         black --verbose .
     - name: Commit Formated Code
-      uses: EndBug/add-and-commit@v5
-      env:
-        # This is necessary in order to push a commit to the repo
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: EndBug/add-and-commit@v7
       with:
         message: "Format code with black"
         # Ref https://git-scm.com/docs/git-add#_examples

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.10
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Python developers; providing common abstractions to
 different hardware devices, and a suite of utilities for sending and receiving
 messages on a can bus.
 
-The library currently supports Python 3.6+ as well as PyPy 3 and runs
+The library currently supports Python 3.7+ as well as PyPy 3 and runs
 on Mac, Linux and Windows.
 
 ==============================  ===========
@@ -59,7 +59,7 @@ Library Version                 Python
 ------------------------------  -----------
   2.x                           2.6+, 3.4+
   3.x                           2.7+, 3.5+
-  4.x *(currently on develop)*  3.6+
+  4.x *(currently on develop)*  3.7+
 ==============================  ===========
 
 

--- a/can/ctypesutil.py
+++ b/can/ctypesutil.py
@@ -14,7 +14,7 @@ __all__ = ["CLibrary", "HANDLE", "PHANDLE", "HRESULT"]
 
 
 try:
-    _LibBase =  ctypes.WinDLL  # type: ignore
+    _LibBase = ctypes.WinDLL  # type: ignore
     _FUNCTION_TYPE = ctypes.WINFUNCTYPE  # type: ignore
 except AttributeError:
     _LibBase = ctypes.CDLL

--- a/can/ctypesutil.py
+++ b/can/ctypesutil.py
@@ -14,7 +14,7 @@ __all__ = ["CLibrary", "HANDLE", "PHANDLE", "HRESULT"]
 
 
 try:
-    _LibBase = ctypes.WinDLL  # type: ignore
+    _LibBase =  ctypes.WinDLL  # type: ignore
     _FUNCTION_TYPE = ctypes.WINFUNCTYPE  # type: ignore
 except AttributeError:
     _LibBase = ctypes.CDLL

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,4 +1,4 @@
-pylint==2.11.1
-black==21.10b0
-mypy==0.910
+pylint==2.12.2
+black==21.12b0
+mypy==0.931
 mypy-extensions==0.4.3

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
     classifiers=[
         # a list of all available ones: https://pypi.org/classifiers/
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -73,7 +72,7 @@ setup(
     version=version,
     packages=find_packages(exclude=["test*", "doc", "scripts", "examples"]),
     scripts=list(filter(isfile, (join("scripts/", f) for f in listdir("scripts/")))),
-    author="Python CAN contributors",
+    author="python-can contributors",
     license="LGPL v3",
     package_data={
         "": ["README.rst", "CONTRIBUTORS.txt", "LICENSE.txt", "CHANGELOG.txt"],
@@ -82,7 +81,7 @@ setup(
     },
     # Installation
     # see https://www.python.org/dev/peps/pep-0345/#version-specifiers
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "setuptools",
         "wrapt~=1.10",

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,11 @@
 [testenv]
 deps =
     pytest==6.2.*,>=6.2.5
-    pytest-timeout==2.0.1
+    pytest-timeout==2.0.2
     pytest-cov==3.0.0
-    coverage==6.0.2
+    coverage==6.2
     codecov==2.1.12
-    hypothesis~=6.24.0
+    hypothesis~=6.35.0
     pyserial~=3.5
     parameterized~=0.8
 


### PR DESCRIPTION
I think most changes do not require explanation. The README was changed since Python 3.6 reached EOL as discussed in (the end of the discussion of) #528.