### PR TITLE
Improve ASCReader robustness

### DIFF
--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -218,6 +218,8 @@ class ASCReader(BaseIOHandler):
                 line,
                 re.ASCII | re.IGNORECASE,
             ):
+                # line might be a comment, chip status,
+                # J1939 message or some other unsupported event
                 continue
 
             msg_kwargs: Dict[str, Union[float, bool, int]] = {}

--- a/test/data/logfile.asc
+++ b/test/data/logfile.asc
@@ -2,6 +2,7 @@ date Sam Sep 30 15:06:13.191 2017
 base hex  timestamps absolute
 internal events logged
 // version 9.0.0
+//0.000000 previous log file: logfile_errorframes.asc
 Begin Triggerblock Sam Sep 30 15:06:13.191 2017
    0.000000 Start of measurement
    0.015991 CAN 1 Status:chip status error passive - TxErr: 132 RxErr: 0

--- a/test/logformats_test.py
+++ b/test/logformats_test.py
@@ -554,6 +554,9 @@ class TestAscFileFormat(ReaderWriterTest):
         actual = self._read_log_file("test_CanErrorFrames.asc")
         self.assertMessagesEqual(actual, expected_messages)
 
+    def test_ignore_comments(self):
+        _msg_list = self._read_log_file("logfile.asc")
+
 
 class TestGzipASCFileFormat(ReaderWriterTest):
     """Tests can.GzipASCWriter and can.GzipASCReader"""


### PR DESCRIPTION
I noticed that the ASCReader fails if the file contains comments.