### PR TITLE
Prepare 4.0.0-rc.0

### DIFF
--- a/can/__init__.py
+++ b/can/__init__.py
@@ -8,7 +8,7 @@ messages on a can bus.
 import logging
 from typing import Dict, Any
 
-__version__ = "4.0.0-dev.2"
+__version__ = "4.0.0-rc.0"
 
 log = logging.getLogger("can")
 

--- a/doc/history.rst
+++ b/doc/history.rst
@@ -49,7 +49,7 @@ The CANalyst-II interface was contributed by Shaoyu Meng in 2018.
 Support for CAN within Python
 -----------------------------
 
-Python natively supports the CAN protocol from version 3.3 on, if running on Linux:
+Python natively supports the CAN protocol from version 3.3 on, if running on Linux (with a sufficiently new kernel):
 
 ==============  ==============================================================  ====
 Python version  Feature                                                         Link
@@ -58,4 +58,5 @@ Python version  Feature                                                         
 3.4             Broadcast Management (BCM) commands are natively supported      `Docs <https://docs.python.org/3/library/socket.html#socket.CAN_BCM>`__
 3.5             CAN FD support                                                  `Docs <https://docs.python.org/3/library/socket.html#socket.CAN_RAW_FD_FRAMES>`__
 3.7             Support for CAN ISO-TP                                          `Docs <https://docs.python.org/3/library/socket.html#socket.CAN_ISOTP>`__
+3.9             Native support for joining CAN filters                          `Docs <https://docs.python.org/3/library/socket.html#socket.CAN_RAW_JOIN_FILTERS>`__
 ==============  ==============================================================  ====

--- a/doc/pycanlib.pml
+++ b/doc/pycanlib.pml
@@ -1,4 +1,4 @@
-/* This promela model was used to verify the concurrent design of the bus object. */
+/* This promela model was used to verify a past design of the bus object. */
 
 bool lock = false;
 


### PR DESCRIPTION
I did not update the [Acknowledgements](https://python-can.readthedocs.io/en/develop/history.html#acknowledgements) section since it's hard to get an overview over the last few years. Even after assembling the changelog, which already took forever. One needs to also update the `CONTRIBUTORS.txt`. **But** both can IMHO also be updated just before the final `4.0.0`, and do not need to be ready for the pre-release. The changelog was more important, since people can check the changes and change their code. I'll open an issue for it, but I'm not eager to actually do it ...