### PR TITLE
Improve gs_usb usability and fix loopback frames

### DIFF
--- a/can/interfaces/gs_usb.py
+++ b/can/interfaces/gs_usb.py
@@ -112,7 +112,7 @@ class GsUsbBus(can.BusABC):
         msg = can.Message(
             timestamp=frame.timestamp,
             arbitration_id=frame.arbitration_id,
-            is_extended_id=frame.can_dlc,
+            is_extended_id=frame.is_extended_id,
             is_remote_frame=frame.is_remote_frame,
             is_error_frame=frame.is_error_frame,
             channel=self.channel_info,

--- a/can/interfaces/gs_usb.py
+++ b/can/interfaces/gs_usb.py
@@ -14,7 +14,16 @@ logger = logging.getLogger(__name__)
 
 
 class GsUsbBus(can.BusABC):
-    def __init__(self, channel, bitrate, index=None, bus=None, address=None, can_filters=None, **kwargs):
+    def __init__(
+        self,
+        channel,
+        bitrate,
+        index=None,
+        bus=None,
+        address=None,
+        can_filters=None,
+        **kwargs,
+    ):
         """
         :param channel: usb device name
         :param index: device number if using automatic scan, starting from 0.
@@ -25,12 +34,16 @@ class GsUsbBus(can.BusABC):
         :param bitrate: CAN network bandwidth (bits/s)
         """
         if (index is not None) and ((bus or address) is not None):
-            raise CanInitializationError(f"index and bus/address cannot be used simultaneously")
+            raise CanInitializationError(
+                f"index and bus/address cannot be used simultaneously"
+            )
 
         if index is not None:
             devs = GsUsb.scan()
-            if len(devs) < index:
-                raise CanInitializationError(f"Cannot find device {index}. Devices found: {len(devs)}")
+            if len(devs) <= index:
+                raise CanInitializationError(
+                    f"Cannot find device {index}. Devices found: {len(devs)}"
+                )
             gs_usb = devs[index]
         else:
             gs_usb = GsUsb.find(bus=bus, address=address)

--- a/doc/interfaces/gs_usb.rst
+++ b/doc/interfaces/gs_usb.rst
@@ -7,7 +7,15 @@ Windows/Linux/Mac CAN driver based on usbfs or WinUSB WCID for Geschwister Schne
 
 Install: ``pip install "python-can[gs_usb]"``
 
-Usage: pass ``bus`` and ``address`` to open the device. The parameters can be got by ``pyusb`` as shown below:
+Usage: pass device ``index`` (starting from 0) if using automatic device detection:
+
+::
+
+    import can
+
+    bus = can.Bus(bustype="gs_usb", channel=dev.product, index=0, bitrate=250000)
+
+Alternatively, pass ``bus`` and ``address`` to open a specific device. The parameters can be got by ``pyusb`` as shown below:
 
 ::
 


### PR DESCRIPTION
This improves the `gs_usb` interface by adding ability to specify device index instead of USB bus/address. The previous method was really inconvenient, because bus/address changes with each USB enumeration. This required libusb dependency in end applications to scan for adapters.

Additionaly, this fixes `is_extended_id` and loopback (echo) frames, by correctly marking `is_rx` flag.