### PR TITLE
[IO][canutils]: use common CAN interface names in generated logfile

### DIFF
--- a/can/io/canutils.py
+++ b/can/io/canutils.py
@@ -160,6 +160,8 @@ class CanutilsLogWriter(FileIOMessageWriter):
             timestamp = msg.timestamp
 
         channel = msg.channel if msg.channel is not None else self.channel
+        if isinstance(channel, int) or isinstance(channel, str) and channel.isdigit():
+            channel = f"can{channel}"
 
         framestr = "(%f) %s" % (timestamp, channel)
 


### PR DESCRIPTION
CAN interfaces in canutils logfiles are usually named 'can0', 'can32' or
'vcan8'. This allows to split logfiles just by performing 'grep' or to
rename CAN interfaces easily with 'sed'.

The current implementation of the canutils log file writer just provides
channel numbers for CAN interfaces. This patch adds the string 'can' to
the channel number to make it look like a usual canutils logfiles that can
be preprocessed as described above.

Signed-off-by: Oliver Hartkopp <socketcan@hartkopp.net>