### PR TITLE
%d format is for a number, not str

### DIFF
--- a/can/interfaces/neousys/neousys.py
+++ b/can/interfaces/neousys/neousys.py
@@ -131,7 +131,7 @@ try:
         NEOUSYS_CANLIB = CDLL("libwdt_dio.so")
     logger.info("Loaded Neousys WDT_DIO Can driver")
 except OSError as error:
-    logger.info("Cannot load Neousys CAN bus dll or shared object: %d", format(error))
+    logger.info("Cannot load Neousys CAN bus dll or shared object: %s", error)
 
 
 class NeousysBus(BusABC):


### PR DESCRIPTION
Failure to initiate the Neousys DLL was causing `TypeError: %d format: a number is required, not str` error since the log line argument is not a number.