### PR TITLE
Add parameter for `on_error` to `BusABC.send_periodic`

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -82,3 +82,4 @@ Felix Nieuwenhuizen
 @pkess
 @felixn
 @Tbruno25
+@andebjor


### PR DESCRIPTION
If there is an error while sending messages in a (background) periodic
task, then the `on_error` callback is called, if set. If the callback is
configured and returns `True` then the task continues, otherwise it is
aborted.

While it is possible to update a task with a callback after the task has
been created, this procedure is prone to a race condition where the
callback might not be configured in time for the first send event. Thus,
if the first send fails and the callback has not yet been configured,
the task will abort.

This commit solves the race condition issue by adding an argument to
`BusABC.send_periodic` to specify the callback. By including the
callback in the constructor it will be deterministically active for all
sends in the task. This fixes issue #1282.

This commit also adds myself to the CONTRIBUTORS list.