### PR TITLE
fix: conversion for port number

### DIFF
--- a/can/util.py
+++ b/can/util.py
@@ -215,12 +215,12 @@ def _create_bus_config(config: Dict[str, Any]) -> typechecking.BusConfig:
         if isinstance(config["port"], str):
         	if config["port"].isnumeric():
         		config["port"] = int(config["port"])
-        		if not 0 < config["port"] < 65535:
-        			raise ValueError("Port config must be inside 0-65535 range!")
         	else:
         		raise ValueError("Port config must be a number!")
         elif not isinstance(config["port"], int):
         	raise TypeError("Port config must be string or integer!")
+	if not 0 < config["port"] < 65535:
+		raise ValueError("Port config must be inside 0-65535 range!")
     if "bitrate" in config:
         config["bitrate"] = int(config["bitrate"])
     if "fd" in config:

--- a/can/util.py
+++ b/can/util.py
@@ -219,8 +219,8 @@ def _create_bus_config(config: Dict[str, Any]) -> typechecking.BusConfig:
                 raise ValueError("Port config must be a number!")
         elif not isinstance(config["port"], int):
             raise TypeError("Port config must be string or integer!")
-    if not 0 < config["port"] < 65535:
-        raise ValueError("Port config must be inside 0-65535 range!")
+        if not 0 < config["port"] < 65535:
+            raise ValueError("Port config must be inside 0-65535 range!")
     if "bitrate" in config:
         config["bitrate"] = int(config["bitrate"])
     if "fd" in config:

--- a/can/util.py
+++ b/can/util.py
@@ -212,15 +212,20 @@ def _create_bus_config(config: Dict[str, Any]) -> typechecking.BusConfig:
             f'Unknown interface type "{config["interface"]}"'
         )
     if "port" in config:
-        if isinstance(config["port"], str):
+        # convert port to integer if necessary
+        if isinstance(config["port"], int):
+            port = config["port"]
+        elif isinstance(config["port"], str):
             if config["port"].isnumeric():
-                config["port"] = int(config["port"])
+                config["port"] = port = int(config["port"])
             else:
                 raise ValueError("Port config must be a number!")
-        elif not isinstance(config["port"], int):
+        else:
             raise TypeError("Port config must be string or integer!")
-        if not 0 < int(config["port"]) < 65535:
+
+        if not 0 < port < 65535:
             raise ValueError("Port config must be inside 0-65535 range!")
+
     if "bitrate" in config:
         config["bitrate"] = int(config["bitrate"])
     if "fd" in config:

--- a/can/util.py
+++ b/can/util.py
@@ -211,7 +211,16 @@ def _create_bus_config(config: Dict[str, Any]) -> typechecking.BusConfig:
         raise CanInterfaceNotImplementedError(
             f'Unknown interface type "{config["interface"]}"'
         )
-
+    if "port" in config:
+        if isinstance(config["port"], str):
+        	if config["port"].isnumeric():
+        		config["port"] = int(config["port"])
+        		if not 0 < config["port"] < 65535:
+        			raise ValueError("Port config must be inside 0-65535 range!")
+        	else:
+        		raise ValueError("Port config must be a number!")
+        elif not isinstance(config["port"], int):
+        	raise TypeError("Port config must be string or integer!")
     if "bitrate" in config:
         config["bitrate"] = int(config["bitrate"])
     if "fd" in config:

--- a/can/util.py
+++ b/can/util.py
@@ -213,14 +213,14 @@ def _create_bus_config(config: Dict[str, Any]) -> typechecking.BusConfig:
         )
     if "port" in config:
         if isinstance(config["port"], str):
-        	if config["port"].isnumeric():
-        		config["port"] = int(config["port"])
-        	else:
-        		raise ValueError("Port config must be a number!")
+            if config["port"].isnumeric():
+                config["port"] = int(config["port"])
+            else:
+                raise ValueError("Port config must be a number!")
         elif not isinstance(config["port"], int):
-        	raise TypeError("Port config must be string or integer!")
-	if not 0 < config["port"] < 65535:
-		raise ValueError("Port config must be inside 0-65535 range!")
+            raise TypeError("Port config must be string or integer!")
+    if not 0 < config["port"] < 65535:
+        raise ValueError("Port config must be inside 0-65535 range!")
     if "bitrate" in config:
         config["bitrate"] = int(config["bitrate"])
     if "fd" in config:

--- a/can/util.py
+++ b/can/util.py
@@ -219,7 +219,7 @@ def _create_bus_config(config: Dict[str, Any]) -> typechecking.BusConfig:
                 raise ValueError("Port config must be a number!")
         elif not isinstance(config["port"], int):
             raise TypeError("Port config must be string or integer!")
-        if not 0 < config["port"] < 65535:
+        if not 0 < int(config["port"]) < 65535:
             raise ValueError("Port config must be inside 0-65535 range!")
     if "bitrate" in config:
         config["bitrate"] = int(config["bitrate"])

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -53,6 +53,9 @@ class RenameKwargsTest(unittest.TestCase):
 
 class TestBusConfig(unittest.TestCase):
     base_config = dict(interface="socketcan", bitrate=500_000)
+    port_alpha_config = dict(interface="socketcan", bitrate=500_000, port="fail123")
+    port_to_high_config = dict(interface="socketcan", bitrate=500_000, port="999999")
+    port_wrong_type_config = dict(interface="socketcan", bitrate=500_000, port=(1234,))
 
     def test_timing_can_use_int(self):
         """
@@ -64,6 +67,9 @@ class TestBusConfig(unittest.TestCase):
             _create_bus_config({**self.base_config, **timing_conf})
         except TypeError as e:
             self.fail(e)
+        self.assertRaises(ValueError, _create_bus_config({**self.port_alpha_config, **timing_conf}))
+        self.assertRaises(ValueError, _create_bus_config({**self.port_to_high_config, **timing_conf}))
+        self.assertRaises(TypeError, _create_bus_config({**self.port_wrong_type_config, **timing_conf}))
 
 
 class TestChannel2Int(unittest.TestCase):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -67,9 +67,9 @@ class TestBusConfig(unittest.TestCase):
             _create_bus_config({**self.base_config, **timing_conf})
         except TypeError as e:
             self.fail(e)
-        self.assertRaises(ValueError, _create_bus_config({**self.port_alpha_config, **timing_conf}))
-        self.assertRaises(ValueError, _create_bus_config({**self.port_to_high_config, **timing_conf}))
-        self.assertRaises(TypeError, _create_bus_config({**self.port_wrong_type_config, **timing_conf}))
+        self.assertRaises(ValueError, _create_bus_config, {**self.port_alpha_config, **timing_conf})
+        self.assertRaises(ValueError, _create_bus_config, {**self.port_to_high_config, **timing_conf})
+        self.assertRaises(TypeError, _create_bus_config, {**self.port_wrong_type_config, **timing_conf})
 
 
 class TestChannel2Int(unittest.TestCase):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -67,9 +67,17 @@ class TestBusConfig(unittest.TestCase):
             _create_bus_config({**self.base_config, **timing_conf})
         except TypeError as e:
             self.fail(e)
-        self.assertRaises(ValueError, _create_bus_config, {**self.port_alpha_config, **timing_conf})
-        self.assertRaises(ValueError, _create_bus_config, {**self.port_to_high_config, **timing_conf})
-        self.assertRaises(TypeError, _create_bus_config, {**self.port_wrong_type_config, **timing_conf})
+        self.assertRaises(
+            ValueError, _create_bus_config, {**self.port_alpha_config, **timing_conf}
+        )
+        self.assertRaises(
+            ValueError, _create_bus_config, {**self.port_to_high_config, **timing_conf}
+        )
+        self.assertRaises(
+            TypeError,
+            _create_bus_config,
+            {**self.port_wrong_type_config, **timing_conf},
+        )
 
 
 class TestChannel2Int(unittest.TestCase):


### PR DESCRIPTION
If reading the port number (for remote can) from a config file, the dict contains a string, that crashes becouse it require an integer.