### PR TITLE
Fix fileno error on Windows (robotell bus)

### DIFF
--- a/can/interfaces/robotell.py
+++ b/can/interfaces/robotell.py
@@ -371,7 +371,9 @@ class robotellBus(BusABC):
         try:
             return self.serialPortOrig.fileno()
         except io.UnsupportedOperation:
-            raise NotImplementedError("fileno is not implemented using current CAN bus on this platform")
+            raise NotImplementedError(
+                "fileno is not implemented using current CAN bus on this platform"
+            )
         except Exception as exception:
             raise CanOperationError("Cannot fetch fileno") from exception
 

--- a/can/interfaces/robotell.py
+++ b/can/interfaces/robotell.py
@@ -2,6 +2,7 @@
 Interface for Chinese Robotell compatible interfaces (win32/linux).
 """
 
+import io
 import time
 import logging
 
@@ -367,10 +368,12 @@ class robotellBus(BusABC):
         self.serialPortOrig.close()
 
     def fileno(self):
-        if hasattr(self.serialPortOrig, "fileno"):
+        try:
             return self.serialPortOrig.fileno()
-        # Return an invalid file descriptor on Windows
-        return -1
+        except io.UnsupportedOperation:
+            raise NotImplementedError("fileno is not implemented using current CAN bus on this platform")
+        except Exception as exception:
+            raise CanOperationError("Cannot fetch fileno") from exception
 
     def get_serial_number(self, timeout):
         """Get serial number of the slcan interface.

--- a/test/test_robotell.py
+++ b/test/test_robotell.py
@@ -944,5 +944,6 @@ class robotellTestCase(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             self.bus.fileno()
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_robotell.py
+++ b/test/test_robotell.py
@@ -940,6 +940,9 @@ class robotellTestCase(unittest.TestCase):
             ),
         )
 
+    def test_when_no_fileno(self):
+        with self.assertRaises(NotImplementedError):
+            self.bus.fileno()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Handling io.UnsupportedOperation and raising NotImplementedError prevents https://github.com/hardbyte/python-can/issues/1312 bug