### PR TITLE
Remove redundant writer.stop call that throws error

### DIFF
--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -217,8 +217,8 @@ class BaseRotatingLogger(Listener, BaseIOHandler, ABC):
             An instance of a writer class.
         """
         # Close the old writer first
-        if self._writer is not None:
-            self._writer.stop()
+        # if self._writer is not None:
+        #     self._writer.stop()
 
         logger = Logger(filename, *self.writer_args, **self.writer_kwargs)
         if isinstance(logger, FileIOMessageWriter):


### PR DESCRIPTION
The issue is that the writer has already previously been told to stop. 

The function `on_message_received` is called:
https://github.com/hardbyte/python-can/blob/796b52586a5d891e4e2077b423de40cba07f8b44/can/io/logger.py#L198-L206

Which calls the `self.do_rollover()` function https://github.com/hardbyte/python-can/blob/796b52586a5d891e4e2077b423de40cba07f8b44/can/io/logger.py#L333-L335. The `writer` is told to stop:
```
    def do_rollover(self) -> None:
        if self.writer:
            self.writer.stop()


        sfn = self.base_filename
        dfn = self.rotation_filename(self._default_name())
        self.rotate(sfn, dfn)


        self._writer = self._get_new_writer(self.base_filename)
```

The `_get_new_writer` function then tells the `_writer` to close https://github.com/hardbyte/python-can/blob/796b52586a5d891e4e2077b423de40cba07f8b44/can/io/logger.py#L219-L221.
```
        # Close the old writer first
        if self._writer is not None:
            self._writer.stop()
```
I believe `writer` and `_writer` are linked. So the call to close the `_writer` is `_get_new_writer` is redundant and is throwing an error because the `writer` is no longer open. 

closes #1316 