### PR TITLE
Fix fileno error on Windows (Serial bus)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,17 @@
 python-can
 ==========
 
-|release| |python_implementation| |downloads| |downloads_monthly| |formatter|
+|release| |conda forge release| |python_implementation| |downloads| |downloads_monthly| |formatter|
 
 |docs| |github-actions| |build_travis| |coverage| |mergify|
 
 .. |release| image:: https://img.shields.io/pypi/v/python-can.svg
    :target: https://pypi.python.org/pypi/python-can/
    :alt: Latest Version on PyPi
+   
+.. |conda forge release| image:: https://img.shields.io/conda/vn/conda-forge/python-can
+   :target: https://anaconda.org/conda-forge/python-can
+   :alt: Latest Version on Conda Forge
 
 .. |python_implementation| image:: https://img.shields.io/pypi/implementation/python-can
    :target: https://pypi.python.org/pypi/python-can/

--- a/README.rst
+++ b/README.rst
@@ -1,17 +1,13 @@
 python-can
 ==========
 
-|release| |conda forge release| |python_implementation| |downloads| |downloads_monthly| |formatter|
+|release| |python_implementation| |downloads| |downloads_monthly| |formatter|
 
 |docs| |github-actions| |build_travis| |coverage| |mergify|
 
 .. |release| image:: https://img.shields.io/pypi/v/python-can.svg
    :target: https://pypi.python.org/pypi/python-can/
    :alt: Latest Version on PyPi
-   
-.. |conda forge release| image:: https://img.shields.io/conda/vn/conda-forge/python-can
-   :target: https://anaconda.org/conda-forge/python-can
-   :alt: Latest Version on Conda Forge
 
 .. |python_implementation| image:: https://img.shields.io/pypi/implementation/python-can
    :target: https://pypi.python.org/pypi/python-can/

--- a/can/interfaces/serial/serial_can.py
+++ b/can/interfaces/serial/serial_can.py
@@ -7,6 +7,7 @@ recording CAN traces.
 See the interface documentation for the format being used.
 """
 
+import io
 import logging
 import struct
 from typing import Any, List, Tuple, Optional
@@ -212,10 +213,14 @@ class SerialBus(BusABC):
             raise CanOperationError("could not read from serial") from error
 
     def fileno(self) -> int:
-        if hasattr(self._ser, "fileno"):
+        try:
             return self._ser.fileno()
-        # Return an invalid file descriptor on Windows
-        return -1
+        except io.UnsupportedOperation:
+            raise NotImplementedError(
+                "fileno is not implemented using current CAN bus on this platform"
+            )
+        except Exception as exception:
+            raise CanOperationError("Cannot fetch fileno") from exception
 
     @staticmethod
     def _detect_available_configs() -> List[AutoDetectedConfig]:

--- a/test/serial_test.py
+++ b/test/serial_test.py
@@ -145,10 +145,15 @@ class SimpleSerialTestBase(ComparingMessagesTestCase):
         except NotImplementedError:
             pass  # allow it to be left non-implemented for Windows platform
         else:
-            fileno.__gt__ = lambda self, compare: True  # Current platform implements fileno, so get the mock to respond to a greater than comparison
+            fileno.__gt__ = (
+                lambda self, compare: True
+            )  # Current platform implements fileno, so get the mock to respond to a greater than comparison
             self.assertIsNotNone(fileno)
-            self.assertFalse(fileno == -1)  # forcing the value to -1 is the old way of managing fileno on Windows but it is not compatible with notifiers
+            self.assertFalse(
+                fileno == -1
+            )  # forcing the value to -1 is the old way of managing fileno on Windows but it is not compatible with notifiers
             self.assertTrue(fileno > 0)
+
 
 class SimpleSerialTest(unittest.TestCase, SimpleSerialTestBase):
     def __init__(self, *args, **kwargs):

--- a/test/serial_test.py
+++ b/test/serial_test.py
@@ -136,6 +136,19 @@ class SimpleSerialTestBase(ComparingMessagesTestCase):
         msg = can.Message(timestamp=-1)
         self.assertRaises(ValueError, self.bus.send, msg)
 
+    def test_when_no_fileno(self):
+        """
+        Tests for the fileno method catching the missing pyserial implementeation on the Windows platform
+        """
+        try:
+            fileno = self.bus.fileno()
+        except NotImplementedError:
+            pass  # allow it to be left non-implemented for Windows platform
+        else:
+            fileno.__gt__ = lambda self, compare: True  # Current platform implements fileno, so get the mock to respond to a greater than comparison
+            self.assertIsNotNone(fileno)
+            self.assertFalse(fileno == -1)  # forcing the value to -1 is the old way of managing fileno on Windows but it is not compatible with notifiers
+            self.assertTrue(fileno > 0)
 
 class SimpleSerialTest(unittest.TestCase, SimpleSerialTestBase):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
I was having issues with the Async example from the docs using the Serial interface: `io.UnsupportedOperation: fileno`

I looked back through the issues and found that several people have hit the fileno error over the years (#760, #877, #902). I have implemented the most recent fix from #1313 on the serial_bus.py interface and added a test case to the test_serial.py file.