### PR TITLE
Allow ICSApiError to be pickled and un-pickled

### DIFF
--- a/can/interfaces/ics_neovi/neovi_bus.py
+++ b/can/interfaces/ics_neovi/neovi_bus.py
@@ -95,6 +95,15 @@ class ICSApiError(CanError):
         self.severity = severity
         self.restart_needed = restart_needed == 1
 
+    def __reduce__(self):
+        return type(self), (
+            self.error_code,
+            self.description_short,
+            self.description_long,
+            self.severity,
+            self.restart_needed,
+        )
+
     @property
     def error_number(self) -> int:
         """Deprecated. Renamed to :attr:`can.CanError.error_code`."""

--- a/test/test_neovi.py
+++ b/test/test_neovi.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+"""
+"""
+import pickle
+import unittest
+from can.interfaces.ics_neovi import ICSApiError
+
+
+class ICSApiErrorTest(unittest.TestCase):
+    def test_error_pickling(self):
+        iae = ICSApiError(
+            0xF00,
+            "description_short",
+            "description_long",
+            severity=ICSApiError.ICS_SPY_ERR_CRITICAL,
+            restart_needed=1,
+        )
+        pickled_iae = pickle.dumps(iae)
+        un_pickled_iae = pickle.loads(pickled_iae)
+        assert iae.__dict__ == un_pickled_iae.__dict__
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fix `TypeError` when trying to un-pickle `ICSApiError`.

`TypeError: __init__() missing 4 required positional arguments: 'description_short', 'description_long', 'severity', and 'restart_needed'`