### PR TITLE
Sort interface names, to make documentation reproducible

### DIFF
--- a/can/logger.py
+++ b/can/logger.py
@@ -43,7 +43,7 @@ def _create_base_argument_parser(parser: argparse.ArgumentParser) -> None:
         dest="interface",
         help="""Specify the backend CAN interface to use. If left blank,
                         fall back to reading from configuration files.""",
-        choices=can.VALID_INTERFACES,
+        choices=sorted(can.VALID_INTERFACES),
     )
 
     parser.add_argument(


### PR DESCRIPTION
`can.VALID_INTERFACES` is a frozenset, and therefore an *unordered* collection.

Therefore, the output of `python3 -m can.logger -h` (that is: the help for the `--interface` flag) depends on the actual ordering of the elements, which is undefined.
This means that the output (and in consequence the sphinx documentation) is not reproducible (as it might yield different results based on...whatever).

Since [Reproducible Builds](https://reproducible-builds.org/) is a *good thing™*, this patch sorts the interfaces before displaying them.