### PR TITLE
Exclude repository-configuration from git-archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.git*      	export-ignore
+.*.yml  	export-ignore


### PR DESCRIPTION
tracking repository configuration (like `.gitignore`) and CI-configuration (`.github/`, `.travis.yml`) within a repository is nice, practical and sometimes unavoidable.

however, such configs do not place nicely when downstreams import the archives into their own git-based workflows.

e.g. for the Debian packaging of `python-can`, we definitely do not want to hide any build-artifacts via `.gitignore` (our workflow is very different from that of upstream development).
we also do not want to accidentally trigger our CI (our CI is supposed to test the packaging, rather than the development).
otoh, we also want to follow the upstream sources as close as possible (that is: without adding/changing/removing any files from the upstream releases).

the typical fix for this is to simply not include the repository-configuration when exporting a snapshot, such as is created automatically by github when downloading a "Release Tarball" (which is really just running `git archive` in the background).

the `.gitattributes` file in this PR does exactly this: it excludes a number of repository- and CI-configuration files from `git archive`.