### PR TITLE
Add py.typed file and distribute it upon installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
         "": ["README.rst", "CONTRIBUTORS.txt", "LICENSE.txt", "CHANGELOG.md"],
         "doc": ["*.*"],
         "examples": ["*.py"],
+        "can": ["py.typed"],
     },
     # Installation
     # see https://www.python.org/dev/peps/pep-0345/#version-specifiers


### PR DESCRIPTION
This should allow downstream packages and "end users" to use type checkers more easily.

Fixes #1340.