### PR TITLE
Add device_id parameter to PcanBus constructor

### DIFF
--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -288,7 +288,7 @@ class PcanBus(BusABC):
 
     def _find_channel_by_dev_id(self, device_id):
         """
-        Iterates over all possible channels to find a channel that matches the device
+        Iterate over all possible channels to find a channel that matches the device
         ID. This method is somewhat brute force, but the Basic API only offers a
         suitable API call since V4.4.0.
 

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -297,7 +297,9 @@ class PcanBus(BusABC):
             no channel can be found.
         """
         for ch_name, ch_handle in PCAN_CHANNEL_NAMES.items():
-            err, cur_dev_id = self.m_objPCANBasic.GetValue(ch_handle, PCAN_DEVICE_NUMBER)
+            err, cur_dev_id = self.m_objPCANBasic.GetValue(
+                ch_handle, PCAN_DEVICE_NUMBER
+            )
             if err != PCAN_ERROR_OK:
                 continue
 

--- a/test/test_pcan.py
+++ b/test/test_pcan.py
@@ -344,6 +344,24 @@ class TestPCANBus(unittest.TestCase):
             self.assertEqual(self.bus.status_string(), expected_result)
             self.mock_pcan.GetStatus.assert_called()
 
+    @parameterized.expand([(0x0, 'error'), (0x42, 'PCAN_USBBUS8')])
+    def test_constructor_with_device_id(self, dev_id, expected_result):
+        def get_value_side_effect(handle, param):
+            if param == PCAN_API_VERSION:
+                return PCAN_ERROR_OK, self.PCAN_API_VERSION_SIM.encode("ascii")
+
+            if handle in (PCAN_USBBUS8, PCAN_USBBUS14):
+                return 0, 0x42
+            else:
+                return PCAN_ERROR_ILLHW, 0x0
+        self.mock_pcan.GetValue = Mock(side_effect=get_value_side_effect)
+
+        if expected_result == 'error':
+            self.assertRaises(ValueError, can.Bus, bustype="pcan", device_id=dev_id)
+        else:
+            self.bus = can.Bus(bustype="pcan", device_id=dev_id)
+            self.assertEqual(expected_result, self.bus.channel_info)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_pcan.py
+++ b/test/test_pcan.py
@@ -344,7 +344,7 @@ class TestPCANBus(unittest.TestCase):
             self.assertEqual(self.bus.status_string(), expected_result)
             self.mock_pcan.GetStatus.assert_called()
 
-    @parameterized.expand([(0x0, 'error'), (0x42, 'PCAN_USBBUS8')])
+    @parameterized.expand([(0x0, "error"), (0x42, "PCAN_USBBUS8")])
     def test_constructor_with_device_id(self, dev_id, expected_result):
         def get_value_side_effect(handle, param):
             if param == PCAN_API_VERSION:
@@ -354,9 +354,10 @@ class TestPCANBus(unittest.TestCase):
                 return 0, 0x42
             else:
                 return PCAN_ERROR_ILLHW, 0x0
+
         self.mock_pcan.GetValue = Mock(side_effect=get_value_side_effect)
 
-        if expected_result == 'error':
+        if expected_result == "error":
             self.assertRaises(ValueError, can.Bus, bustype="pcan", device_id=dev_id)
         else:
             self.bus = can.Bus(bustype="pcan", device_id=dev_id)


### PR DESCRIPTION
This pull request adds support for constructing PCAN bus instances based on the device ID.

Before, it was only possible to select a certain bus based on the channel name (i.e. `PCAN_USBBUSx`). This can be troublesome since the order of the devices is not necessarily consistent across reboots or USB reconnects. With this patch, it is possible to choose the device based on its device ID. The device ID can be freely set through the API or PCAN-View.

Things to discuss before a merge:
* At the moment, the implementation tests all possible PCAN channels. A more suitable method which queries the driver for active channels was introduced in version 4.4.0. I refrained from using it because I believe this addition was fairly recent and using it would make the feature incompatible to older API versions.