### PR TITLE
Fix race condition in back2back_test for UDP multicast bus

### DIFF
--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -76,21 +76,31 @@ class Back2BackTestCase(unittest.TestCase):
         if not sent_msg.is_remote_frame:
             self.assertSequenceEqual(recv_msg.data, sent_msg.data)
 
-    def _send_and_receive(self, msg: can.Message) -> None:
+    def _send_and_receive(self, msg: can.Message, bus_clear_timeout: float = 0) -> None:
         # Send with bus 1, receive with bus 2
+        print(f"Send on Bus 1: {msg}")
         self.bus1.send(msg)
+
         recv_msg = self.bus2.recv(self.TIMEOUT)
+        print(f"Received on Bus 2: {recv_msg}")
         self._check_received_message(recv_msg, msg)
+
         # Some buses may receive their own messages. Remove it from the queue
-        self.bus1.recv(0)
+        cleared_msg = self.bus1.recv(bus_clear_timeout)
+        print(f"Bus 1 msg cleared: {cleared_msg}")
 
         # Send with bus 2, receive with bus 1
         # Add 1 to arbitration ID to make it a different message
         msg.arbitration_id += 1
+        print(f"Send on Bus 2: {msg}")
         self.bus2.send(msg)
+
         # Some buses may receive their own messages. Remove it from the queue
-        self.bus2.recv(0)
+        cleared_msg = self.bus2.recv(bus_clear_timeout)
+        print(f"Bus 2 msg cleared: {cleared_msg}")
+
         recv_msg = self.bus1.recv(self.TIMEOUT)
+        print(f"Received on Bus 1: {recv_msg}")
         self._check_received_message(recv_msg, msg)
 
     def test_no_message(self):
@@ -141,6 +151,10 @@ class Back2BackTestCase(unittest.TestCase):
     def test_dlc_less_than_eight(self):
         msg = can.Message(is_extended_id=False, arbitration_id=0x300, data=[4, 5, 6])
         self._send_and_receive(msg)
+
+    def test_dlc_less_than_eight_with_clear_timeout(self):
+        msg = can.Message(is_extended_id=False, arbitration_id=0x300, data=[4, 5, 6])
+        self._send_and_receive(msg, bus_clear_timeout=0.3)
 
     @unittest.skip(
         "TODO: how shall this be treated if sending messages locally? should be done uniformly"

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -321,11 +321,12 @@ class BasicTestUdpMulticastBusIPv4(Back2BackTestCase):
     "only supported on Unix systems (but not on Travis CI; and not on macOS at GitHub Actions)",
 )
 class BasicTestUdpMulticastBusIPv6(Back2BackTestCase):
+    HOST_LOCAL_MCAST_GROUP_IPv6 = "ff11:7079:7468:6f6e:6465:6d6f:6d63:6173"
 
     INTERFACE_1 = "udp_multicast"
-    CHANNEL_1 = UdpMulticastBus.DEFAULT_GROUP_IPv6
+    CHANNEL_1 = HOST_LOCAL_MCAST_GROUP_IPv6
     INTERFACE_2 = "udp_multicast"
-    CHANNEL_2 = UdpMulticastBus.DEFAULT_GROUP_IPv6
+    CHANNEL_2 = HOST_LOCAL_MCAST_GROUP_IPv6
 
     def test_unique_message_instances(self):
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
Add debug prints to back2back_test to analyze race condition, see #1345.
Might fail if pytest does not print stdout