### PR TITLE
Fix the sized rotating logger size bug for the blf writer

### DIFF
--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -352,6 +352,7 @@ class ASCWriter(FileIOMessageWriter):
         self,
         file: Union[StringPathLike, TextIO],
         channel: int = 1,
+        **options
     ) -> None:
         """
         :param file: a path-like object or as file-like object to write to

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -349,10 +349,7 @@ class ASCWriter(FileIOMessageWriter):
     FORMAT_EVENT = "{timestamp: 9.6f} {message}\n"
 
     def __init__(
-        self,
-        file: Union[StringPathLike, TextIO],
-        channel: int = 1,
-        **options
+        self, file: Union[StringPathLike, TextIO], channel: int = 1, **options: Any
     ) -> None:
         """
         :param file: a path-like object or as file-like object to write to

--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -531,7 +531,6 @@ class BLFWriter(FileIOMessageWriter):
         self._buffer_size += obj_size + padding_size
         self.object_count += 1
         if self._buffer_size >= self.max_container_size:
-            print("Flush the buffer to a file. Larger than max container!")
             self._flush()
 
     def _flush(self):

--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -531,6 +531,7 @@ class BLFWriter(FileIOMessageWriter):
         self._buffer_size += obj_size + padding_size
         self.object_count += 1
         if self._buffer_size >= self.max_container_size:
+            print("Flush the buffer to a file. Larger than max container!")
             self._flush()
 
     def _flush(self):

--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -533,7 +533,6 @@ class BLFWriter(FileIOMessageWriter):
 
         self._buffer_size += obj_size + padding_size
         self.object_count += 1
-        a = len(zlib.compress(memoryview(b"".join(self._buffer)), 1))
         if self._buffer_size >= self.max_container_size:
             self._flush()
 

--- a/can/io/canutils.py
+++ b/can/io/canutils.py
@@ -5,7 +5,7 @@ It is is compatible with "candump -L" from the canutils program
 """
 
 import logging
-from typing import Generator, TextIO, Union
+from typing import Generator, TextIO, Union, Any
 
 from can.message import Message
 from .generic import FileIOMessageWriter, MessageReader
@@ -132,7 +132,7 @@ class CanutilsLogWriter(FileIOMessageWriter):
         file: Union[StringPathLike, TextIO],
         channel: str = "vcan0",
         append: bool = False,
-        **options,
+        **options: Any,
     ):
         """
         :param file: a path-like object or as file-like object to write to

--- a/can/io/canutils.py
+++ b/can/io/canutils.py
@@ -132,6 +132,7 @@ class CanutilsLogWriter(FileIOMessageWriter):
         file: Union[StringPathLike, TextIO],
         channel: str = "vcan0",
         append: bool = False,
+        **options,
     ):
         """
         :param file: a path-like object or as file-like object to write to

--- a/can/io/csv.py
+++ b/can/io/csv.py
@@ -87,7 +87,7 @@ class CSVWriter(FileIOMessageWriter):
     file: TextIO
 
     def __init__(
-        self, file: Union[StringPathLike, TextIO], append: bool = False
+        self, file: Union[StringPathLike, TextIO], append: bool = False, **options
     ) -> None:
         """
         :param file: a path-like object or a file-like object to write to.

--- a/can/io/csv.py
+++ b/can/io/csv.py
@@ -10,7 +10,7 @@ TODO: This module could use https://docs.python.org/2/library/csv.html#module-cs
 """
 
 from base64 import b64encode, b64decode
-from typing import TextIO, Generator, Union
+from typing import TextIO, Generator, Union, Any
 
 from can.message import Message
 from .generic import FileIOMessageWriter, MessageReader
@@ -87,7 +87,7 @@ class CSVWriter(FileIOMessageWriter):
     file: TextIO
 
     def __init__(
-        self, file: Union[StringPathLike, TextIO], append: bool = False, **options
+        self, file: Union[StringPathLike, TextIO], append: bool = False, **options: Any
     ) -> None:
         """
         :param file: a path-like object or a file-like object to write to.

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -326,7 +326,6 @@ class SizedRotatingLogger(BaseRotatingLogger):
             return False
 
         if self.writer.file.tell() >= self.max_bytes:
-            print("file.tell(): {} bytes".format(self.writer.file.tell()))
             return True
 
         return False

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -325,19 +325,8 @@ class SizedRotatingLogger(BaseRotatingLogger):
         if self.max_bytes <= 0:
             return False
 
-        # The blf writer initially writes the header (144 bytes) of data to the
-        # file, but then does not write again until the buffer size becomes
-        # larger than the max container size and is flushed to the file. This
-        # results in two cases: (1) the requested file size is less than 144
-        # bytes and files are spam written, or (2) the size of the buffer that
-        # goes into the file is consistently the max container size. Therefore,
-        # the buffer size must be checked for the blf writer specifically.
-        if (
-            self.writer.file.tell() >= self.max_bytes
-            or self._writer._buffer_size >= self.max_bytes
-        ):
+        if self.writer.file.tell() >= self.max_bytes:
             print("file.tell(): {} bytes".format(self.writer.file.tell()))
-            print("Buffer size: {} bytes".format(self._writer._buffer_size))
             return True
 
         return False

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -325,7 +325,14 @@ class SizedRotatingLogger(BaseRotatingLogger):
         if self.max_bytes <= 0:
             return False
 
+        value = self.writer.file.tell()
+
+        if value != 144:
+            print("NOT 144!")
+
         if self.writer.file.tell() >= self.max_bytes:
+            print('Rollover: {} bytes'.format(value))
+            print('Buffer size: {} bytes'.format(self._writer._buffer_size))
             return True
 
         return False

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -325,14 +325,19 @@ class SizedRotatingLogger(BaseRotatingLogger):
         if self.max_bytes <= 0:
             return False
 
-        value = self.writer.file.tell()
-
-        if value != 144:
-            print("NOT 144!")
-
-        if self.writer.file.tell() >= self.max_bytes:
-            print('Rollover: {} bytes'.format(value))
-            print('Buffer size: {} bytes'.format(self._writer._buffer_size))
+        # The blf writer initially writes the header (144 bytes) of data to the
+        # file, but then does not write again until the buffer size becomes
+        # larger than the max container size and is flushed to the file. This
+        # results in two cases: (1) the requested file size is less than 144
+        # bytes and files are spam written, or (2) the size of the buffer that
+        # goes into the file is consistently the max container size. Therefore,
+        # the buffer size must be checked for the blf writer specifically.
+        if (
+            self.writer.file.tell() >= self.max_bytes
+            or self._writer._buffer_size >= self.max_bytes
+        ):
+            print("file.tell(): {} bytes".format(self.writer.file.tell()))
+            print("Buffer size: {} bytes".format(self._writer._buffer_size))
             return True
 
         return False

--- a/can/logger.py
+++ b/can/logger.py
@@ -215,6 +215,7 @@ def main() -> None:
 
     options = {"append": results.append}
     if results.file_size:
+        options["max_container_size"] = results.file_size  # bytes
         logger = SizedRotatingLogger(
             base_filename=results.log_file, max_bytes=results.file_size, **options
         )

--- a/can/logger.py
+++ b/can/logger.py
@@ -170,8 +170,9 @@ def main() -> None:
         "--file_size",
         dest="file_size",
         type=int,
-        help="Maximum file size in bytes (or for the case of blf, maximum buffer size before compression and flush to "
-        "file). Rotate log file when size threshold is reached.",
+        help="Maximum file size in bytes (or for the case of blf, maximum "
+        "buffer size before compression and flush to file). Rotate log "
+        "file when size threshold is reached.",
         default=None,
     )
 

--- a/can/logger.py
+++ b/can/logger.py
@@ -170,8 +170,8 @@ def main() -> None:
         "--file_size",
         dest="file_size",
         type=int,
-        help="Maximum file size in bytes. Rotate log file when size threshold "
-        "is reached.",
+        help="Maximum file size in bytes (or for the case of blf, maximum buffer size before compression and flush to "
+        "file). Rotate log file when size threshold is reached.",
         default=None,
     )
 


### PR DESCRIPTION
I see two options here:
  
  1. The `-s` option for the blf rolling logger will **not** define the file size to be written, but rather the buffer size prior to compression
  2. A mathematical equation is to be written that computes the _expected_ file size of the buffer based on the compression integer passed to [zlib.compress](https://docs.python.org/3/library/zlib.html#zlib.compress). (This would require either some knowledge of how the compression functions, or could be an equation fit made from a table of collected values based on a range of compressed buffer sizes vs. the input integer.)
 
I plan to move forward shortly with a commit that will implement the solution (1). 

closes #1359 