### PR TITLE
Raise appropriate error message when append is not possible

### DIFF
--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -352,6 +352,7 @@ class ASCWriter(FileIOMessageWriter):
         self,
         file: Union[StringPathLike, TextIO],
         channel: int = 1,
+        **kwargs,
     ) -> None:
         """
         :param file: a path-like object or as file-like object to write to
@@ -360,6 +361,13 @@ class ASCWriter(FileIOMessageWriter):
         :param channel: a default channel to use when the message does not
                         have a channel set
         """
+        if "append" in kwargs:
+            if kwargs["append"]:
+                raise Exception(
+                    f"{self.__class__.__name__} is currently not "
+                    f"equipped to append messages to an existing "
+                    f"file."
+                )
         super().__init__(file, mode="w")
 
         self.channel = channel

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -352,7 +352,7 @@ class ASCWriter(FileIOMessageWriter):
         self,
         file: Union[StringPathLike, TextIO],
         channel: int = 1,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """
         :param file: a path-like object or as file-like object to write to

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -362,7 +362,7 @@ class ASCWriter(FileIOMessageWriter):
                         have a channel set
         """
         if kwargs.get("append", False):
-            raise TypeError(
+            raise ValueError(
                 f"{self.__class__.__name__} is currently not equipped to "
                 f"append messages to an existing file."
             )

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -363,7 +363,7 @@ class ASCWriter(FileIOMessageWriter):
         """
         if "append" in kwargs:
             if kwargs["append"]:
-                raise Exception(
+                raise TypeError(
                     f"{self.__class__.__name__} is currently not "
                     f"equipped to append messages to an existing "
                     f"file."

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -349,7 +349,10 @@ class ASCWriter(FileIOMessageWriter):
     FORMAT_EVENT = "{timestamp: 9.6f} {message}\n"
 
     def __init__(
-        self, file: Union[StringPathLike, TextIO], channel: int = 1, **kwargs: Any,
+        self,
+        file: Union[StringPathLike, TextIO],
+        channel: int = 1,
+        **kwargs: Any,
     ) -> None:
         """
         :param file: a path-like object or as file-like object to write to

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -349,10 +349,7 @@ class ASCWriter(FileIOMessageWriter):
     FORMAT_EVENT = "{timestamp: 9.6f} {message}\n"
 
     def __init__(
-        self,
-        file: Union[StringPathLike, TextIO],
-        channel: int = 1,
-        **kwargs: Any,
+        self, file: Union[StringPathLike, TextIO], channel: int = 1, **kwargs: Any,
     ) -> None:
         """
         :param file: a path-like object or as file-like object to write to
@@ -361,13 +358,11 @@ class ASCWriter(FileIOMessageWriter):
         :param channel: a default channel to use when the message does not
                         have a channel set
         """
-        if "append" in kwargs:
-            if kwargs["append"]:
-                raise TypeError(
-                    f"{self.__class__.__name__} is currently not "
-                    f"equipped to append messages to an existing "
-                    f"file."
-                )
+        if kwargs.get("append", False):
+            raise TypeError(
+                f"{self.__class__.__name__} is currently not equipped to "
+                f"append messages to an existing file."
+            )
         super().__init__(file, mode="w")
 
         self.channel = channel

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -14,6 +14,7 @@ from types import TracebackType
 from typing_extensions import Literal
 from pkg_resources import iter_entry_points
 
+import can.io
 from ..message import Message
 from ..listener import Listener
 from .generic import BaseIOHandler, FileIOMessageWriter, MessageWriter
@@ -225,6 +226,11 @@ class BaseRotatingLogger(Listener, BaseIOHandler, ABC):
             return logger
         elif isinstance(logger, Printer) and logger.file is not None:
             return cast(FileIOMessageWriter, logger)
+        elif isinstance(logger, can.io.SqliteWriter):
+            raise Exception(
+                "The SqliteWriter is not available in conjunction"
+                "with the sized rotating logger."
+            )
         else:
             raise Exception(
                 "The Logger corresponding to the arguments is not a FileIOMessageWriter or "

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -226,15 +226,10 @@ class BaseRotatingLogger(Listener, BaseIOHandler, ABC):
             return logger
         elif isinstance(logger, Printer) and logger.file is not None:
             return cast(FileIOMessageWriter, logger)
-        elif isinstance(logger, can.io.SqliteWriter):
-            raise Exception(
-                "The SqliteWriter is not available in conjunction"
-                "with the sized rotating logger."
-            )
         else:
             raise Exception(
-                "The Logger corresponding to the arguments is not a FileIOMessageWriter or "
-                "can.Printer"
+                f"The Logger, {logger.__class__.__name__}, corresponding to "
+                f"the arguments is not a FileIOMessageWriter or can.Printer"
             )
 
     def stop(self) -> None:

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -228,8 +228,8 @@ class BaseRotatingLogger(Listener, BaseIOHandler, ABC):
             return cast(FileIOMessageWriter, logger)
         else:
             raise Exception(
-                f"The Logger, {logger.__class__.__name__}, corresponding to "
-                f"the arguments is not a FileIOMessageWriter or can.Printer"
+                f"The log format \".{filename.split('.')[-1]}\" is not "
+                f"supported by {self.__class__.__name__}"
             )
 
     def stop(self) -> None:

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -228,7 +228,7 @@ class BaseRotatingLogger(Listener, BaseIOHandler, ABC):
             return cast(FileIOMessageWriter, logger)
         else:
             raise Exception(
-                f"The log format \"{os.path.splitext(filename)[-1]}\" is not "
+                f'The log format "{os.path.splitext(filename)[-1]}" is not '
                 f"supported by {self.__class__.__name__}"
             )
 

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -228,8 +228,8 @@ class BaseRotatingLogger(Listener, BaseIOHandler, ABC):
             return cast(FileIOMessageWriter, logger)
         else:
             raise Exception(
-                f'The log format "{os.path.splitext(filename)[-1]}" is not '
-                f"supported by {self.__class__.__name__}"
+                f"The log format \"{''.join(pathlib.Path(filename).suffixes[-2:])}"
+                f'" is not supported by {self.__class__.__name__}'
             )
 
     def stop(self) -> None:

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -228,7 +228,7 @@ class BaseRotatingLogger(Listener, BaseIOHandler, ABC):
             return cast(FileIOMessageWriter, logger)
         else:
             raise Exception(
-                f"The log format \".{filename.split('.')[-1]}\" is not "
+                f"The log format \"{os.path.splitext(filename)[-1]}\" is not "
                 f"supported by {self.__class__.__name__}"
             )
 

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -139,6 +139,12 @@ class SqliteWriter(MessageWriter, BufferedReader):
         .. warning:: In contrary to all other readers/writers the Sqlite handlers
                      do not accept file-like objects as the `file` parameter.
         """
+        if "append" in kwargs:
+            if kwargs["append"]:
+                raise Exception(
+                    "The append argument should not be used in "
+                    "conjunction with the SqliteWriter."
+                )
         super().__init__(file=None)
         self.table_name = table_name
         self._db_filename = file

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -139,12 +139,11 @@ class SqliteWriter(MessageWriter, BufferedReader):
         .. warning:: In contrary to all other readers/writers the Sqlite handlers
                      do not accept file-like objects as the `file` parameter.
         """
-        if "append" in kwargs:
-            if kwargs["append"]:
-                raise TypeError(
-                    "The append argument should not be used in "
-                    "conjunction with the SqliteWriter."
-                )
+        if kwargs.get("append", False):
+            raise TypeError(
+                f"The append argument should not be used in "
+                f"conjunction with the {self.__class__.__name__}."
+            )
         super().__init__(file=None)
         self.table_name = table_name
         self._db_filename = file

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -140,7 +140,7 @@ class SqliteWriter(MessageWriter, BufferedReader):
                      do not accept file-like objects as the `file` parameter.
         """
         if kwargs.get("append", False):
-            raise TypeError(
+            raise ValueError(
                 f"The append argument should not be used in "
                 f"conjunction with the {self.__class__.__name__}."
             )

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -129,7 +129,7 @@ class SqliteWriter(MessageWriter, BufferedReader):
     """Maximum number of messages to buffer before writing to the database"""
 
     def __init__(
-        self, file: StringPathLike, table_name: str = "messages", **options: Any
+        self, file: StringPathLike, table_name: str = "messages", **kwargs: Any
     ) -> None:
         """
         :param file: a `str` or path like object that points

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -141,7 +141,7 @@ class SqliteWriter(MessageWriter, BufferedReader):
         """
         if "append" in kwargs:
             if kwargs["append"]:
-                raise Exception(
+                raise TypeError(
                     "The append argument should not be used in "
                     "conjunction with the SqliteWriter."
                 )

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -8,7 +8,7 @@ import time
 import threading
 import logging
 import sqlite3
-from typing import Generator
+from typing import Generator, Any
 
 from can.listener import BufferedReader
 from can.message import Message
@@ -128,7 +128,9 @@ class SqliteWriter(MessageWriter, BufferedReader):
     MAX_BUFFER_SIZE_BEFORE_WRITES = 500
     """Maximum number of messages to buffer before writing to the database"""
 
-    def __init__(self, file: StringPathLike, table_name: str = "messages") -> None:
+    def __init__(
+        self, file: StringPathLike, table_name: str = "messages", **options: Any
+    ) -> None:
         """
         :param file: a `str` or path like object that points
                      to the database file to use

--- a/test/logformats_test.py
+++ b/test/logformats_test.py
@@ -311,7 +311,7 @@ class ReaderWriterTest(unittest.TestCase, ComparingMessagesTestCase, metaclass=A
         # use append mode for second half
         try:
             writer = self.writer_constructor(self.test_file_name, append=True)
-        except TypeError as e:
+        except ValueError as e:
             # maybe "append" is not a formal parameter (this is the case for SqliteWriter)
             try:
                 writer = self.writer_constructor(self.test_file_name)


### PR DESCRIPTION
- Handle "append" by adding **options to SqlWriter 
- Check logger instance for SqliteWriter in rotating logger setup and raise appropriate error.

closes #1318