### PR TITLE
Write 3 ms digits to ascii to resolve CANoe bug

### DIFF
--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -344,7 +344,6 @@ class ASCWriter(FileIOMessageWriter):
             "{bit_timing_conf_ext_data:>8}",
         ]
     )
-    # Use trigger start time to replace file start time
     FORMAT_START_OF_FILE_DATE = "%a %b %d %I:%M:%S.%f %p %Y"
     FORMAT_DATE = "%a %b %d %I:%M:%S.{} %p %Y"
     FORMAT_EVENT = "{timestamp: 9.6f} {message}\n"
@@ -411,10 +410,6 @@ class ASCWriter(FileIOMessageWriter):
             formatted_date = time.strftime(
                 self.FORMAT_DATE.format(mlsec), time.localtime(self.last_timestamp)
             )
-            # changed 2022-08-04, moved file start header here to be one.
-            self.file.write(f"date {formatted_date}\n")
-            self.file.write("base hex  timestamps absolute\n")
-            self.file.write("internal events logged\n")
             self.file.write(f"Begin Triggerblock {formatted_date}\n")
             self.header_written = True
             self.log_event("Start of measurement")  # caution: this is a recursive call!

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -346,6 +346,8 @@ class ASCWriter(FileIOMessageWriter):
     )
     # Use trigger start time to replace file start time
     FORMAT_START_OF_FILE_DATE = "%a %b %d %I:%M:%S.%f %p %Y"
+    FORMAT_DATE = "%a %b %d %I:%M:%S.{} %p %Y"
+    FORMAT_EVENT = "{timestamp: 9.6f} {message}\n"
 
     def __init__(
         self,
@@ -366,9 +368,9 @@ class ASCWriter(FileIOMessageWriter):
         # write start of file header
         now = datetime.now().strftime(self.FORMAT_START_OF_FILE_DATE)
         # Note: CANoe requires that the microsecond field only have 3 digits
-        idx = now.index('.')  # Find the index in the string of the decimal
+        idx = now.index(".")  # Find the index in the string of the decimal
         # Keep decimal and first three ms digits (4), remove remaining digits
-        now = now.replace(now[idx+4:now[idx:].index(' ') + idx], '')
+        now = now.replace(now[idx + 4 : now[idx:].index(" ") + idx], "")
         self.file.write(f"date {now}\n")
         self.file.write("base hex  timestamps absolute\n")
         self.file.write("internal events logged\n")
@@ -406,7 +408,7 @@ class ASCWriter(FileIOMessageWriter):
             # changed 2022-08-04, moved file start header here to be one.
             self.file.write(f"date {formatted_date}\n")
             self.file.write("base hex  timestamps absolute\n")
-            self.file.write("internal events logged\n")            
+            self.file.write("internal events logged\n")
             self.file.write(f"Begin Triggerblock {formatted_date}\n")
             self.header_written = True
             self.log_event("Start of measurement")  # caution: this is a recursive call!

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -344,9 +344,8 @@ class ASCWriter(FileIOMessageWriter):
             "{bit_timing_conf_ext_data:>8}",
         ]
     )
+    # Use trigger start time to replace file start time
     FORMAT_START_OF_FILE_DATE = "%a %b %d %I:%M:%S.%f %p %Y"
-    FORMAT_DATE = "%a %b %d %I:%M:%S.{} %p %Y"
-    FORMAT_EVENT = "{timestamp: 9.6f} {message}\n"
 
     def __init__(
         self,
@@ -366,6 +365,10 @@ class ASCWriter(FileIOMessageWriter):
 
         # write start of file header
         now = datetime.now().strftime(self.FORMAT_START_OF_FILE_DATE)
+        # Note: CANoe requires that the microsecond field only have 3 digits
+        idx = now.index('.')  # Find the index in the string of the decimal
+        # Keep decimal and first three ms digits (4), remove remaining digits
+        now = now.replace(now[idx+4:now[idx:].index(' ') + idx], '')
         self.file.write(f"date {now}\n")
         self.file.write("base hex  timestamps absolute\n")
         self.file.write("internal events logged\n")
@@ -400,6 +403,10 @@ class ASCWriter(FileIOMessageWriter):
             formatted_date = time.strftime(
                 self.FORMAT_DATE.format(mlsec), time.localtime(self.last_timestamp)
             )
+            # changed 2022-08-04, moved file start header here to be one.
+            self.file.write(f"date {formatted_date}\n")
+            self.file.write("base hex  timestamps absolute\n")
+            self.file.write("internal events logged\n")            
             self.file.write(f"Begin Triggerblock {formatted_date}\n")
             self.header_written = True
             self.log_event("Start of measurement")  # caution: this is a recursive call!

--- a/can/logger.py
+++ b/can/logger.py
@@ -235,13 +235,13 @@ def main() -> None:
     print(f"Connected to {bus.__class__.__name__}: {bus.channel_info}")
     print(f"Can Logger (Started on {datetime.now()})")
 
+    options = {"append": results.append}
     if results.file_size:
-        options = {"append": results.append}
         logger = SizedRotatingLogger(
             base_filename=results.log_file, max_bytes=results.file_size, **options
         )
     else:
-        logger = Logger(filename=results.log_file)  # type: ignore
+        logger = Logger(filename=results.log_file, **options)  # type: ignore
 
     try:
         while True:

--- a/can/logger.py
+++ b/can/logger.py
@@ -213,13 +213,13 @@ def main() -> None:
     print(f"Connected to {bus.__class__.__name__}: {bus.channel_info}")
     print(f"Can Logger (Started on {datetime.now()})")
 
-    options = {"append": results.append}
     if results.file_size:
+        options = {"append": results.append}
         logger = SizedRotatingLogger(
             base_filename=results.log_file, max_bytes=results.file_size, **options
         )
     else:
-        logger = Logger(filename=results.log_file, **options)  # type: ignore
+        logger = Logger(filename=results.log_file)  # type: ignore
 
     try:
         while True:


### PR DESCRIPTION
- The ascii writer will now only write 3 micro second decimal places to a log file. 
- The ascii format currently is not setup to append. I recenly added in **options to the logger script. **options are only required for
the rolling logger.

closes #1315
closes #1357

