### PR TITLE
socketcan: Make find_available_interfaces() find slcanX interfaces

### DIFF
--- a/can/interfaces/socketcan/utils.py
+++ b/can/interfaces/socketcan/utils.py
@@ -38,7 +38,7 @@ def pack_filters(can_filters: Optional[typechecking.CanFilters] = None) -> bytes
     return struct.pack(can_filter_fmt, *filter_data)
 
 
-_PATTERN_CAN_INTERFACE = re.compile(r"(sl|v)?can\d+")
+_PATTERN_CAN_INTERFACE = re.compile(r"(sl|v|vx)?can\d+")
 
 
 def find_available_interfaces() -> Iterable[str]:

--- a/can/interfaces/socketcan/utils.py
+++ b/can/interfaces/socketcan/utils.py
@@ -38,7 +38,7 @@ def pack_filters(can_filters: Optional[typechecking.CanFilters] = None) -> bytes
     return struct.pack(can_filter_fmt, *filter_data)
 
 
-_PATTERN_CAN_INTERFACE = re.compile(r"v?can\d+")
+_PATTERN_CAN_INTERFACE = re.compile(r"(sl|v)?can\d+")
 
 
 def find_available_interfaces() -> Iterable[str]:

--- a/doc/interfaces/socketcan.rst
+++ b/doc/interfaces/socketcan.rst
@@ -57,6 +57,28 @@ existing ``can0`` interface with a bitrate of 1MB:
 
     sudo ip link set can0 up type can bitrate 1000000
 
+CAN over Serial / SLCAN
+~~~~~~~~~~~~~~~~~~~~~~~
+
+SLCAN adapters can be used directly via :doc:`/interfaces/slcan`, or
+via :doc:`/interfaces/socketcan` with some help from the ``slcand`` utility
+which can be found in the `can-utils <https://github.com/linux-can/can-utils>` package.
+
+To create a socketcan interface for an SLCAN adapter run the following:
+
+.. code-block:: bash
+
+    slcand -f -o -c -s5 /dev/ttyAMA0
+    ip link set up slcan0
+
+Names of the interfaces created by ``slcand`` match the ``slcan\d+`` regex.
+If a custom name is required, it can be specified as the last argument. E.g.:
+
+.. code-block:: bash
+
+    slcand -f -o -c -s5 /dev/ttyAMA0 can0
+    ip link set up can0
+
 .. _socketcan-pcan:
 
 PCAN

--- a/doc/interfaces/socketcan.rst
+++ b/doc/interfaces/socketcan.rst
@@ -62,7 +62,7 @@ CAN over Serial / SLCAN
 
 SLCAN adapters can be used directly via :doc:`/interfaces/slcan`, or
 via :doc:`/interfaces/socketcan` with some help from the ``slcand`` utility
-which can be found in the `can-utils <https://github.com/linux-can/can-utils>` package.
+which can be found in the `can-utils <https://github.com/linux-can/can-utils>`_ package.
 
 To create a socketcan interface for an SLCAN adapter run the following:
 

--- a/test/open_vcan.sh
+++ b/test/open_vcan.sh
@@ -5,5 +5,7 @@
 modprobe vcan
 ip link add dev vcan0 type vcan
 ip link set up vcan0 mtu 72
+ip link add dev vxcan0 type vcan
+ip link set up vxcan0 mtu 72
 ip link add dev slcan0 type vcan
 ip link set up slcan0 mtu 72

--- a/test/open_vcan.sh
+++ b/test/open_vcan.sh
@@ -5,3 +5,5 @@
 modprobe vcan
 ip link add dev vcan0 type vcan
 ip link set up vcan0 mtu 72
+ip link add dev slcan0 type vcan
+ip link set up slcan0 mtu 72

--- a/test/test_socketcan_helpers.py
+++ b/test/test_socketcan_helpers.py
@@ -31,10 +31,11 @@ class TestSocketCanHelpers(unittest.TestCase):
         result = list(find_available_interfaces())
         self.assertGreaterEqual(len(result), 0)
         for entry in result:
-            self.assertRegex(entry, r"v?can\d+")
+            self.assertRegex(entry, r"(sl|v)?can\d+")
         if TEST_INTERFACE_SOCKETCAN:
-            self.assertGreaterEqual(len(result), 1)
+            self.assertGreaterEqual(len(result), 2)
             self.assertIn("vcan0", result)
+            self.assertIn("slcan0", result)
 
 
 if __name__ == "__main__":

--- a/test/test_socketcan_helpers.py
+++ b/test/test_socketcan_helpers.py
@@ -31,10 +31,11 @@ class TestSocketCanHelpers(unittest.TestCase):
         result = list(find_available_interfaces())
         self.assertGreaterEqual(len(result), 0)
         for entry in result:
-            self.assertRegex(entry, r"(sl|v)?can\d+")
+            self.assertRegex(entry, r"(sl|v|vx)?can\d+")
         if TEST_INTERFACE_SOCKETCAN:
-            self.assertGreaterEqual(len(result), 2)
+            self.assertGreaterEqual(len(result), 3)
             self.assertIn("vcan0", result)
+            self.assertIn("vxcan0", result)
             self.assertIn("slcan0", result)
 
 


### PR DESCRIPTION
Hello,

This change allows `can.detect_available_configs(['socketcan'])` find not just `canX` and `vcanX` interfaces, but also `slcanX` interfaces too. Such names are given by default to interfaces that are created using the `slcand` utility.

The module has an option to work with SLCAN adapters directly, but creating a SocketCAN interface instead can be beneficial too (e.g.: make it possible to use Wireshark, can-utils, cantools and etc.). For this reason I added few lines to the doc about how to use SLCAN adapters with socketcan.

Regards,
Maksim