### PR TITLE
VectorBus: rework init procedure and tests

### DIFF
--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -771,6 +771,10 @@ class VectorBus(BusABC):
         """Generate a sync pulse at the hardware synchronization line
         (hardware party line) with a maximum frequency of 10 Hz. It is only allowed
         to generate a sync pulse at one channel and at one device at the same time.
+
+        :param channel:
+            The channel as an integer value. This corresponds to the ``channel`` argument
+            in :meth:`~can.interfaces.vector.VectorBus.__init__`.
         """
         try:
             channel_mask = self.channel_masks[channel]
@@ -857,7 +861,7 @@ class VectorBus(BusABC):
                     self.channel_masks[channel],
                     bitrate,
                 )
-                LOG.info("SetChannelBitrate: baudr.=%u", bitrate)
+                LOG.info("xlCanSetChannelBitrate: baudr.=%u", bitrate)
             return
 
         # if channel does not have init access, check whether bitrate is correct already
@@ -876,7 +880,7 @@ class VectorBus(BusABC):
         raise VectorInitializationError(
             error_code=xldefine.XL_Status.XL_ERR_INVALID_ACCESS,
             error_string=f"Channel {channel} did not receive init access. Unable to set bitrate.",
-            function="VectorBus.set_bitrate_can",
+            function="VectorBus._set_bitrate_can",
         )
 
     def _set_bitrate_canfd(
@@ -912,18 +916,18 @@ class VectorBus(BusABC):
                 self.port_handle, self.channel_masks[channel], canfd_conf
             )
             LOG.info(
-                "SetFdConfig.: ABaudr.=%u, DBaudr.=%u",
+                "xlCanFdSetConfiguration.: ABaudr.=%u, DBaudr.=%u",
                 canfd_conf.arbitrationBitRate,
                 canfd_conf.dataBitRate,
             )
             LOG.info(
-                "SetFdConfig.: sjwAbr=%u, tseg1Abr=%u, tseg2Abr=%u",
+                "xlCanFdSetConfiguration.: sjwAbr=%u, tseg1Abr=%u, tseg2Abr=%u",
                 canfd_conf.sjwAbr,
                 canfd_conf.tseg1Abr,
                 canfd_conf.tseg2Abr,
             )
             LOG.info(
-                "SetFdConfig.: sjwDbr=%u, tseg1Dbr=%u, tseg2Dbr=%u",
+                "xlCanFdSetConfiguration.: sjwDbr=%u, tseg1Dbr=%u, tseg2Dbr=%u",
                 canfd_conf.sjwDbr,
                 canfd_conf.tseg1Dbr,
                 canfd_conf.tseg2Dbr,
@@ -951,7 +955,7 @@ class VectorBus(BusABC):
         raise VectorInitializationError(
             error_code=xldefine.XL_Status.XL_ERR_INVALID_ACCESS,
             error_string=f"Channel {channel} did not receive init access. Unable to set bitrate.",
-            function="VectorBus.set_bitrate_canfd",
+            function="VectorBus._set_bitrate_canfd",
         )
 
 

--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -831,14 +831,14 @@ class VectorBus(BusABC):
         For each channel an XL_CHIPSTATE event can be received by implementing
         VectorBus.handle_can_event() or VectorBus.handle_canfd_event().
         """
-        xldriver.xlCanRequestChipState(self.port_handle, self.mask)
+        self.xldriver.xlCanRequestChipState(self.port_handle, self.mask)
 
     def generate_sync_pulse(self) -> None:
         """This function generates a sync pulse at the hardware synchronization line
         (hardware party line) with a maximum frequency of 10 Hz. It is only allowed
         to generate a sync pulse at one channel and at one device at the same time.
         """
-        xldriver.xlGenerateSyncPulse(self.port_handle, self.mask)
+        self.xldriver.xlGenerateSyncPulse(self.port_handle, self.mask)
 
 
 class VectorChannelConfig(NamedTuple):

--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -781,7 +781,7 @@ class VectorBus(BusABC):
         self.xldriver.xlGenerateSyncPulse(self.port_handle, self.mask)
 
     def init_access(self, channel: int) -> bool:
-        """Return True if the application has InitAccess on the given channel.
+        """Return True if the application has init access on the given channel.
 
         :param channel:
             The channel as an integer value. This corresponds to the ``channel`` argument
@@ -808,7 +808,7 @@ class VectorBus(BusABC):
         kwargs = [sjw, tseg1, tseg2]
         if any(kwargs) and not all(kwargs):
             raise ValueError(
-                f"Either all of {sjw=}, {tseg1=}, {tseg2=} must be set or None of them."
+                f"Either all of sjw, tseg1, tseg2 must be set or None of them."
             )
 
         # set parameters if channel has init access

--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -802,7 +802,7 @@ class VectorBus(BusABC):
             raise ValueError(
                 f'Channel "{channel}" is not a valid channel. '
                 f"Available channels: {', '.join([str(c) for c in self.channel_masks])}."
-            )
+            ) from None
 
     def _get_channel_config(self, channel: int) -> "VectorChannelConfig":
         channel_mask = self._get_channel_mask(channel)

--- a/can/interfaces/vector/xlclass.py
+++ b/can/interfaces/vector/xlclass.py
@@ -45,6 +45,13 @@ class s_xl_chip_state(ctypes.Structure):
     ]
 
 
+class s_xl_sync_pulse(ctypes.Structure):
+    _fields_ = [
+        ("pulseCode", ctypes.c_ubyte),
+        ("time", XLuint64),
+    ]
+
+
 class s_xl_can_ev_chip_state(ctypes.Structure):
     _fields_ = [
         ("busStatus", ctypes.c_ubyte),
@@ -65,7 +72,11 @@ class s_xl_can_ev_sync_pulse(ctypes.Structure):
 
 # BASIC bus message structure
 class s_xl_tag_data(ctypes.Union):
-    _fields_ = [("msg", s_xl_can_msg), ("chipState", s_xl_chip_state)]
+    _fields_ = [
+        ("msg", s_xl_can_msg),
+        ("chipState", s_xl_chip_state),
+        ("syncPulse", s_xl_sync_pulse),
+    ]
 
 
 # CAN FD messages

--- a/can/interfaces/vector/xldefine.py
+++ b/can/interfaces/vector/xldefine.py
@@ -318,3 +318,9 @@ class XL_HardwareType(IntEnum):
     XL_HWTYPE_VX1161A = 114
     XL_HWTYPE_VX1161B = 115
     XL_MAX_HWTYPE = 120
+
+
+class XL_SyncPulseSource(IntEnum):
+    XL_SYNC_PULSE_EXTERNAL = 0
+    XL_SYNC_PULSE_OUR = 1
+    XL_SYNC_PULSE_OUR_SHARED = 2

--- a/can/interfaces/vector/xldefine.py
+++ b/can/interfaces/vector/xldefine.py
@@ -64,7 +64,7 @@ class XL_BusTypes(IntFlag):
     XL_BUS_TYPE_A429 = 8192  # =0x00002000
 
 
-class XL_CANFD_BusParams_CanOpMode(IntEnum):
+class XL_CANFD_BusParams_CanOpMode(IntFlag):
     XL_BUS_PARAMS_CANOPMODE_CAN20 = 1
     XL_BUS_PARAMS_CANOPMODE_CANFD = 2
     XL_BUS_PARAMS_CANOPMODE_CANFD_NO_ISO = 8

--- a/can/interfaces/vector/xldriver.py
+++ b/can/interfaces/vector/xldriver.py
@@ -272,3 +272,18 @@ xlGetEventString.restype = xlclass.XLstringType
 xlCanGetEventString = _xlapi_dll.xlCanGetEventString
 xlCanGetEventString.argtypes = [ctypes.POINTER(xlclass.XLcanRxEvent)]
 xlCanGetEventString.restype = xlclass.XLstringType
+
+xlGetReceiveQueueLevel = _xlapi_dll.xlGetReceiveQueueLevel
+xlGetReceiveQueueLevel.argtypes = [xlclass.XLportHandle, ctypes.POINTER(ctypes.c_int)]
+xlGetReceiveQueueLevel.restype = xlclass.XLstatus
+xlGetReceiveQueueLevel.errcheck = check_status_operation
+
+xlGenerateSyncPulse = _xlapi_dll.xlGenerateSyncPulse
+xlGenerateSyncPulse.argtypes = [xlclass.XLportHandle, xlclass.XLaccess]
+xlGenerateSyncPulse.restype = xlclass.XLstatus
+xlGenerateSyncPulse.errcheck = check_status_operation
+
+xlFlushReceiveQueue = _xlapi_dll.xlFlushReceiveQueue
+xlFlushReceiveQueue.argtypes = [xlclass.XLportHandle]
+xlFlushReceiveQueue.restype = xlclass.XLstatus
+xlFlushReceiveQueue.errcheck = check_status_operation

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -3,11 +3,14 @@
 """
 Test for Vector Interface
 """
-
+import contextlib
 import ctypes
 import os
 import pickle
+import random
+import time
 import unittest
+from typing import List
 from unittest.mock import Mock
 
 import pytest
@@ -24,244 +27,508 @@ from can.interfaces.vector import (
 )
 from test.config import IS_WINDOWS
 
+MOCK = True
+try:
+    from can.interfaces.vector import xldriver
+
+    # test real driver if available
+    MOCK = False
+except Exception:
+    pass
+
 
 class TestVectorBus(unittest.TestCase):
     def setUp(self) -> None:
-        # basic mock for XLDriver
-        can.interfaces.vector.canlib.xldriver = Mock()
 
-        # bus creation functions
-        can.interfaces.vector.canlib.xldriver.xlOpenDriver = Mock()
-        can.interfaces.vector.canlib.xldriver.xlGetApplConfig = Mock(
-            side_effect=xlGetApplConfig
-        )
-        can.interfaces.vector.canlib.xldriver.xlGetChannelIndex = Mock(
-            side_effect=xlGetChannelIndex
-        )
-        can.interfaces.vector.canlib.xldriver.xlOpenPort = Mock(side_effect=xlOpenPort)
-        can.interfaces.vector.canlib.xldriver.xlCanFdSetConfiguration = Mock(
-            return_value=0
-        )
-        can.interfaces.vector.canlib.xldriver.xlCanSetChannelMode = Mock(return_value=0)
-        can.interfaces.vector.canlib.xldriver.xlActivateChannel = Mock(return_value=0)
-        can.interfaces.vector.canlib.xldriver.xlGetSyncTime = Mock(
-            side_effect=xlGetSyncTime
-        )
-        can.interfaces.vector.canlib.xldriver.xlCanSetChannelAcceptance = Mock(
-            return_value=0
-        )
-        can.interfaces.vector.canlib.xldriver.xlCanSetChannelBitrate = Mock(
-            return_value=0
-        )
-        can.interfaces.vector.canlib.xldriver.xlSetNotification = Mock(
-            side_effect=xlSetNotification
-        )
+        if MOCK:
+            # mock channel configuration
+            canlib.get_channel_configs = Mock(
+                side_effect=get_channel_configs,
+            )
 
-        # bus deactivation functions
-        can.interfaces.vector.canlib.xldriver.xlDeactivateChannel = Mock(return_value=0)
-        can.interfaces.vector.canlib.xldriver.xlClosePort = Mock(return_value=0)
-        can.interfaces.vector.canlib.xldriver.xlCloseDriver = Mock()
+            # basic mock for XLDriver
+            can.interfaces.vector.canlib.xldriver = Mock()
 
-        # sender functions
-        can.interfaces.vector.canlib.xldriver.xlCanTransmit = Mock(return_value=0)
-        can.interfaces.vector.canlib.xldriver.xlCanTransmitEx = Mock(return_value=0)
+            # bus creation functions
+            can.interfaces.vector.canlib.xldriver.xlOpenDriver = Mock()
+            can.interfaces.vector.canlib.xldriver.xlGetApplConfig = Mock(
+                side_effect=xlGetApplConfig
+            )
+            can.interfaces.vector.canlib.xldriver.xlGetChannelIndex = Mock(
+                side_effect=xlGetChannelIndex
+            )
+            can.interfaces.vector.canlib.xldriver.xlOpenPort = Mock(
+                side_effect=xlOpenPort
+            )
+            can.interfaces.vector.canlib.xldriver.xlCanFdSetConfiguration = Mock(
+                return_value=0
+            )
+            can.interfaces.vector.canlib.xldriver.xlCanSetChannelMode = Mock(
+                return_value=0
+            )
+            can.interfaces.vector.canlib.xldriver.xlActivateChannel = Mock(
+                return_value=0
+            )
+            can.interfaces.vector.canlib.xldriver.xlGetSyncTime = Mock(
+                side_effect=xlGetSyncTime
+            )
+            can.interfaces.vector.canlib.xldriver.xlCanSetChannelAcceptance = Mock(
+                return_value=0
+            )
+            can.interfaces.vector.canlib.xldriver.xlCanSetChannelBitrate = Mock(
+                return_value=0
+            )
+            can.interfaces.vector.canlib.xldriver.xlSetNotification = Mock(
+                side_effect=xlSetNotification
+            )
 
-        # various functions
-        can.interfaces.vector.canlib.xldriver.xlCanFlushTransmitQueue = Mock()
-        can.interfaces.vector.canlib.xldriver.xlSetTimerRate = Mock()
-        can.interfaces.vector.canlib.xldriver.xlGenerateSyncPulse = Mock()
-        can.interfaces.vector.canlib.xldriver.xlFlushReceiveQueue = Mock()
-        can.interfaces.vector.canlib.WaitForSingleObject = Mock()
+            # bus deactivation functions
+            can.interfaces.vector.canlib.xldriver.xlDeactivateChannel = Mock(
+                return_value=0
+            )
+            can.interfaces.vector.canlib.xldriver.xlClosePort = Mock(return_value=0)
+            can.interfaces.vector.canlib.xldriver.xlCloseDriver = Mock()
+
+            # sender functions
+            can.interfaces.vector.canlib.xldriver.xlCanTransmit = Mock(return_value=0)
+            can.interfaces.vector.canlib.xldriver.xlCanTransmitEx = Mock(return_value=0)
+
+            # various functions
+            can.interfaces.vector.canlib.xldriver.xlCanFlushTransmitQueue = Mock()
+            can.interfaces.vector.canlib.xldriver.xlSetTimerRate = Mock()
+            can.interfaces.vector.canlib.xldriver.xlGenerateSyncPulse = Mock()
+            can.interfaces.vector.canlib.xldriver.xlFlushReceiveQueue = Mock()
+            can.interfaces.vector.canlib.WaitForSingleObject = Mock()
 
         self.bus = None
 
     def tearDown(self) -> None:
         if self.bus:
-            self.bus.shutdown()
+            with contextlib.suppress(canlib.VectorOperationError):
+                self.bus.shutdown()
             self.bus = None
 
     def test_bus_creation(self) -> None:
-        self.bus = can.Bus(channel=0, bustype="vector", _testing=True)
-        self.assertIsInstance(self.bus, canlib.VectorBus)
-        can.interfaces.vector.canlib.xldriver.xlOpenDriver.assert_called()
-        can.interfaces.vector.canlib.xldriver.xlGetApplConfig.assert_called()
+        if MOCK:
+            self.bus = can.Bus(
+                app_name="test_bus_creation",
+                bustype="vector",
+                channel=0,
+                _testing=True,
+            )
+            self.assertIsInstance(self.bus, canlib.VectorBus)
 
-        can.interfaces.vector.canlib.xldriver.xlOpenPort.assert_called()
-        xlOpenPort_args = can.interfaces.vector.canlib.xldriver.xlOpenPort.call_args[0]
-        self.assertEqual(
-            xlOpenPort_args[5], xldefine.XL_InterfaceVersion.XL_INTERFACE_VERSION.value
-        )
-        self.assertEqual(xlOpenPort_args[6], xldefine.XL_BusTypes.XL_BUS_TYPE_CAN.value)
+            can.interfaces.vector.canlib.xldriver.xlOpenDriver.assert_called()
+            can.interfaces.vector.canlib.xldriver.xlGetApplConfig.assert_called()
 
-        can.interfaces.vector.canlib.xldriver.xlCanFdSetConfiguration.assert_not_called()
-        can.interfaces.vector.canlib.xldriver.xlCanSetChannelBitrate.assert_not_called()
+            can.interfaces.vector.canlib.xldriver.xlOpenPort.assert_called()
+            xlOpenPort_args = (
+                can.interfaces.vector.canlib.xldriver.xlOpenPort.call_args[0]
+            )
+            self.assertEqual(
+                xlOpenPort_args[5],
+                xldefine.XL_InterfaceVersion.XL_INTERFACE_VERSION.value,
+            )
+            self.assertEqual(
+                xlOpenPort_args[6], xldefine.XL_BusTypes.XL_BUS_TYPE_CAN.value
+            )
+
+            can.interfaces.vector.canlib.xldriver.xlCanFdSetConfiguration.assert_not_called()
+            can.interfaces.vector.canlib.xldriver.xlCanSetChannelBitrate.assert_not_called()
+        else:
+            self.bus = can.Bus(
+                app_name="test_bus_creation",
+                bustype="vector",
+                channel=0,
+                serial=100,
+                _testing=True,
+            )
+            self.assertIsInstance(self.bus, canlib.VectorBus)
+
+            vcc = _find_channel_configuration(100, 0)
+            assert vcc.busParams.bus_type is xldefine.XL_BusTypes.XL_BUS_TYPE_CAN
+            assert (
+                vcc.busParams.can_params["can_op_mode"]
+                is xldefine.XL_CANFD_BusParams_CanOpMode.XL_BUS_PARAMS_CANOPMODE_CAN20
+            )
+            assert vcc.isOnBus
 
     def test_bus_creation_bitrate(self) -> None:
-        self.bus = can.Bus(channel=0, bustype="vector", bitrate=200000, _testing=True)
-        self.assertIsInstance(self.bus, canlib.VectorBus)
-        can.interfaces.vector.canlib.xldriver.xlOpenDriver.assert_called()
-        can.interfaces.vector.canlib.xldriver.xlGetApplConfig.assert_called()
-
-        can.interfaces.vector.canlib.xldriver.xlOpenPort.assert_called()
-        xlOpenPort_args = can.interfaces.vector.canlib.xldriver.xlOpenPort.call_args[0]
-        self.assertEqual(
-            xlOpenPort_args[5], xldefine.XL_InterfaceVersion.XL_INTERFACE_VERSION.value
-        )
-        self.assertEqual(xlOpenPort_args[6], xldefine.XL_BusTypes.XL_BUS_TYPE_CAN.value)
-
-        can.interfaces.vector.canlib.xldriver.xlCanFdSetConfiguration.assert_not_called()
-        can.interfaces.vector.canlib.xldriver.xlCanSetChannelBitrate.assert_called()
-        xlCanSetChannelBitrate_args = (
-            can.interfaces.vector.canlib.xldriver.xlCanSetChannelBitrate.call_args[0]
-        )
-        self.assertEqual(xlCanSetChannelBitrate_args[2], 200000)
-
-    def test_bus_creation_fd(self) -> None:
-        self.bus = can.Bus(channel=0, bustype="vector", fd=True, _testing=True)
-        self.assertIsInstance(self.bus, canlib.VectorBus)
-        can.interfaces.vector.canlib.xldriver.xlOpenDriver.assert_called()
-        can.interfaces.vector.canlib.xldriver.xlGetApplConfig.assert_called()
-
-        can.interfaces.vector.canlib.xldriver.xlOpenPort.assert_called()
-        xlOpenPort_args = can.interfaces.vector.canlib.xldriver.xlOpenPort.call_args[0]
-        self.assertEqual(
-            xlOpenPort_args[5],
-            xldefine.XL_InterfaceVersion.XL_INTERFACE_VERSION_V4.value,
-        )
-        self.assertEqual(xlOpenPort_args[6], xldefine.XL_BusTypes.XL_BUS_TYPE_CAN.value)
-
-        can.interfaces.vector.canlib.xldriver.xlCanFdSetConfiguration.assert_called()
-        can.interfaces.vector.canlib.xldriver.xlCanSetChannelBitrate.assert_not_called()
-
-    def test_bus_creation_fd_bitrate_timings(self) -> None:
         self.bus = can.Bus(
-            channel=0,
+            app_name="test_bus_creation_bitrate",
             bustype="vector",
-            fd=True,
-            bitrate=500000,
-            data_bitrate=2000000,
-            sjw_abr=10,
-            tseg1_abr=11,
-            tseg2_abr=12,
-            sjw_dbr=13,
-            tseg1_dbr=14,
-            tseg2_dbr=15,
+            channel=0,
+            serial=100,
+            bitrate=200_000,
             _testing=True,
         )
         self.assertIsInstance(self.bus, canlib.VectorBus)
-        can.interfaces.vector.canlib.xldriver.xlOpenDriver.assert_called()
-        can.interfaces.vector.canlib.xldriver.xlGetApplConfig.assert_called()
 
-        can.interfaces.vector.canlib.xldriver.xlOpenPort.assert_called()
-        xlOpenPort_args = can.interfaces.vector.canlib.xldriver.xlOpenPort.call_args[0]
-        self.assertEqual(
-            xlOpenPort_args[5],
-            xldefine.XL_InterfaceVersion.XL_INTERFACE_VERSION_V4.value,
+        if MOCK:
+            can.interfaces.vector.canlib.xldriver.xlOpenDriver.assert_called()
+            can.interfaces.vector.canlib.xldriver.xlOpenPort.assert_called()
+            xlOpenPort_args = (
+                can.interfaces.vector.canlib.xldriver.xlOpenPort.call_args[0]
+            )
+            self.assertEqual(
+                xlOpenPort_args[5],
+                xldefine.XL_InterfaceVersion.XL_INTERFACE_VERSION.value,
+            )
+            self.assertEqual(
+                xlOpenPort_args[6], xldefine.XL_BusTypes.XL_BUS_TYPE_CAN.value
+            )
+
+            can.interfaces.vector.canlib.xldriver.xlCanFdSetConfiguration.assert_not_called()
+            can.interfaces.vector.canlib.xldriver.xlCanSetChannelBitrate.assert_called()
+            xlCanSetChannelBitrate_args = (
+                can.interfaces.vector.canlib.xldriver.xlCanSetChannelBitrate.call_args[
+                    0
+                ]
+            )
+            self.assertEqual(xlCanSetChannelBitrate_args[2], 200_000)
+        else:
+            vcc = _find_channel_configuration(100, 0)
+            assert vcc.busParams.bus_type is xldefine.XL_BusTypes.XL_BUS_TYPE_CAN
+            assert (
+                vcc.busParams.can_params["can_op_mode"]
+                in xldefine.XL_CANFD_BusParams_CanOpMode.XL_BUS_PARAMS_CANOPMODE_CAN20
+            )
+            assert vcc.busParams.can_params["bitrate"] == 200_000
+            assert vcc.isOnBus
+
+    def test_bus_creation_fd(self) -> None:
+        self.bus = can.Bus(
+            app_name="test_bus_creation_fd",
+            channel=0,
+            serial=100,
+            bitrate=500_000,
+            data_bitrate=1_000_000,
+            fd=True,
+            bustype="vector",
+            _testing=True,
         )
-        self.assertEqual(xlOpenPort_args[6], xldefine.XL_BusTypes.XL_BUS_TYPE_CAN.value)
+        self.assertIsInstance(self.bus, canlib.VectorBus)
 
-        can.interfaces.vector.canlib.xldriver.xlCanFdSetConfiguration.assert_called()
-        can.interfaces.vector.canlib.xldriver.xlCanSetChannelBitrate.assert_not_called()
+        if MOCK:
+            can.interfaces.vector.canlib.xldriver.xlOpenDriver.assert_called()
+            can.interfaces.vector.canlib.xldriver.xlOpenPort.assert_called()
+            xlOpenPort_args = (
+                can.interfaces.vector.canlib.xldriver.xlOpenPort.call_args[0]
+            )
+            self.assertEqual(
+                xlOpenPort_args[5],
+                xldefine.XL_InterfaceVersion.XL_INTERFACE_VERSION_V4.value,
+            )
+            self.assertEqual(
+                xlOpenPort_args[6], xldefine.XL_BusTypes.XL_BUS_TYPE_CAN.value
+            )
 
-        xlCanFdSetConfiguration_args = (
-            can.interfaces.vector.canlib.xldriver.xlCanFdSetConfiguration.call_args[0]
+            can.interfaces.vector.canlib.xldriver.xlCanFdSetConfiguration.assert_called()
+            can.interfaces.vector.canlib.xldriver.xlCanSetChannelBitrate.assert_not_called()
+        else:
+            vcc = _find_channel_configuration(100, 0)
+            assert vcc.busParams.bus_type is xldefine.XL_BusTypes.XL_BUS_TYPE_CAN
+            assert (
+                xldefine.XL_CANFD_BusParams_CanOpMode.XL_BUS_PARAMS_CANOPMODE_CANFD
+                in vcc.busParams.canfd_params["can_op_mode"]
+            )
+            assert vcc.busParams.canfd_params["bitrate"] == 500_000
+            assert vcc.busParams.canfd_params["data_bitrate"] == 1_000_000
+            assert vcc.isOnBus
+
+    def test_bus_creation_fd_bitrate_timings(self) -> None:
+        self.bus = can.Bus(
+            app_name="test_bus_creation_fd_bitrate_timings",
+            serial=100,
+            channel=0,
+            bustype="vector",
+            fd=True,
+            bitrate=500_000,
+            data_bitrate=5_000_000,
+            sjw_abr=32,
+            tseg1_abr=127,
+            tseg2_abr=32,
+            sjw_dbr=6,
+            tseg1_dbr=9,
+            tseg2_dbr=6,
+            _testing=True,
         )
-        canFdConf = xlCanFdSetConfiguration_args[2]
-        self.assertEqual(canFdConf.arbitrationBitRate, 500000)
-        self.assertEqual(canFdConf.dataBitRate, 2000000)
-        self.assertEqual(canFdConf.sjwAbr, 10)
-        self.assertEqual(canFdConf.tseg1Abr, 11)
-        self.assertEqual(canFdConf.tseg2Abr, 12)
-        self.assertEqual(canFdConf.sjwDbr, 13)
-        self.assertEqual(canFdConf.tseg1Dbr, 14)
-        self.assertEqual(canFdConf.tseg2Dbr, 15)
+        self.assertIsInstance(self.bus, canlib.VectorBus)
+
+        if MOCK:
+            can.interfaces.vector.canlib.xldriver.xlOpenDriver.assert_called()
+            can.interfaces.vector.canlib.xldriver.xlOpenPort.assert_called()
+            xlOpenPort_args = (
+                can.interfaces.vector.canlib.xldriver.xlOpenPort.call_args[0]
+            )
+            self.assertEqual(
+                xlOpenPort_args[5],
+                xldefine.XL_InterfaceVersion.XL_INTERFACE_VERSION_V4.value,
+            )
+            self.assertEqual(
+                xlOpenPort_args[6], xldefine.XL_BusTypes.XL_BUS_TYPE_CAN.value
+            )
+
+            can.interfaces.vector.canlib.xldriver.xlCanFdSetConfiguration.assert_called()
+            can.interfaces.vector.canlib.xldriver.xlCanSetChannelBitrate.assert_not_called()
+
+            xlCanFdSetConfiguration_args = (
+                can.interfaces.vector.canlib.xldriver.xlCanFdSetConfiguration.call_args[
+                    0
+                ]
+            )
+            canFdConf = xlCanFdSetConfiguration_args[2]
+            self.assertEqual(canFdConf.arbitrationBitRate, 500_000)
+            self.assertEqual(canFdConf.dataBitRate, 5_000_000)
+            self.assertEqual(canFdConf.sjwAbr, 32)
+            self.assertEqual(canFdConf.tseg1Abr, 127)
+            self.assertEqual(canFdConf.tseg2Abr, 32)
+            self.assertEqual(canFdConf.sjwDbr, 6)
+            self.assertEqual(canFdConf.tseg1Dbr, 9)
+            self.assertEqual(canFdConf.tseg2Dbr, 6)
+        else:
+            vcc = _find_channel_configuration(100, 0)
+            assert vcc.busParams.bus_type is xldefine.XL_BusTypes.XL_BUS_TYPE_CAN
+            assert (
+                xldefine.XL_CANFD_BusParams_CanOpMode.XL_BUS_PARAMS_CANOPMODE_CANFD
+                in vcc.busParams.canfd_params["can_op_mode"]
+            )
+            assert vcc.busParams.canfd_params["bitrate"] == 500_000
+            assert vcc.busParams.canfd_params["data_bitrate"] == 5_000_000
+            assert vcc.busParams.canfd_params["sjw_abr"] == 32
+            assert vcc.busParams.canfd_params["tseg1_abr"] == 127
+            assert vcc.busParams.canfd_params["tseg2_abr"] == 32
+            assert vcc.busParams.canfd_params["sjw_dbr"] == 6
+            assert vcc.busParams.canfd_params["tseg1_dbr"] == 9
+            assert vcc.busParams.canfd_params["tseg2_dbr"] == 6
+
+            assert vcc.isOnBus
 
     def test_receive(self) -> None:
-        can.interfaces.vector.canlib.xldriver.xlReceive = Mock(side_effect=xlReceive)
-        self.bus = can.Bus(channel=0, bustype="vector", _testing=True)
-        self.bus.recv(timeout=0.05)
-        can.interfaces.vector.canlib.xldriver.xlReceive.assert_called()
-        can.interfaces.vector.canlib.xldriver.xlCanReceive.assert_not_called()
+        self.bus = can.Bus(
+            app_name="test_receive",
+            serial=100,
+            channel=0,
+            bustype="vector",
+            _testing=True,
+            receive_own_messages=True,
+        )
+        if MOCK:
+            can.interfaces.vector.canlib.xldriver.xlReceive = Mock(
+                side_effect=xlReceive
+            )
+            self.bus.recv(timeout=0.05)
+            can.interfaces.vector.canlib.xldriver.xlReceive.assert_called()
+            can.interfaces.vector.canlib.xldriver.xlCanReceive.assert_not_called()
+        else:
+            tx_msg = can.Message(
+                channel=0,
+                arbitration_id=100,
+                is_extended_id=False,
+                data=random.randbytes(8),
+                is_rx=False,
+                dlc=8,
+            )
+            self.bus.send(tx_msg)
+            rx_msg = self.bus.recv()
+            assert tx_msg.equals(rx_msg, timestamp_delta=None)
 
     def test_receive_fd(self) -> None:
-        can.interfaces.vector.canlib.xldriver.xlCanReceive = Mock(
-            side_effect=xlCanReceive
+        while _find_channel_configuration(100, 0).isOnBus:
+            time.sleep(0.1)
+            print("wait for bus")
+        self.bus = canlib.VectorBus(
+            app_name="test_receive_fd",
+            channel=0,
+            serial=100,
+            fd=True,
+            bitrate=500_000,
+            data_bitrate=5_000_000,
+            sjw_abr=32,
+            tseg1_abr=127,
+            tseg2_abr=32,
+            sjw_dbr=6,
+            tseg1_dbr=9,
+            tseg2_dbr=6,
+            receive_own_messages=True,
+            _testing=True,
         )
-        self.bus = can.Bus(channel=0, bustype="vector", fd=True, _testing=True)
-        self.bus.recv(timeout=0.05)
-        can.interfaces.vector.canlib.xldriver.xlReceive.assert_not_called()
-        can.interfaces.vector.canlib.xldriver.xlCanReceive.assert_called()
+
+        if MOCK:
+            can.interfaces.vector.canlib.xldriver.xlCanReceive = Mock(
+                side_effect=xlCanReceive
+            )
+            self.bus.recv(timeout=0.05)
+            can.interfaces.vector.canlib.xldriver.xlReceive.assert_not_called()
+            can.interfaces.vector.canlib.xldriver.xlCanReceive.assert_called()
+        else:
+            tx_msg = can.Message(
+                channel=0,
+                arbitration_id=100,
+                is_extended_id=False,
+                is_fd=True,
+                data=random.randbytes(32),
+                is_rx=False,
+                bitrate_switch=True,
+            )
+            self.bus.send(tx_msg)
+            rx_msg = self.bus.recv(1.0)
+            assert tx_msg.equals(rx_msg, timestamp_delta=None)
 
     def test_receive_non_msg_event(self) -> None:
-        can.interfaces.vector.canlib.xldriver.xlReceive = Mock(
-            side_effect=xlReceive_chipstate
+        self.bus = canlib.VectorBus(
+            app_name="test_receive_non_msg_event",
+            serial=100,
+            channel=0,
+            _testing=True,
         )
-        self.bus = can.Bus(channel=0, bustype="vector", _testing=True)
         self.bus.handle_can_event = Mock()
-        self.bus.recv(timeout=0.05)
-        can.interfaces.vector.canlib.xldriver.xlReceive.assert_called()
-        can.interfaces.vector.canlib.xldriver.xlCanReceive.assert_not_called()
-        self.bus.handle_can_event.assert_called()
+
+        if MOCK:
+            can.interfaces.vector.canlib.xldriver.xlReceive = Mock(
+                side_effect=xlReceive_chipstate
+            )
+
+            self.bus.recv(timeout=0.05)
+            can.interfaces.vector.canlib.xldriver.xlReceive.assert_called()
+            can.interfaces.vector.canlib.xldriver.xlCanReceive.assert_not_called()
+            self.bus.handle_can_event.assert_called()
+        else:
+            # request and receive chipstate
+            self.bus.request_chip_state()
+            while self.bus.recv(-1.0):
+                pass
+            self.bus.handle_can_event.assert_called()
 
     def test_receive_fd_non_msg_event(self) -> None:
-        can.interfaces.vector.canlib.xldriver.xlCanReceive = Mock(
-            side_effect=xlCanReceive_chipstate
+        self.bus = canlib.VectorBus(
+            app_name="test_receive_fd_non_msg_event",
+            serial=100,
+            channel=0,
+            fd=True,
+            _testing=True,
         )
-        self.bus = can.Bus(channel=0, bustype="vector", fd=True, _testing=True)
         self.bus.handle_canfd_event = Mock()
-        self.bus.recv(timeout=0.05)
-        can.interfaces.vector.canlib.xldriver.xlReceive.assert_not_called()
-        can.interfaces.vector.canlib.xldriver.xlCanReceive.assert_called()
-        self.bus.handle_canfd_event.assert_called()
+
+        if MOCK:
+            can.interfaces.vector.canlib.xldriver.xlCanReceive = Mock(
+                side_effect=xlCanReceive_chipstate
+            )
+            self.bus.handle_canfd_event = Mock()
+            self.bus.recv(timeout=0.05)
+            self.bus.handle_canfd_event.assert_called()
+            can.interfaces.vector.canlib.xldriver.xlReceive.assert_not_called()
+            can.interfaces.vector.canlib.xldriver.xlCanReceive.assert_called()
+        else:
+            self.bus.request_chip_state()
+            while self.bus.recv(-1):
+                pass
+            self.bus.handle_canfd_event.assert_called()
 
     def test_send(self) -> None:
-        self.bus = can.Bus(channel=0, bustype="vector", _testing=True)
+        self.bus = can.Bus(
+            app_name="test_send", serial=100, channel=0, bustype="vector", _testing=True
+        )
         msg = can.Message(
             arbitration_id=0xC0FFEF, data=[1, 2, 3, 4, 5, 6, 7, 8], is_extended_id=True
         )
         self.bus.send(msg)
-        can.interfaces.vector.canlib.xldriver.xlCanTransmit.assert_called()
-        can.interfaces.vector.canlib.xldriver.xlCanTransmitEx.assert_not_called()
+
+        if MOCK:
+            can.interfaces.vector.canlib.xldriver.xlCanTransmit.assert_called()
+            can.interfaces.vector.canlib.xldriver.xlCanTransmitEx.assert_not_called()
 
     def test_send_fd(self) -> None:
-        self.bus = can.Bus(channel=0, bustype="vector", fd=True, _testing=True)
+        self.bus = can.Bus(
+            app_name="test_send_fd",
+            serial=100,
+            channel=0,
+            fd=True,
+            bitrate=500_000,
+            data_bitrate=5_000_000,
+            sjw_abr=32,
+            tseg1_abr=127,
+            tseg2_abr=32,
+            sjw_dbr=6,
+            tseg1_dbr=9,
+            tseg2_dbr=6,
+            bustype="vector",
+            _testing=True,
+        )
         msg = can.Message(
             arbitration_id=0xC0FFEF, data=[1, 2, 3, 4, 5, 6, 7, 8], is_extended_id=True
         )
         self.bus.send(msg)
-        can.interfaces.vector.canlib.xldriver.xlCanTransmit.assert_not_called()
-        can.interfaces.vector.canlib.xldriver.xlCanTransmitEx.assert_called()
+
+        if MOCK:
+            can.interfaces.vector.canlib.xldriver.xlCanTransmit.assert_not_called()
+            can.interfaces.vector.canlib.xldriver.xlCanTransmitEx.assert_called()
 
     def test_flush_tx_buffer(self) -> None:
-        self.bus = can.Bus(channel=0, bustype="vector", _testing=True)
+        self.bus = can.Bus(
+            app_name="test_flush_tx_buffer",
+            serial=100,
+            channel=0,
+            bustype="vector",
+            _testing=True,
+        )
         self.bus.flush_tx_buffer()
-        can.interfaces.vector.canlib.xldriver.xlCanFlushTransmitQueue.assert_called()
+
+        if MOCK:
+            can.interfaces.vector.canlib.xldriver.xlCanFlushTransmitQueue.assert_called()
 
     def test_shutdown(self) -> None:
-        self.bus = can.Bus(channel=0, bustype="vector", _testing=True)
+        self.bus = can.Bus(
+            app_name="test_shutdown",
+            serial=100,
+            channel=0,
+            bustype="vector",
+            _testing=True,
+        )
         self.bus.shutdown()
-        can.interfaces.vector.canlib.xldriver.xlDeactivateChannel.assert_called()
-        can.interfaces.vector.canlib.xldriver.xlClosePort.assert_called()
-        can.interfaces.vector.canlib.xldriver.xlCloseDriver.assert_called()
+
+        if MOCK:
+            can.interfaces.vector.canlib.xldriver.xlDeactivateChannel.assert_called()
+            can.interfaces.vector.canlib.xldriver.xlClosePort.assert_called()
+            can.interfaces.vector.canlib.xldriver.xlCloseDriver.assert_called()
 
     def test_reset(self) -> None:
-        self.bus = can.Bus(channel=0, bustype="vector", _testing=True)
+        self.bus = can.Bus(
+            app_name="test_reset",
+            serial=100,
+            channel=0,
+            bustype="vector",
+            _testing=True,
+        )
         self.bus.reset()
-        can.interfaces.vector.canlib.xldriver.xlDeactivateChannel.assert_called()
-        can.interfaces.vector.canlib.xldriver.xlActivateChannel.assert_called()
+
+        if MOCK:
+            can.interfaces.vector.canlib.xldriver.xlDeactivateChannel.assert_called()
+            can.interfaces.vector.canlib.xldriver.xlActivateChannel.assert_called()
 
     def test_popup_hw_cfg(self) -> None:
-        canlib.xldriver.xlPopupHwConfig = Mock()
-        canlib.VectorBus.popup_vector_hw_configuration(10)
-        assert canlib.xldriver.xlPopupHwConfig.called
-        args, kwargs = canlib.xldriver.xlPopupHwConfig.call_args
-        assert isinstance(args[0], ctypes.c_char_p)
-        assert isinstance(args[1], ctypes.c_uint)
+        if MOCK:
+            canlib.xldriver.xlPopupHwConfig = Mock()
+            canlib.VectorBus.popup_vector_hw_configuration(10)
+            assert canlib.xldriver.xlPopupHwConfig.called
+            args, kwargs = canlib.xldriver.xlPopupHwConfig.call_args
+            assert isinstance(args[0], ctypes.c_char_p)
+            assert isinstance(args[1], ctypes.c_uint)
+        else:
+            canlib.VectorBus.popup_vector_hw_configuration(0)
 
     def test_get_application_config(self) -> None:
-        canlib.xldriver.xlGetApplConfig = Mock()
-        canlib.VectorBus.get_application_config(app_name="CANalyzer", app_channel=0)
-        assert canlib.xldriver.xlGetApplConfig.called
+        if MOCK:
+            canlib.xldriver.xlGetApplConfig = Mock()
+            canlib.VectorBus.get_application_config(app_name="CANalyzer", app_channel=0)
+            assert canlib.xldriver.xlGetApplConfig.called
+        else:
+            hw_type, hw_index, hw_channel = canlib.VectorBus.get_application_config(
+                app_name="CANalyzer", app_channel=0
+            )
+            assert isinstance(hw_type, xldefine.XL_HardwareType)
+            assert isinstance(hw_index, int)
+            assert isinstance(hw_index, int)
 
     def test_set_application_config(self) -> None:
         canlib.xldriver.xlSetApplConfig = Mock()
@@ -276,38 +543,66 @@ class TestVectorBus(unittest.TestCase):
 
     def test_set_timer_rate(self) -> None:
         bus: canlib.VectorBus = can.Bus(
-            channel=0, bustype="vector", fd=True, _testing=True
+            app_name="test_set_timer_rate",
+            serial=100,
+            channel=0,
+            bustype="vector",
+            _testing=True,
         )
         bus.set_timer_rate(timer_rate_ms=1)
-        assert canlib.xldriver.xlSetTimerRate.called
+
+        if MOCK:
+            assert canlib.xldriver.xlSetTimerRate.called
 
     def test_flush_rx_buffer(self) -> None:
-        bus: canlib.VectorBus = can.Bus(
-            channel=0, bustype="vector", fd=True, _testing=True
+        self.bus: canlib.VectorBus = can.Bus(
+            app_name="test_flush_rx_buffer",
+            serial=100,
+            channel=0,
+            bustype="vector",
+            _testing=True,
         )
-        bus.flush_rx_buffer()
-        assert canlib.xldriver.xlFlushReceiveQueue.called
+        self.bus.flush_rx_buffer()
+
+        if MOCK:
+            assert canlib.xldriver.xlFlushReceiveQueue.called
 
     def test_request_chip_state(self) -> None:
-        bus: canlib.VectorBus = can.Bus(
-            channel=0, bustype="vector", fd=True, _testing=True
+        self.bus: canlib.VectorBus = can.Bus(
+            app_name="test_request_chip_state",
+            serial=100,
+            channel=0,
+            bustype="vector",
+            _testing=True,
         )
-        bus.request_chip_state()
-        assert canlib.xldriver.xlCanRequestChipState.called
+        self.bus.request_chip_state()
+
+        if MOCK:
+            assert canlib.xldriver.xlCanRequestChipState.called
 
     def test_generate_sync_pulse(self) -> None:
-        bus: canlib.VectorBus = can.Bus(
-            channel=0, bustype="vector", fd=True, _testing=True
+        self.bus: canlib.VectorBus = can.Bus(
+            app_name="test_generate_sync_pulse",
+            serial=100,
+            channel=0,
+            bustype="vector",
+            _testing=True,
         )
-        bus.generate_sync_pulse()
-        assert canlib.xldriver.xlGenerateSyncPulse.called
+        self.bus.generate_sync_pulse()
+
+        if MOCK:
+            assert canlib.xldriver.xlGenerateSyncPulse.called
 
     def test_called_without_testing_argument(self) -> None:
         """This tests if an exception is thrown when we are not running on Windows."""
         if os.name != "nt":
             with self.assertRaises(can.CanInterfaceNotImplementedError):
                 # do not set the _testing argument, since it would suppress the exception
-                can.Bus(channel=0, bustype="vector")
+                can.Bus(
+                    app_name="test_called_without_testing_argument",
+                    channel=0,
+                    bustype="vector",
+                )
 
     def test_vector_error_pickle(self) -> None:
         for error_type in [
@@ -370,18 +665,21 @@ class TestVectorChannelConfig:
         assert hasattr(VectorChannelConfig, "channelBusCapabilities")
         assert hasattr(VectorChannelConfig, "isOnBus")
         assert hasattr(VectorChannelConfig, "connectedBusType")
+        assert hasattr(VectorChannelConfig, "busParams")
+        assert hasattr(VectorChannelConfig, "driverVersion")
+        assert hasattr(VectorChannelConfig, "interfaceVersion")
         assert hasattr(VectorChannelConfig, "serialNumber")
         assert hasattr(VectorChannelConfig, "articleNumber")
         assert hasattr(VectorChannelConfig, "transceiverName")
 
 
 def xlGetApplConfig(
-    app_name_p: ctypes.c_char_p,
+    app_name_p: bytes,
     app_channel: ctypes.c_uint,
-    hw_type: ctypes.POINTER(ctypes.c_uint),
-    hw_index: ctypes.POINTER(ctypes.c_uint),
-    hw_channel: ctypes.POINTER(ctypes.c_uint),
-    bus_type: ctypes.c_uint,
+    hw_type: ctypes.c_uint,
+    hw_index: ctypes.c_uint,
+    hw_channel: ctypes.c_uint,
+    bus_type: xldefine.XL_BusTypes,
 ) -> int:
     hw_type.value = 1
     hw_channel.value = 0
@@ -389,21 +687,22 @@ def xlGetApplConfig(
 
 
 def xlGetChannelIndex(
-    hw_type: ctypes.c_int, hw_index: ctypes.c_int, hw_channel: ctypes.c_int
+    hw_type: xldefine.XL_HardwareType, hw_index: int, hw_channel: int
 ) -> int:
     return hw_channel
 
 
 def xlOpenPort(
-    port_handle_p: ctypes.POINTER(xlclass.XLportHandle),
-    app_name_p: ctypes.c_char_p,
-    access_mask: xlclass.XLaccess,
-    permission_mask_p: ctypes.POINTER(xlclass.XLaccess),
-    rx_queue_size: ctypes.c_uint,
-    xl_interface_version: ctypes.c_uint,
-    bus_type: ctypes.c_uint,
+    port_handle_p: xlclass.XLportHandle,
+    app_name_p: bytes,
+    access_mask: int,
+    permission_mask_p: xlclass.XLaccess,
+    rx_queue_size: int,
+    xl_interface_version: xldefine.XL_InterfaceVersion,
+    bus_type: xldefine.XL_BusTypes,
 ) -> int:
     port_handle_p.value = 0
+    permission_mask_p.value = access_mask
     return 0
 
 
@@ -425,8 +724,8 @@ def xlSetNotification(
 
 def xlReceive(
     port_handle: xlclass.XLportHandle,
-    event_count_p: ctypes.POINTER(ctypes.c_uint),
-    event: ctypes.POINTER(xlclass.XLevent),
+    event_count_p: ctypes.c_uint,
+    event: xlclass.XLevent,
 ) -> int:
     event.tag = xldefine.XL_EventTags.XL_RECEIVE_MSG.value
     event.tagData.msg.id = 0x123
@@ -439,9 +738,7 @@ def xlReceive(
     return 0
 
 
-def xlCanReceive(
-    port_handle: xlclass.XLportHandle, event: ctypes.POINTER(xlclass.XLcanRxEvent)
-) -> int:
+def xlCanReceive(port_handle: xlclass.XLportHandle, event: xlclass.XLcanRxEvent) -> int:
     event.tag = xldefine.XL_CANFD_RX_EventTags.XL_CAN_EV_TAG_RX_OK.value
     event.tagData.canRxOkMsg.canId = 0x123
     event.tagData.canRxOkMsg.dlc = 8
@@ -455,8 +752,8 @@ def xlCanReceive(
 
 def xlReceive_chipstate(
     port_handle: xlclass.XLportHandle,
-    event_count_p: ctypes.POINTER(ctypes.c_uint),
-    event: ctypes.POINTER(xlclass.XLevent),
+    event_count_p: ctypes.c_uint,
+    event: xlclass.XLevent,
 ) -> int:
     event.tag = xldefine.XL_EventTags.XL_CHIP_STATE.value
     event.tagData.chipState.busStatus = 8
@@ -468,7 +765,7 @@ def xlReceive_chipstate(
 
 
 def xlCanReceive_chipstate(
-    port_handle: xlclass.XLportHandle, event: ctypes.POINTER(xlclass.XLcanRxEvent)
+    port_handle: xlclass.XLportHandle, event: xlclass.XLcanRxEvent
 ) -> int:
     event.tag = xldefine.XL_CANFD_RX_EventTags.XL_CAN_EV_TAG_CHIP_STATE.value
     event.tagData.canChipState.busStatus = 8
@@ -477,6 +774,62 @@ def xlCanReceive_chipstate(
     event.timeStamp = 0
     event.chanIndex = 2
     return 0
+
+
+def get_channel_configs() -> List[VectorChannelConfig]:
+    raw_data = """
+    56 69 72 74 75 61 6c 20 43 68 61 6e 6e 65 6c 20 31 00 00 00 00 00 
+    00 00 00 00 00 00 00 00 00 00 01 00 00 16 00 00 00 00 00 00 01 00 
+    00 00 00 00 00 00 07 00 00 a0 01 00 01 00 00 00 00 00 00 01 00 00 
+    00 20 a1 07 00 01 04 03 01 01 00 00 00 00 00 00 00 01 00 00 00 00 
+    68 89 09 00 00 00 00 00 00 00 00 14 00 0a 15 04 00 00 00 00 00 00 
+    00 00 00 00 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 00 00 
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 64 00 00 00 58 1b 00 
+    00 56 69 72 74 75 61 6c 20 43 41 4e 00 00 00 00 00 00 00 00 00 00 
+    00 00 00 00 00 00 00 00 00 00 00 04 00 00 00 00 00 00 00 00 00 00 
+    02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
+    00 00 00 00 00 00 00
+    """
+    xlcc = xlclass.XLchannelConfig.from_buffer_copy(bytes.fromhex(raw_data))
+    return [
+        VectorChannelConfig(
+            name=xlcc.name.decode(),
+            hwType=xldefine.XL_HardwareType(xlcc.hwType),
+            hwIndex=xlcc.hwIndex,
+            hwChannel=xlcc.hwChannel,
+            channelIndex=xlcc.channelIndex,
+            channelMask=xlcc.channelMask,
+            channelCapabilities=xldefine.XL_ChannelCapabilities(
+                xlcc.channelCapabilities
+            ),
+            channelBusCapabilities=xldefine.XL_BusCapabilities(
+                xlcc.channelBusCapabilities
+            ),
+            isOnBus=bool(xlcc.isOnBus),
+            connectedBusType=xldefine.XL_BusTypes(xlcc.connectedBusType),
+            busParams=canlib.VectorBusParams.from_bus_params(xlcc.busParams),
+            driverVersion=".".join(
+                [str(x) for x in xlcc.driverVersion.to_bytes(4, "little")]
+            ),
+            interfaceVersion=xldefine.XL_InterfaceVersion(xlcc.interfaceVersion),
+            serialNumber=xlcc.serialNumber,
+            articleNumber=xlcc.articleNumber,
+            transceiverName=xlcc.transceiverName.decode(),
+        )
+    ]
+
+
+def _find_channel_configuration(
+    serial: int,
+    channel: int,
+) -> VectorChannelConfig:
+    vcc_list = canlib.get_channel_configs()
+    for vcc in vcc_list:
+        if serial != vcc.serialNumber:
+            continue
+        if channel != vcc.hwChannel:
+            continue
+        return vcc
 
 
 if __name__ == "__main__":

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -68,6 +68,9 @@ class TestVectorBus(unittest.TestCase):
 
         # various functions
         can.interfaces.vector.canlib.xldriver.xlCanFlushTransmitQueue = Mock()
+        can.interfaces.vector.canlib.xldriver.xlSetTimerRate = Mock()
+        can.interfaces.vector.canlib.xldriver.xlGenerateSyncPulse = Mock()
+        can.interfaces.vector.canlib.xldriver.xlFlushReceiveQueue = Mock()
         can.interfaces.vector.canlib.WaitForSingleObject = Mock()
 
         self.bus = None
@@ -272,12 +275,32 @@ class TestVectorBus(unittest.TestCase):
         assert canlib.xldriver.xlSetApplConfig.called
 
     def test_set_timer_rate(self) -> None:
-        canlib.xldriver.xlSetTimerRate = Mock()
         bus: canlib.VectorBus = can.Bus(
             channel=0, bustype="vector", fd=True, _testing=True
         )
         bus.set_timer_rate(timer_rate_ms=1)
         assert canlib.xldriver.xlSetTimerRate.called
+
+    def test_flush_rx_buffer(self) -> None:
+        bus: canlib.VectorBus = can.Bus(
+            channel=0, bustype="vector", fd=True, _testing=True
+        )
+        bus.flush_rx_buffer()
+        assert canlib.xldriver.xlFlushReceiveQueue.called
+
+    def test_request_chip_state(self) -> None:
+        bus: canlib.VectorBus = can.Bus(
+            channel=0, bustype="vector", fd=True, _testing=True
+        )
+        bus.request_chip_state()
+        assert canlib.xldriver.xlCanRequestChipState.called
+
+    def test_generate_sync_pulse(self) -> None:
+        bus: canlib.VectorBus = can.Bus(
+            channel=0, bustype="vector", fd=True, _testing=True
+        )
+        bus.generate_sync_pulse()
+        assert canlib.xldriver.xlGenerateSyncPulse.called
 
     def test_called_without_testing_argument(self) -> None:
         """This tests if an exception is thrown when we are not running on Windows."""

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -334,9 +334,6 @@ class TestVectorBus(unittest.TestCase):
             assert tx_msg.equals(rx_msg, timestamp_delta=None)
 
     def test_receive_fd(self) -> None:
-        while _find_channel_configuration(100, 0).isOnBus:
-            time.sleep(0.1)
-            print("wait for bus")
         self.bus = canlib.VectorBus(
             app_name="test_receive_fd",
             channel=0,


### PR DESCRIPTION
@christiansandberg could you please take a look at this one? It might seem big but i'm using at for a while now and it works fine.

#### Major changes:

* The tests now run on the XL API virtual bus if it is available. If no driver is found, then we continue to mock as before.
* An exception is raised when the application does not have init access and the requested bit timings cannot be set. **No more silent failures**. The procedure is as follows
  * if the application has init access, set the requested timings and return
  * otherwise check the currently active bit timings. If the timings are compatible, then return. If the timings are wrong, raise an exception.

#### New public methods:

* `VectorBus.flush_rx_buffer()`
* `VectorBus.request_chip_state()`
* `VectorBus.generate_sync_pulse()`
* `VectorBus.init_access()`
* the `VectorBus._set_bitrate_can()` and `VectorBus._set_bitrate_canfd()` could be made public in the future, too

#### New `VectorBus.__init__()` parameter:

* `ensure_init_access`  (raise exception when init access is not available)