### PR TITLE
Fix _default_name for compressed files

### DIFF
--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -345,11 +345,11 @@ class SizedRotatingLogger(BaseRotatingLogger):
         """Generate the default rotation filename."""
         path = pathlib.Path(self.base_filename)
         new_name = (
-            path.stem
+            path.parts[-1].split(".")[0]
             + "_"
             + datetime.now().strftime("%Y-%m-%dT%H%M%S")
             + "_"
             + f"#{self.rollover_count:03}"
-            + path.suffix
+            + "".join(pathlib.Path(self.base_filename).suffixes[-2:])
         )
         return str(path.parent / new_name)

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -350,6 +350,6 @@ class SizedRotatingLogger(BaseRotatingLogger):
             + datetime.now().strftime("%Y-%m-%dT%H%M%S")
             + "_"
             + f"#{self.rollover_count:03}"
-            + "".join(pathlib.Path(self.base_filename).suffixes[-2:])
+            + "".join(path.suffixes[-2:])
         )
         return str(path.parent / new_name)

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -345,7 +345,7 @@ class SizedRotatingLogger(BaseRotatingLogger):
         """Generate the default rotation filename."""
         path = pathlib.Path(self.base_filename)
         new_name = (
-            path.parts[-1].split(".")[0]
+            path.stem.split(".")[0]
             + "_"
             + datetime.now().strftime("%Y-%m-%dT%H%M%S")
             + "_"


### PR DESCRIPTION
Previously the compressed `SizedRotatingLogger` created files such as: `file.log_2022-08-27T111103_#000.gz`

Given the changes in 115f3de3ecf3c831079edddc7c6f106c3f6f4832, zipped file names are supported: `file_2022-08-27T112545_#000.log.gz`

closes #1382 