### PR TITLE
Move windows-curses dependency to an optional extra

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -103,6 +103,16 @@ If ``python-can`` is already installed, the CANtact backend can be installed sep
 
 Additional CANtact documentation is available at `cantact.io <https://cantact.io>`__.
 
+CanViewer
+~~~~~~~~~
+
+``python-can`` has support for showing a simple CAN viewer terminal application
+by running ``python -m can.viewer``. On Windows, this depends on the
+`windows-curses library <https://pypi.org/project/windows-curses/>`__ which can
+be installed with:
+
+``python3 -m pip install "python-can[viewer]"``
+
 Installing python-can in development mode
 -----------------------------------------
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -111,7 +111,7 @@ by running ``python -m can.viewer``. On Windows, this depends on the
 `windows-curses library <https://pypi.org/project/windows-curses/>`__ which can
 be installed with:
 
-``python3 -m pip install "python-can[viewer]"``
+``python -m pip install "python-can[viewer]"``
 
 Installing python-can in development mode
 -----------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ extras_require = {
     "gs_usb": ["gs_usb>=0.2.1"],
     "nixnet": ["nixnet>=0.3.1"],
     "pcan": ["uptime~=3.0.1"],
+    "viewer": [
+        'windows-curses;platform_system=="Windows" and platform_python_implementation=="CPython"'
+    ],
 }
 
 setup(
@@ -86,7 +89,6 @@ setup(
     install_requires=[
         "setuptools",
         "wrapt~=1.10",
-        'windows-curses;platform_system=="Windows" and platform_python_implementation=="CPython"',
         "typing_extensions>=3.10.0.0",
         'pywin32;platform_system=="Windows" and platform_python_implementation=="CPython"',
         'msgpack~=1.0.0;platform_system!="Windows"',


### PR DESCRIPTION
Python 3.11 wheels for windows-curses are [not yet available][1], and this meant that python-can could not be installed on windows with Python 3.11. Since windows-curses is only used in viewer.py, change the dependnecy to an optional extra.

[1]: https://github.com/zephyrproject-rtos/windows-curses/issues/31

Fixes https://github.com/hardbyte/python-can/issues/1394