### PR TITLE
Update BufferedReader.get_message docstring

### DIFF
--- a/can/listener.py
+++ b/can/listener.py
@@ -105,13 +105,13 @@ class BufferedReader(Listener):  # pylint: disable=abstract-method
 
     def get_message(self, timeout: float = 0.5) -> Optional[Message]:
         """
-        Attempts to retrieve the latest message received by the instance. If no message is
-        available it blocks for given timeout or until a message is received, or else
-        returns None (whichever is shorter). This method does not block after
-        :meth:`can.BufferedReader.stop` has been called.
+        Attempts to retrieve the message that has been in the queue for the longest amount
+        of time (FIFO). If no message is available, it blocks for given timeout or until a
+        message is received (whichever is shorter), or else returns None. This method does
+        not block after :meth:`can.BufferedReader.stop` has been called.
 
         :param timeout: The number of seconds to wait for a new message.
-        :return: the Message if there is one, or None if there is not.
+        :return: the received :class:`can.Message` or `None`, if the queue is empty.
         """
         try:
             if self.is_stopped:


### PR DESCRIPTION
** Docstring now states that the `get_message` method utilizes a FIFO ordering for grabbing messages from the queue.

#1207