### PR TITLE
setup.cfg: Use license_files instead of license_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-license_file = LICENSE.txt
+license_files = LICENSE.txt
 
 [mypy]
 warn_return_any = True


### PR DESCRIPTION
Without this (and recent enough setuptools) I get this warning:

/home/nert/dev/python-can/.tox/.package/lib/python3.10/site-packages/setuptools/config/setupcfg.py:508: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.