### PR TITLE
Add with statement to example in README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,8 @@ Example usage
     # import the library
     import can
 
-    # create a bus instance
+    # create a bus instance using 'with' statement,
+    # this will cause bus.shutdown() to be called on the block exit;
     # many other interfaces are supported as well (see documentation)
     with can.Bus(interface='socketcan',
                   channel='vcan0',

--- a/README.rst
+++ b/README.rst
@@ -91,21 +91,21 @@ Example usage
 
     # create a bus instance
     # many other interfaces are supported as well (see documentation)
-    bus = can.Bus(interface='socketcan',
+    with can.Bus(interface='socketcan',
                   channel='vcan0',
-                  receive_own_messages=True)
+                  receive_own_messages=True) as bus:
 
-    # send a message
-    message = can.Message(arbitration_id=123, is_extended_id=True,
-                          data=[0x11, 0x22, 0x33])
-    bus.send(message, timeout=0.2)
+       # send a message
+       message = can.Message(arbitration_id=123, is_extended_id=True,
+                             data=[0x11, 0x22, 0x33])
+       bus.send(message, timeout=0.2)
 
-    # iterate over received messages
-    for msg in bus:
-        print(f"{msg.arbitration_id:X}: {msg.data}")
+       # iterate over received messages
+       for msg in bus:
+           print(f"{msg.arbitration_id:X}: {msg.data}")
 
-    # or use an asynchronous notifier
-    notifier = can.Notifier(bus, [can.Logger("recorded.log"), can.Printer()])
+       # or use an asynchronous notifier
+       notifier = can.Notifier(bus, [can.Logger("recorded.log"), can.Printer()])
 
 You can find more information in the documentation, online at
 `python-can.readthedocs.org <https://python-can.readthedocs.org/en/stable/>`__.


### PR DESCRIPTION
Not using with expression in code might cause lack of cleanup and hard to trace errors, also because Bus doesn't override `__del__`. 

So it's a good idea to provide a 100% percent correct example in README for people who don't go into examples folder and read into the code.

Not sure if a sleep call is not needed after the notifier though.