### PR TITLE
Allow restarting of transmission tasks for socketcan

### DIFF
--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -388,7 +388,9 @@ class CyclicSendTask(
             can_id=self.task_id,
             nframes=0,
         )
-        log.debug(f"Reading properties of (cyclic) transmission task id={self.task_id}", )
+        log.debug(
+            f"Reading properties of (cyclic) transmission task id={self.task_id}",
+        )
         try:
             self.bcm_socket.send(check_header)
         except OSError as error:

--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -349,7 +349,7 @@ class CyclicSendTask(
         self.task_id = task_id
         self._tx_setup(self.messages)
 
-    def _tx_setup(self, messages: Sequence[Message], raise_if_task_exists=True) -> None:
+    def _tx_setup(self, messages: Sequence[Message], raise_if_task_exists: bool =True) -> None:
         # Create a low level packed frame to pass to the kernel
         body = bytearray()
         self.flags = CAN_FD_FRAME if messages[0].is_fd else 0

--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -349,7 +349,7 @@ class CyclicSendTask(
         self.task_id = task_id
         self._tx_setup(self.messages)
 
-    def _tx_setup(self, messages: Sequence[Message]) -> None:
+    def _tx_setup(self, messages: Sequence[Message], raise_if_task_exists=True) -> None:
         # Create a low level packed frame to pass to the kernel
         body = bytearray()
         self.flags = CAN_FD_FRAME if messages[0].is_fd else 0
@@ -363,7 +363,8 @@ class CyclicSendTask(
             ival1 = 0.0
             ival2 = self.period
 
-        self._check_bcm_task()
+        if raise_if_task_exists:
+            self._check_bcm_task()
 
         header = build_bcm_transmit_header(
             self.task_id, count, ival1, ival2, self.flags, nframes=len(messages)
@@ -375,7 +376,7 @@ class CyclicSendTask(
 
     def _check_bcm_task(self) -> None:
         # Do a TX_READ on a task ID, and check if we get EINVAL. If so,
-        # then we are referring to a CAN message with the existing ID
+        # then we are referring to a CAN message with an existing ID
         check_header = build_bcm_header(
             opcode=CAN_BCM_TX_READ,
             flags=0,
@@ -387,12 +388,17 @@ class CyclicSendTask(
             can_id=self.task_id,
             nframes=0,
         )
+        log.debug(f"Reading properties of (cyclic) transmission task id={self.task_id}", )
         try:
             self.bcm_socket.send(check_header)
         except OSError as error:
             if error.errno != errno.EINVAL:
                 raise can.CanOperationError("failed to check", error.errno) from error
+            else:
+                log.debug("Invalid argument - transmission task not known to kernel")
         else:
+            # No exception raised - transmission task with this ID exists in kernel.
+            # Existence of an existing transmission task might not be a problem!
             raise can.CanOperationError(
                 f"A periodic task for task ID {self.task_id} is already in progress "
                 "by the SocketCAN Linux layer"
@@ -438,7 +444,7 @@ class CyclicSendTask(
         send_bcm(self.bcm_socket, header + body)
 
     def start(self) -> None:
-        """Start a periodic task by sending TX_SETUP message to Linux kernel.
+        """Restart a periodic task by sending TX_SETUP message to Linux kernel.
 
         It verifies presence of the particular BCM task through sending TX_READ
         message to Linux kernel prior to scheduling.
@@ -446,7 +452,7 @@ class CyclicSendTask(
         :raises ValueError:
             If the task referenced by ``task_id`` is already running.
         """
-        self._tx_setup(self.messages)
+        self._tx_setup(self.messages, raise_if_task_exists=False)
 
 
 class MultiRateCyclicSendTask(CyclicSendTask):

--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -349,7 +349,9 @@ class CyclicSendTask(
         self.task_id = task_id
         self._tx_setup(self.messages)
 
-    def _tx_setup(self, messages: Sequence[Message], raise_if_task_exists: bool =True) -> None:
+    def _tx_setup(
+        self, messages: Sequence[Message], raise_if_task_exists: bool = True
+    ) -> None:
         # Create a low level packed frame to pass to the kernel
         body = bytearray()
         self.flags = CAN_FD_FRAME if messages[0].is_fd else 0


### PR DESCRIPTION
I was going through the examples and found that restarting BCM tasks was broken.

The error is due to a requirement that the transmission task NOT exist in kernel space when sending the restart message. I'm not sure how long it has been broken for.

@hartkopp would you mind checking my logic?