### PR TITLE
Use furo html theme for documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -49,7 +49,6 @@ extensions = [
     "sphinx.ext.graphviz",
     "sphinxcontrib.programoutput",
     "sphinx_inline_tabs",
-    "sphinx_rtd_theme",
 ]
 
 # Now, you can use the alias name as a new role, e.g. :issue:`123`.
@@ -139,7 +138,7 @@ ctypesutil.HRESULT = ctypes.c_long
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "sphinx_rtd_theme"
+html_theme = "furo"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -1,4 +1,4 @@
 sphinx>=5.2.3
 sphinxcontrib-programoutput
-sphinx_rtd_theme
 sphinx-inline-tabs
+furo

--- a/doc/interfaces/vector.rst
+++ b/doc/interfaces/vector.rst
@@ -15,7 +15,9 @@ the bus or in a config file.
 Channel should be given as a list of channels starting at 0.
 
 Here is an example configuration file connecting to CAN 1 and CAN 2 for an
-application named "python-can"::
+application named "python-can":
+
+::
 
     [default]
     interface = vector


### PR DESCRIPTION
What do you think?

The output can be seen [here](https://python-can--1443.org.readthedocs.build/en/1443/).