### PR TITLE
Adjust minimum year to 1971

### DIFF
--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -119,8 +119,13 @@ def timestamp_to_systemtime(timestamp: float) -> TSystemTime:
 
 def systemtime_to_timestamp(systemtime: TSystemTime) -> float:
     try:
+        year_adjusted = (
+            systemtime[0]
+            if systemtime[0] >= 1971
+            else systemtime[0] + (1971 - systemtime[0])
+        )
         t = datetime.datetime(
-            systemtime[0],
+            year_adjusted,
             systemtime[1],
             systemtime[3],
             systemtime[4],


### PR DESCRIPTION
- If there's a case incoming date data is incorrect, adjust year to start from 1971.
- This resolves issue of #1444 

