### PR TITLE
Use high resolution timer on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     types: [ published ]
   pull_request:
   push:
-    branches: [ develop, main ]
+
 env:
   PY_COLORS: "1"
 

--- a/can/broadcastmanager.py
+++ b/can/broadcastmanager.py
@@ -248,7 +248,15 @@ class ThreadBasedCyclicSendTask(
 
         if HAS_EVENTS:
             self.period_ms = int(round(period * 1000, 0))
-            self.event = win32event.CreateWaitableTimer(None, False, None)
+            try:
+                self.event = win32event.CreateWaitableTimerEx(
+                    None,
+                    None,
+                    win32event.CREATE_WAITABLE_TIMER_HIGH_RESOLUTION,
+                    win32event.TIMER_ALL_ACCESS,
+                )
+            except (AttributeError, OSError):
+                self.event = win32event.CreateWaitableTimer(None, False, None)
 
         self.start()
 

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         "setuptools",
         "wrapt~=1.10",
         "typing_extensions>=3.10.0.0",
-        'pywin32;platform_system=="Windows" and platform_python_implementation=="CPython"',
+        'pywin32>=305;platform_system=="Windows" and platform_python_implementation=="CPython"',
         'msgpack~=1.0.0;platform_system!="Windows"',
         "packaging",
     ],


### PR DESCRIPTION
Improve timing precision for BroadcastManager without calling timeBeginPeriod.

If merged, this should stay in develop for some time. I'm not sure if catching `OSError` is sufficient to make this compatible to old Windows versions.

Related: #1262 