### PR TITLE
Fix canfilter typing error

### DIFF
--- a/can/typechecking.py
+++ b/can/typechecking.py
@@ -8,9 +8,10 @@ if typing.TYPE_CHECKING:
 
 import typing_extensions
 
-CanFilter: typing_extensions = typing_extensions.TypedDict(
-    "CanFilter", {"can_id": int, "can_mask": int}
-)
+
+class CanFilter(typing_extensions.TypedDict):
+    can_id: int
+    can_mask: int
 
 
 class CanFilterExtended(typing_extensions.TypedDict):


### PR DESCRIPTION
Fix Canfilter type ending up doing the following error: `Module cannot be used as a type`

