### PR TITLE
Update documentation with plugins, related tools etc.

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -45,6 +45,7 @@ Contents:
    interfaces
    virtual-interfaces
    plugin-interface
+   other-tools
    scripts
    development
    history

--- a/doc/interfaces.rst
+++ b/doc/interfaces.rst
@@ -9,10 +9,10 @@ device is different, you should carefully go through your interface's
 documentation.
 
 .. note::
-   The *Interface Names* are listed in :doc:`configuration`.
+   The standard *Interface Names* are listed in :doc:`configuration`.
 
 
-The available hardware interfaces are:
+The standard available hardware interfaces of a normal python-can installation are:
 
 .. toctree::
    :maxdepth: 1
@@ -39,3 +39,5 @@ The available hardware interfaces are:
    interfaces/usb2can
    interfaces/vector
 
+
+Additional interface types can be added via the :ref:`plugin interface`, or by installing a module that utilises the :ref:`plugin interface`.

--- a/doc/other-tools.rst
+++ b/doc/other-tools.rst
@@ -72,4 +72,4 @@ Other CAN related tools, programs etc.
 |
 |
 .. note::
-See also the available plugins for python-can in :doc:`plugin interface`.
+See also the available plugins for python-can in :ref:`plugin interface`.

--- a/doc/other-tools.rst
+++ b/doc/other-tools.rst
@@ -15,38 +15,31 @@ CAN Message protocols (implemented in Python)
     * The `can-j1939`_ module provides an implementation of the CAN SAE J1939 standard for Python,
       including J1939-22. `can-j1939`_ uses python-can to provide support for multiple hardware
       interfaces.
-
-.. _can-j1939: https://github.com/juergenH87/python-can-j1939
-	
 #. CIA CANopen
     * The `canopen`_ module provides an implementation of the CIA CANopen protocol, aiming to be
       used for automation and testing purposes
-
-.. _canopen: https://canopen.readthedocs.io/en/latest/
-
 #. ISO 15765-2 (ISO TP)
     * The `can-isotp`_ module provides an implementation of the ISO TP CAN protocol for sending
       data packets via a CAN transport layer.
-
-.. _can-isotp: https://can-isotp.readthedocs.io/en/latest/
 
 #. UDS
     * The `python-uds`_ module is a communication protocol agnostic implementation of the Unified
       Diagnostic Services (UDS) protocol defined in ISO 14229-1, although it does have extensions
       for performing UDS over CAN utilising the ISO TP protocol. This module has not been updated
       for some time. 
-    * The `uds`_ module is a another tool that implements the UDS protocol, although it does have
+    * The `uds`_ module is another tool that implements the UDS protocol, although it does have
 	  extensions for performing UDS over CAN utilising the ISO TP protocol. This module has not
 	  been updated for some time.
-
-.. _python-uds: https://python-uds.readthedocs.io/en/latest/index.html
-.. _uds: https://uds.readthedocs.io/en/latest/
-
 #. XCP
     * The `pyxcp`_ module implements the Universal Measurement and Calibration Protocol (XCP).
       The purpose of XCP is to adjust parameters and acquire current values of internal
       variables in an ECU.
-
+	  
+.. _can-j1939: https://github.com/juergenH87/python-can-j1939
+.. _canopen: https://canopen.readthedocs.io/en/latest/
+.. _can-isotp: https://can-isotp.readthedocs.io/en/latest/
+.. _python-uds: https://python-uds.readthedocs.io/en/latest/index.html
+.. _uds: https://uds.readthedocs.io/en/latest/
 .. _pyxcp: https://pyxcp.readthedocs.io/en/latest/
 
 CAN Frame Parsing tools etc. (implemented in Python)
@@ -54,17 +47,14 @@ CAN Frame Parsing tools etc. (implemented in Python)
 
 #. CAN Message / Database scripting
     * The `cantools`_ package provides multiple methods for interacting with can message database
-      files, and using thjese files to monitor live busses with a command line monitor tool.
-
-.. _cantools: https://cantools.readthedocs.io/en/latest/
-
+      files, and using these files to monitor live busses with a command line monitor tool.
 #. CAN Message / Log Decoding
     * The `canmatrix`_ module provides methods for converting between multiple popular message
       frame definition file formats (e.g. .DBC files, .KCD files, .ARXML files etc.).
-
     * The `pretty_j1939`_ module can be used to post-process CAN logs of J1939 traffic into human
       readable terminal prints or into a JSON file for consumption elsewhere in your scripts.
 
+.. _cantools: https://cantools.readthedocs.io/en/latest/
 .. _canmatrix: https://canmatrix.readthedocs.io/en/latest/
 .. _pretty_j1939: https://github.com/nmfta-repo/pretty_j1939
 
@@ -73,14 +63,12 @@ Other CAN related tools, programs etc.
 
 #. Micropython CAN class
     * A `CAN class`_ is available for the original micropython pyboard, with much of the same
-      functionality as is availble with python-can (but with a different API!).
-
-.. _`CAN class`: https://docs.micropython.org/en/latest/library/pyb.CAN.html
-
+      functionality as is available with python-can (but with a different API!).
 #. ASAM MDF Files
     * The `asammdf`_ module provides many methods for processing ASAM (Association for
       Standardization of Automation and Measuring Systems) MDF (Measurement Data Format) files.
 
+.. _`CAN class`: https://docs.micropython.org/en/latest/library/pyb.CAN.html
 .. _`asammdf`: https://asammdf.readthedocs.io/en/master/
 
 |

--- a/doc/other-tools.rst
+++ b/doc/other-tools.rst
@@ -1,7 +1,7 @@
 Other CAN bus tools
 ===================
 
-In order to keep the project maintainable, the scope of the module is limited to providing common
+In order to keep the project maintainable, the scope of the package is limited to providing common
 abstractions to different hardware devices, and a basic suite of utilities for sending and
 receiving messages on a CAN bus. Other tools are available that either extend the functionality
 of python-can, or provide complementry features that an engineer dealing with CAN will find useful.

--- a/doc/other-tools.rst
+++ b/doc/other-tools.rst
@@ -15,30 +15,39 @@ CAN Message protocols (implemented in Python)
     * The `can-j1939`_ module provides an implementation of the CAN SAE J1939 standard for Python,
       including J1939-22. `can-j1939`_ uses python-can to provide support for multiple hardware
       interfaces.
-    .. _can-j1939: https://github.com/juergenH87/python-can-j1939
+
+.. _can-j1939: https://github.com/juergenH87/python-can-j1939
+	
 #. CIA CANopen
     * The `canopen`_ module provides an implementation of the CIA CANopen protocol, aiming to be
       used for automation and testing purposes
-    .. _canopen: https://canopen.readthedocs.io/en/latest/
+
+.. _canopen: https://canopen.readthedocs.io/en/latest/
+
 #. ISO 15765-2 (ISO TP)
     * The `can-isotp`_ module provides an implementation of the ISO TP CAN protocol for sending
       data packets via a CAN transport layer.
-    .. _can-isotp: https://can-isotp.readthedocs.io/en/latest/
+
+.. _can-isotp: https://can-isotp.readthedocs.io/en/latest/
+
 #. UDS
     * The `python-uds`_ module is a communication protocol agnostic implementation of the Unified
       Diagnostic Services (UDS) protocol defined in ISO 14229-1, although it does have extensions
       for performing UDS over CAN utilising the ISO TP protocol. This module has not been updated
       for some time. 
-    .. _python-uds: https://python-uds.readthedocs.io/en/latest/index.html
-    * The `uds`_ module is a another tool that implements the UDS protocol, although it does have extensions
-      for performing UDS over CAN utilising the ISO TP protocol. This module has not been updated
-      for some time. 
-    .. _uds: https://uds.readthedocs.io/en/latest/
+    * The `uds`_ module is a another tool that implements the UDS protocol, although it does have
+	  extensions for performing UDS over CAN utilising the ISO TP protocol. This module has not
+	  been updated for some time.
+
+.. _python-uds: https://python-uds.readthedocs.io/en/latest/index.html
+.. _uds: https://uds.readthedocs.io/en/latest/
+
 #. XCP
     * The `pyxcp`_ module implements the Universal Measurement and Calibration Protocol (XCP).
       The purpose of XCP is to adjust parameters and acquire current values of internal
       variables in an ECU.
-    .. _pyxcp: https://pyxcp.readthedocs.io/en/latest/
+
+.. _pyxcp: https://pyxcp.readthedocs.io/en/latest/
 
 CAN Frame Parsing tools etc. (implemented in Python)
 ----------------------------------------------------
@@ -46,15 +55,18 @@ CAN Frame Parsing tools etc. (implemented in Python)
 #. CAN Message / Database scripting
     * The `cantools`_ package provides multiple methods for interacting with can message database
       files, and using thjese files to monitor live busses with a command line monitor tool.
-    .. _cantools: https://cantools.readthedocs.io/en/latest/
+
+.. _cantools: https://cantools.readthedocs.io/en/latest/
 
 #. CAN Message / Log Decoding
     * The `canmatrix`_ module provides methods for converting between multiple popular message
       frame definition file formats (e.g. .DBC files, .KCD files, .ARXML files etc.).
-    .. _canmatrix: https://canmatrix.readthedocs.io/en/latest/
+
     * The `pretty_j1939`_ module can be used to post-process CAN logs of J1939 traffic into human
       readable terminal prints or into a JSON file for consumption elsewhere in your scripts.
-    .. _pretty_j1939: https://github.com/nmfta-repo/pretty_j1939
+
+.. _canmatrix: https://canmatrix.readthedocs.io/en/latest/
+.. _pretty_j1939: https://github.com/nmfta-repo/pretty_j1939
 
 Other CAN related tools, programs etc.
 --------------------------------------
@@ -63,14 +75,17 @@ Other CAN related tools, programs etc.
     * A `CAN class`_ is available for the original micropython pyboard, with much of the same
       functionality as is availble with python-can (but with a different API!).
 
-    .. _`CAN class`: https://docs.micropython.org/en/latest/library/pyb.CAN.html
+.. _`CAN class`: https://docs.micropython.org/en/latest/library/pyb.CAN.html
+
 #. ASAM MDF Files
     * The `asammdf`_ module provides many methods for processing ASAM (Association for
       Standardization of Automation and Measuring Systems) MDF (Measurement Data Format) files.
-    .. _`asammdf`: https://asammdf.readthedocs.io/en/master/
+
+.. _`asammdf`: https://asammdf.readthedocs.io/en/master/
 
 |
 |
+
 .. note::
    See also the available plugins for python-can in :ref:`plugin interface`.
 

--- a/doc/other-tools.rst
+++ b/doc/other-tools.rst
@@ -1,0 +1,34 @@
+Other CAN bus tools
+===================
+
+In order to keep the project maintainable, the scope of the module is limited to providing common
+abstractions to different hardware devices, and a basic suite of utilities for sending and
+receiving messages on a CAN bus. Other tools are available that either extend the functionality
+of python-can, or provide complementry features that an engineer dealing with CAN will find useful.
+
+Some of these tools are listed below for convenience.
+
+CAN Message protocols
+---------------------
+
+#. SAE J1939 Message Protocol
+    * The `can-j1939`_ module provides an implementation of the CAN SAE J1939 standard for Python,
+      including J1939-22. `can-j1939`_ uses python-can to provide support for multiple hardware
+      interfaces.
+    .. _can-j1939: https://github.com/juergenH87/python-can-j1939
+#. CIA CANopen
+    * The `canopen`_ module provides an implementation of the CIA CANopen protocol, aiming to be
+      used for automation and testing purposes
+    .. _canopen: https://github.com/christiansandberg/canopen
+#. ISO 15765-2 (ISO TP)
+    * The `can-isotp`_ module provides an implementation of the ISO TP CAN protocol for sending
+      data packets via a CAN transport layer.
+    .. _can-isotp: https://github.com/pylessard/python-can-isotp
+
+CAN Frame Parsing tools etc.
+----------------------------
+
+#. CAN Message Decoding
+    * The `canmatrix`_ module provides methods for converting between multiple popular message
+      frame definition file formats (e.g. .DBC files, .KCD files etc.
+    .. _canmatrix: https://github.com/ebroecker/canmatrix

--- a/doc/other-tools.rst
+++ b/doc/other-tools.rst
@@ -8,8 +8,8 @@ of python-can, or provide complementry features that an engineer dealing with CA
 
 Some of these tools are listed below for convenience.
 
-CAN Message protocols
----------------------
+CAN Message protocols (implemented in Python)
+---------------------------------------------
 
 #. SAE J1939 Message Protocol
     * The `can-j1939`_ module provides an implementation of the CAN SAE J1939 standard for Python,
@@ -19,16 +19,57 @@ CAN Message protocols
 #. CIA CANopen
     * The `canopen`_ module provides an implementation of the CIA CANopen protocol, aiming to be
       used for automation and testing purposes
-    .. _canopen: https://github.com/christiansandberg/canopen
+    .. _canopen: https://canopen.readthedocs.io/en/latest/
 #. ISO 15765-2 (ISO TP)
     * The `can-isotp`_ module provides an implementation of the ISO TP CAN protocol for sending
       data packets via a CAN transport layer.
-    .. _can-isotp: https://github.com/pylessard/python-can-isotp
+    .. _can-isotp: https://can-isotp.readthedocs.io/en/latest/
+#. UDS
+    * The `python-uds`_ module is a communication protocol agnostic implementation of the Unified
+      Diagnostic Services (UDS) protocol defined in ISO 14229-1, although it does have extensions
+      for performing UDS over CAN utilising the ISO TP protocol. This module has not been updated
+      for some time. 
+    .. _python-uds: https://python-uds.readthedocs.io/en/latest/index.html
+    * The `uds`_ module is a another tool that implements the UDS protocol, although it does have extensions
+      for performing UDS over CAN utilising the ISO TP protocol. This module has not been updated
+      for some time. 
+    .. _uds: https://uds.readthedocs.io/en/latest/
+#. XCP
+    * The `pyxcp`_ module implements the Universal Measurement and Calibration Protocol (XCP).
+      The purpose of XCP is to adjust parameters and acquire current values of internal
+      variables in an ECU.
+    .. _pyxcp: https://pyxcp.readthedocs.io/en/latest/
 
-CAN Frame Parsing tools etc.
-----------------------------
+CAN Frame Parsing tools etc. (implemented in Python)
+----------------------------------------------------
 
-#. CAN Message Decoding
+#. CAN Message / Database scripting
+    * The `cantools`_ package provides multiple methods for interacting with can message database
+      files, and using thjese files to monitor live busses with a command line monitor tool.
+    .. _cantools: https://cantools.readthedocs.io/en/latest/
+
+#. CAN Message / Log Decoding
     * The `canmatrix`_ module provides methods for converting between multiple popular message
-      frame definition file formats (e.g. .DBC files, .KCD files etc.
-    .. _canmatrix: https://github.com/ebroecker/canmatrix
+      frame definition file formats (e.g. .DBC files, .KCD files, .ARXML files etc.).
+    .. _canmatrix: https://canmatrix.readthedocs.io/en/latest/
+    * The `pretty_j1939`_ module can be used to post-process CAN logs of J1939 traffic into human
+      readable terminal prints or into a JSON file for consumption elsewhere in your scripts.
+    .. _pretty_j1939: https://github.com/nmfta-repo/pretty_j1939
+
+Other CAN related tools, programs etc.
+--------------------------------------
+
+#. Micropython CAN class
+    * A `CAN class`_ is available for the original micropython pyboard, with much of the same
+      functionality as is availble with python-can (but with a different API!).
+
+    .. _`CAN class`: https://docs.micropython.org/en/latest/library/pyb.CAN.html
+#. ASAM MDF Files
+    * The `asammdf`_ module provides many methods for processing ASAM (Association for
+      Standardization of Automation and Measuring Systems) MDF (Measurement Data Format) files.
+    .. _`asammdf`: https://asammdf.readthedocs.io/en/master/
+
+|
+|
+.. note::
+See also the available plugins for python-can in :doc:`plugin interface`.

--- a/doc/other-tools.rst
+++ b/doc/other-tools.rst
@@ -72,4 +72,5 @@ Other CAN related tools, programs etc.
 |
 |
 .. note::
-See also the available plugins for python-can in :ref:`plugin interface`.
+   See also the available plugins for python-can in :ref:`plugin interface`.
+

--- a/doc/plugin-interface.rst
+++ b/doc/plugin-interface.rst
@@ -59,7 +59,8 @@ Example Interface Plugins
 
 The table below lists interface drivers that can be added by installing additional modules that utilise the plugin API. These modules are optional dependencies of python-can.
 
-Note: The below modules are maintained by other authors and any issues should be reported in the relevant repository for that module.
+.. note::
+   The below modules are maintained by other authors and any issues should be reported in the relevant repository for that module.
 
 +----------------------------+-------------------------------------------------------+
 | Name                       | Description                                           |

--- a/doc/plugin-interface.rst
+++ b/doc/plugin-interface.rst
@@ -52,3 +52,25 @@ create an instance of the bus in the **python-can** API:
 
     bus = can.Bus(interface="interface_name", channel=0)
 
+
+
+Example Interface Plugins
+---------------
+
+The table below lists interface drivers that can be added by installing additional modules that utilise the plugin API. These modules are optional dependencies of python-can.
+
+Note: The below modules are maintained by other authors and any issues should be reported in the relevant repository for that module.
+
++----------------------------+-------------------------------------------------------+
+| Name                       | Description                                           |
++============================+=======================================================+
+| `python-can-cvector`_      | Cython based version of the 'VectorBus'               |
++----------------------------+-------------------------------------------------------+
+| `python-can-remote`_       | CAN over network bridge                               |
++----------------------------+-------------------------------------------------------+
+| `python-can-sontheim`_     | CAN Driver for Sontheim CAN interfaces (e.g. CANfox)  |
++----------------------------+-------------------------------------------------------+
+
+.. _python-can-cvector: https://github.com/zariiii9003/python-can-cvector
+.. _python-can-remote: https://github.com/christiansandberg/python-can-remote
+.. _python-can-sontheim: https://github.com/MattWoodhead/python-can-sontheim

--- a/doc/plugin-interface.rst
+++ b/doc/plugin-interface.rst
@@ -55,7 +55,7 @@ create an instance of the bus in the **python-can** API:
 
 
 Example Interface Plugins
----------------
+-------------------------
 
 The table below lists interface drivers that can be added by installing additional modules that utilise the plugin API. These modules are optional dependencies of python-can.
 

--- a/setup.py
+++ b/setup.py
@@ -30,13 +30,18 @@ extras_require = {
     "neovi": ["filelock", "python-ics>=2.12"],
     "canalystii": ["canalystii>=0.1.0"],
     "cantact": ["cantact>=0.0.7"],
+    "cvector": ["python-can-cvector"],
     "gs_usb": ["gs_usb>=0.2.1"],
     "nixnet": ["nixnet>=0.3.1"],
     "pcan": ["uptime~=3.0.1"],
+    "remote": ["python-can-remote"],
+    "sontheim": ["python-can-sontheim>=0.1.2"],
     "viewer": [
         'windows-curses;platform_system=="Windows" and platform_python_implementation=="CPython"'
     ],
 }
+# Add a tag that allows the user to install all optional dependencies at once
+extras_require["all_optional"] = set(dep for deps in extras_require.values() for dep in deps)
 
 setup(
     # Description

--- a/setup.py
+++ b/setup.py
@@ -40,10 +40,6 @@ extras_require = {
         'windows-curses;platform_system=="Windows" and platform_python_implementation=="CPython"'
     ],
 }
-# Add a tag that allows the user to install all optional dependencies at once
-extras_require["all_optional"] = set(
-    dep for deps in extras_require.values() for dep in deps
-)
 
 setup(
     # Description

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,9 @@ extras_require = {
     ],
 }
 # Add a tag that allows the user to install all optional dependencies at once
-extras_require["all_optional"] = set(dep for deps in extras_require.values() for dep in deps)
+extras_require["all_optional"] = set(
+    dep for deps in extras_require.values() for dep in deps
+)
 
 setup(
     # Description


### PR DESCRIPTION
An update to the documentation to add reference to some modules using the plugin interface, and in adition add some references to tools related to python-can to address #1041

Todo:
- [x]  Add example plugins to optional dependencies list as already noted elsewhere in the docs.
- [x]  Add more details and modules to the new "Other Tools" page
- [x]  Check documentation changes render correctly.