### PR TITLE
Fix Bus.__new__ for PEAK CAN-FD interfaces

### DIFF
--- a/can/util.py
+++ b/can/util.py
@@ -233,25 +233,6 @@ def _create_bus_config(config: Dict[str, Any]) -> typechecking.BusConfig:
     if "data_bitrate" in config:
         config["data_bitrate"] = int(config["data_bitrate"])
 
-    # Create bit timing configuration if given
-    timing_conf = {}
-    for key in (
-        "f_clock",
-        "brp",
-        "tseg1",
-        "tseg2",
-        "sjw",
-        "nof_samples",
-        "btr0",
-        "btr1",
-    ):
-        if key in config:
-            timing_conf[key] = int(str(config[key]), base=0)
-            del config[key]
-    if timing_conf:
-        timing_conf["bitrate"] = config["bitrate"]
-        config["timing"] = can.BitTiming(**timing_conf)
-
     return cast(typechecking.BusConfig, config)
 
 

--- a/test/test_pcan.py
+++ b/test/test_pcan.py
@@ -373,6 +373,16 @@ class TestPCANBus(unittest.TestCase):
         with self.assertRaises(CanInitializationError):
             self.bus = can.Bus(bustype="pcan", auto_reset=True)
 
+    def test_peak_fd_bus_constructor_regression(self):
+        # Tests that the following issue has been fixed:
+        # https://github.com/hardbyte/python-can/issues/1458
+        params = {'interface': 'pcan', 'fd': True, 'f_clock': 80000000, 'nom_brp': 1,
+                  'nom_tseg1': 129, 'nom_tseg2': 30, 'nom_sjw': 1, 'data_brp': 1,
+                  'data_tseg1': 9, 'data_tseg2': 6, 'data_sjw': 1, 'channel': 'PCAN_USBBUS1'}
+
+        can.Bus(**params)
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_pcan.py
+++ b/test/test_pcan.py
@@ -376,12 +376,22 @@ class TestPCANBus(unittest.TestCase):
     def test_peak_fd_bus_constructor_regression(self):
         # Tests that the following issue has been fixed:
         # https://github.com/hardbyte/python-can/issues/1458
-        params = {'interface': 'pcan', 'fd': True, 'f_clock': 80000000, 'nom_brp': 1,
-                  'nom_tseg1': 129, 'nom_tseg2': 30, 'nom_sjw': 1, 'data_brp': 1,
-                  'data_tseg1': 9, 'data_tseg2': 6, 'data_sjw': 1, 'channel': 'PCAN_USBBUS1'}
+        params = {
+            "interface": "pcan",
+            "fd": True,
+            "f_clock": 80000000,
+            "nom_brp": 1,
+            "nom_tseg1": 129,
+            "nom_tseg2": 30,
+            "nom_sjw": 1,
+            "data_brp": 1,
+            "data_tseg1": 9,
+            "data_tseg2": 6,
+            "data_sjw": 1,
+            "channel": "PCAN_USBBUS1",
+        }
 
         can.Bus(**params)
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request removes unused code in Bus.__new__ that is responsible for  creating BitTiming instances, but is incompatible with PEAK devices. See issue #1458 .
    
The BitTiming class is an attempt at unifying the various timing parameters of the individual interfaces. The idea is that instead of manually supplying multiple parameters that make up the timing definition of the interface, one can instead supply a single instance of the BitTiming class, which will also automatically calculate derivative values from its input.
    
At the moment, this class is only used by two interfaces: CANtact and CANanalystii. Both either accept a single bitrate or a BitTiming instance. The latter will overrule the former. For reference, a pull request that would implement BitTiming for PEAK devices has not been merged, see #625 .
    
The code that is removed with this commit is part of the generic Bus.__new__ constructor. The removed code searches the set of kwargs parameters for timing-related values. If it finds at least one such value, it creates a BitTiming class instance and adds it to the list of parameters. However, it breaks compatibility with the PEAK interface, see issue #1458. Additionally, the code in question is generic and applies to all interfaces. Instantiating a class here is prone to issues since it must be generic enough to fit all use cases. A better approach would be to simply forward the parameters as was done previously and leave it up to the individual interfaces to handle things properly.