### PR TITLE
PCAN: Fix Detection of Library on Windows on ARM

### DIFF
--- a/can/interfaces/pcan/basic.py
+++ b/can/interfaces/pcan/basic.py
@@ -658,7 +658,7 @@ class PCANBasic:
         #
         if platform.system() == "Windows":
             # Loads the API on Windows
-            self.__m_dllBasic = windll.LoadLibrary("PCANBasic")
+            self.__m_dllBasic = windll.LoadLibrary(find_library("PCANBasic"))
             aReg = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
             try:
                 aKey = winreg.OpenKey(aReg, r"SOFTWARE\PEAK-System\PEAK-Drivers")


### PR DESCRIPTION
Before this commit detection of the PCAN DLL would fail on Windows on ARM, regardless if you used the native Python version, or the x64 version of Python. After this fix detection should work properly as long as the PCAN library for your version of Python is listed first in the `PATH` variable. The default:

1. `C:\Program Files\PEAK-System\PEAK-Drivers 4\APIs\ARM64\` before
2. `C:\Program Files\PEAK-System\PEAK-Drivers 4\APIs\x64\`

should work if you use the (native) ARM version of Python. If you reorder these paths, then loading the library works in the x64 version of Python.

I tested the fix on the native version of Python `3.11` and the x64 version of Python `3.10` in Window on ARM, where everything seemed to work as expected. For more information, please take a look at issue #1461.