### PR TITLE
Improve interface registry: Fix DeprecationWarning + better typing + more robust

### DIFF
--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -36,7 +36,11 @@ if sys.version_info >= (3, 8):
     from importlib.metadata import entry_points
 
     # See https://docs.python.org/3/library/importlib.metadata.html#entry-points, "Compatibility Note".
-    entries = entry_points(group="can.interface") if sys.version_info >= (3, 10) else entry_points().get("can.interface", ())
+    entries = (
+        entry_points(group="can.interface")
+        if sys.version_info >= (3, 10)
+        else entry_points().get("can.interface", ())
+    )
     BACKENDS.update(
         {interface.name: tuple(interface.value.split(":")) for interface in entries}
     )

--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -3,7 +3,7 @@ Interfaces contain low level implementations that interact with CAN hardware.
 """
 
 import sys
-from typing import Dict, Tuple
+from typing import Dict, Iterable, Tuple
 
 # interface_name => (module, classname)
 BACKENDS: Dict[str, Tuple[str, ...]] = {
@@ -33,13 +33,13 @@ BACKENDS: Dict[str, Tuple[str, ...]] = {
 }
 
 if sys.version_info >= (3, 8):
-    from importlib.metadata import entry_points
+    from importlib.metadata import entry_points, EntryPoint
 
     # See https://docs.python.org/3/library/importlib.metadata.html#entry-points, "Compatibility Note".
-    entries = (
+    entries: Iterable[EntryPoint] = (
         entry_points(group="can.interface")
         if sys.version_info >= (3, 10)
-        else entry_points().get("can.interface", ())
+        else entry_points().get("can.interface", [])
     )
     BACKENDS.update(
         {interface.name: tuple(interface.value.split(":")) for interface in entries}

--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -35,7 +35,8 @@ BACKENDS: Dict[str, Tuple[str, ...]] = {
 if sys.version_info >= (3, 8):
     from importlib.metadata import entry_points
 
-    entries = entry_points(group="can.interface")
+    # See https://docs.python.org/3/library/importlib.metadata.html#entry-points, "Compatibility Note".
+    entries = entry_points(group="can.interface") if sys.version_info >= (3, 10) else entry_points().get("can.interface", ())
     BACKENDS.update(
         {interface.name: tuple(interface.value.split(":")) for interface in entries}
     )

--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -3,7 +3,7 @@ Interfaces contain low level implementations that interact with CAN hardware.
 """
 
 import sys
-from typing import cast, Dict, Iterable, Tuple
+from typing import cast, Dict, Tuple
 
 # interface_name => (module, classname)
 BACKENDS: Dict[str, Tuple[str, str]] = {
@@ -36,7 +36,6 @@ if sys.version_info >= (3, 8):
     from importlib.metadata import entry_points
 
     # See https://docs.python.org/3/library/importlib.metadata.html#entry-points, "Compatibility Note".
-    # The second variant causes a deprecation warning on Python >= 3.10.
     if sys.version_info >= (3, 10):
         BACKENDS.update(
             {
@@ -45,6 +44,7 @@ if sys.version_info >= (3, 8):
             }
         )
     else:
+        # The entry_points().get(...) causes a deprecation warning on Python >= 3.10.
         BACKENDS.update(
             {
                 # This cast in wrong if interface.value is formatted badly, but we just fail later
@@ -57,11 +57,10 @@ if sys.version_info >= (3, 8):
 else:
     from pkg_resources import iter_entry_points
 
-    entries = iter_entry_points("can.interface")
     BACKENDS.update(
         {
             interface.name: (interface.module_name, interface.attrs[0])
-            for interface in entries
+            for interface in iter_entry_points("can.interface")
         }
     )
 

--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -35,7 +35,7 @@ BACKENDS: Dict[str, Tuple[str, ...]] = {
 if sys.version_info >= (3, 8):
     from importlib.metadata import entry_points
 
-    entries = entry_points().get("can.interface", ())
+    entries = entry_points(group="can.interface")
     BACKENDS.update(
         {interface.name: tuple(interface.value.split(":")) for interface in entries}
     )

--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -6,37 +6,34 @@ import sys
 from typing import cast, Dict, Iterable, Tuple
 
 # interface_name => (module, classname)
-BACKENDS: Dict[str, Tuple[str, str]] = cast(
-    Dict[str, Tuple[str, str]],
-    {
-        "kvaser": ("can.interfaces.kvaser", "KvaserBus"),
-        "socketcan": ("can.interfaces.socketcan", "SocketcanBus"),
-        "serial": ("can.interfaces.serial.serial_can", "SerialBus"),
-        "pcan": ("can.interfaces.pcan", "PcanBus"),
-        "usb2can": ("can.interfaces.usb2can", "Usb2canBus"),
-        "ixxat": ("can.interfaces.ixxat", "IXXATBus"),
-        "nican": ("can.interfaces.nican", "NicanBus"),
-        "iscan": ("can.interfaces.iscan", "IscanBus"),
-        "virtual": ("can.interfaces.virtual", "VirtualBus"),
-        "udp_multicast": ("can.interfaces.udp_multicast", "UdpMulticastBus"),
-        "neovi": ("can.interfaces.ics_neovi", "NeoViBus"),
-        "vector": ("can.interfaces.vector", "VectorBus"),
-        "slcan": ("can.interfaces.slcan", "slcanBus"),
-        "robotell": ("can.interfaces.robotell", "robotellBus"),
-        "canalystii": ("can.interfaces.canalystii", "CANalystIIBus"),
-        "systec": ("can.interfaces.systec", "UcanBus"),
-        "seeedstudio": ("can.interfaces.seeedstudio", "SeeedBus"),
-        "cantact": ("can.interfaces.cantact", "CantactBus"),
-        "gs_usb": ("can.interfaces.gs_usb", "GsUsbBus"),
-        "nixnet": ("can.interfaces.nixnet", "NiXNETcanBus"),
-        "neousys": ("can.interfaces.neousys", "NeousysBus"),
-        "etas": ("can.interfaces.etas", "EtasBus"),
-        "socketcand": ("can.interfaces.socketcand", "SocketCanDaemonBus"),
-    },
-)
+BACKENDS: Dict[str, Tuple[str, str]] = {
+    "kvaser": ("can.interfaces.kvaser", "KvaserBus"),
+    "socketcan": ("can.interfaces.socketcan", "SocketcanBus"),
+    "serial": ("can.interfaces.serial.serial_can", "SerialBus"),
+    "pcan": ("can.interfaces.pcan", "PcanBus"),
+    "usb2can": ("can.interfaces.usb2can", "Usb2canBus"),
+    "ixxat": ("can.interfaces.ixxat", "IXXATBus"),
+    "nican": ("can.interfaces.nican", "NicanBus"),
+    "iscan": ("can.interfaces.iscan", "IscanBus"),
+    "virtual": ("can.interfaces.virtual", "VirtualBus"),
+    "udp_multicast": ("can.interfaces.udp_multicast", "UdpMulticastBus"),
+    "neovi": ("can.interfaces.ics_neovi", "NeoViBus"),
+    "vector": ("can.interfaces.vector", "VectorBus"),
+    "slcan": ("can.interfaces.slcan", "slcanBus"),
+    "robotell": ("can.interfaces.robotell", "robotellBus"),
+    "canalystii": ("can.interfaces.canalystii", "CANalystIIBus"),
+    "systec": ("can.interfaces.systec", "UcanBus"),
+    "seeedstudio": ("can.interfaces.seeedstudio", "SeeedBus"),
+    "cantact": ("can.interfaces.cantact", "CantactBus"),
+    "gs_usb": ("can.interfaces.gs_usb", "GsUsbBus"),
+    "nixnet": ("can.interfaces.nixnet", "NiXNETcanBus"),
+    "neousys": ("can.interfaces.neousys", "NeousysBus"),
+    "etas": ("can.interfaces.etas", "EtasBus"),
+    "socketcand": ("can.interfaces.socketcand", "SocketCanDaemonBus"),
+}
 
 if sys.version_info >= (3, 8):
-    from importlib.metadata import entry_points, EntryPoint
+    from importlib.metadata import entry_points
 
     # See https://docs.python.org/3/library/importlib.metadata.html#entry-points, "Compatibility Note".
     # The second variant causes a deprecation warning on Python >= 3.10.
@@ -50,7 +47,8 @@ if sys.version_info >= (3, 8):
     else:
         BACKENDS.update(
             {
-                interface.name: tuple(interface.value.split(":"))
+                # This cast in wrong if interface.value is formatted badly, but we just fail later
+                interface.name: cast(Tuple[str, str], tuple(interface.value.split(":")))
                 for interface in entry_points().get("can.interface", [])
             }
         )

--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -48,7 +48,7 @@ if sys.version_info >= (3, 8):
         BACKENDS.update(
             {
                 # This cast in wrong if interface.value is formatted badly, but we just fail later
-                interface.name: cast(Tuple[str, str], tuple(interface.value.split(":")))
+                interface.name: cast(Tuple[str, str], tuple(interface.value.split(":", maxsplit=1)))
                 for interface in entry_points().get("can.interface", [])
             }
         )

--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -48,7 +48,9 @@ if sys.version_info >= (3, 8):
         BACKENDS.update(
             {
                 # This cast in wrong if interface.value is formatted badly, but we just fail later
-                interface.name: cast(Tuple[str, str], tuple(interface.value.split(":", maxsplit=1)))
+                interface.name: cast(
+                    Tuple[str, str], tuple(interface.value.split(":", maxsplit=1))
+                )
                 for interface in entry_points().get("can.interface", [])
             }
         )

--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -47,7 +47,6 @@ if sys.version_info >= (3, 8):
         # The entry_points().get(...) causes a deprecation warning on Python >= 3.10.
         BACKENDS.update(
             {
-                # This cast in wrong if interface.value is formatted badly, but we just fail later
                 interface.name: cast(
                     Tuple[str, str], tuple(interface.value.split(":", maxsplit=1))
                 )

--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -39,14 +39,15 @@ if sys.version_info >= (3, 8):
     from importlib.metadata import entry_points, EntryPoint
 
     # See https://docs.python.org/3/library/importlib.metadata.html#entry-points, "Compatibility Note".
-    entries: Iterable[EntryPoint] = (  # type: ignore
-        entry_points(group="can.interface")
-        if sys.version_info >= (3, 10)
-        else entry_points().get("can.interface", [])
-    )
-    BACKENDS.update(
-        {interface.name: (interface.module, interface.attr) for interface in entries}
-    )
+    # The second variant causes a deprecation warning on Python >= 3.10.
+    if sys.version_info >= (3, 10):
+        BACKENDS.update(
+            {interface.name: (interface.module, interface.attr) for interface in entry_points(group="can.interface")}
+        )
+    else:
+        BACKENDS.update(
+            {interface.name: tuple(interface.value.split(":")) for interface in entry_points().get("can.interface", [])}
+        )
 else:
     from pkg_resources import iter_entry_points
 

--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -36,7 +36,7 @@ if sys.version_info >= (3, 8):
     from importlib.metadata import entry_points, EntryPoint
 
     # See https://docs.python.org/3/library/importlib.metadata.html#entry-points, "Compatibility Note".
-    entries: Iterable[EntryPoint] = (
+    entries: Iterable[EntryPoint] = (  # type: ignore
         entry_points(group="can.interface")
         if sys.version_info >= (3, 10)
         else entry_points().get("can.interface", [])

--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -42,11 +42,17 @@ if sys.version_info >= (3, 8):
     # The second variant causes a deprecation warning on Python >= 3.10.
     if sys.version_info >= (3, 10):
         BACKENDS.update(
-            {interface.name: (interface.module, interface.attr) for interface in entry_points(group="can.interface")}
+            {
+                interface.name: (interface.module, interface.attr)
+                for interface in entry_points(group="can.interface")
+            }
         )
     else:
         BACKENDS.update(
-            {interface.name: tuple(interface.value.split(":")) for interface in entry_points().get("can.interface", [])}
+            {
+                interface.name: tuple(interface.value.split(":"))
+                for interface in entry_points().get("can.interface", [])
+            }
         )
 else:
     from pkg_resources import iter_entry_points


### PR DESCRIPTION
- Previously, the `entry_points().get("can.interface", [])}` expression issued the following: `DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.`. This patch fixes it. I also tested it locally. To reproduce the error before the change, simply run `python -W error -c 'import can.interfaces'`.
- Slightly narrows the type of `can.interfaces.BACKENDS` from `Dict[str, Tuple[str, ...]]` to `Dict[str, Tuple[str, str]]`
- Will behave more robust if too many `:` are given in entry-point declaration