### PR TITLE
Unify bit timings with separate class for CAN FD

### DIFF
--- a/can/__init__.py
+++ b/can/__init__.py
@@ -33,7 +33,7 @@ from .notifier import Notifier
 from .interfaces import VALID_INTERFACES
 from . import interface
 from .interface import Bus, detect_available_configs
-from .bit_timing import BitTiming
+from .bit_timing import BitTiming, BitTimingFd
 
 from .io import Logger, SizedRotatingLogger, Printer, LogReader, MessageSync
 from .io import ASCWriter, ASCReader

--- a/can/bit_timing.py
+++ b/can/bit_timing.py
@@ -1,7 +1,9 @@
-from typing import Optional, Union
+from typing import List, Mapping, Iterator, cast
+
+from can.typechecking import BitTimingFdDict, BitTimingDict
 
 
-class BitTiming:
+class BitTiming(Mapping):
     """Representation of a bit timing configuration.
 
     The class can be constructed in various ways, depending on the information
@@ -9,42 +11,28 @@ class BitTiming:
 
     The preferred way is using bitrate, CAN clock frequency, TSEG1, TSEG2, SJW::
 
-        can.BitTiming(bitrate=1000000, f_clock=8000000, tseg1=5, tseg2=1, sjw=1)
+        can.BitTiming(bitrate=1_000_000, f_clock=8_000_000, tseg1=5, tseg2=1, sjw=1)
 
-    If the clock frequency is unknown it may be omitted but some interfaces may
-    require it.
+    It is also possible specify BTR registers directly::
 
-    Alternatively the BRP can be given instead of bitrate and clock frequency but this
-    will limit the number of supported interfaces.
-
-    It is also possible specify BTR registers directly,
-    but will not work for all interfaces::
-
-        can.BitTiming(btr0=0x00, btr1=0x14)
+        can.BitTiming.from_registers(f_clock=8_000_000, btr0=0x00, btr1=0x14)
     """
-
-    sync_seg = 1
 
     def __init__(
         self,
-        bitrate: Optional[int] = None,
-        f_clock: Optional[int] = None,
-        brp: Optional[int] = None,
-        tseg1: Optional[int] = None,
-        tseg2: Optional[int] = None,
-        sjw: Optional[int] = None,
+        f_clock: int,
+        bitrate: int,
+        tseg1: int,
+        tseg2: int,
+        sjw: int,
         nof_samples: int = 1,
-        btr0: Optional[int] = None,
-        btr1: Optional[int] = None,
-    ):
+    ) -> None:
         """
-        :param int bitrate:
-            Bitrate in bits/s.
         :param int f_clock:
             The CAN system clock frequency in Hz.
             Usually the oscillator frequency divided by 2.
-        :param int brp:
-            Bit Rate Prescaler. Prefer to use bitrate and f_clock instead.
+        :param int bitrate:
+            Bitrate in bit/s.
         :param int tseg1:
             Time segment 1, that is, the number of quanta from (but not including)
             the Sync Segment to the sampling point.
@@ -59,59 +47,149 @@ class BitTiming:
             In this case, the bit will be sampled three quanta in a row,
             with the last sample being taken in the edge between TSEG1 and TSEG2.
             Three samples should only be used for relatively slow baudrates.
+
+        """
+        self._data: BitTimingDict = {
+            "f_clock": f_clock,
+            "bitrate": bitrate,
+            "tseg1": tseg1,
+            "tseg2": tseg2,
+            "sjw": sjw,
+            "nof_samples": nof_samples,
+        }
+
+        if not (5_000 <= bitrate <= 2_000_000):
+            raise ValueError(f"bitrate (={bitrate}) must be in [5,000...2,000,000].")
+
+        if not (1 <= tseg1 <= 16):
+            raise ValueError(f"tseg1 (={tseg1}) must be in [1...16].")
+
+        if not (1 <= tseg2 <= 8):
+            raise ValueError(f"tseg2 (={tseg2}) must be in [1...8].")
+
+        nbt = self.nbt
+        if not (8 <= nbt <= 25):
+            raise ValueError(f"nominal bit time (={nbt}) must be in [8...25].")
+
+        brp = self.brp
+        if not (1 <= brp <= 64):
+            raise ValueError(f"bitrate prescaler (={brp}) must be in [1...64].")
+
+        actual_bitrate = f_clock / (nbt * brp)
+        if abs(actual_bitrate - bitrate) > bitrate / 256:
+            raise ValueError(
+                f"the actual bitrate (={actual_bitrate}) diverges "
+                f"from the requested bitrate (={bitrate})"
+            )
+
+        if not (1 <= sjw <= 4):
+            raise ValueError(f"sjw (={sjw}) must be in [1...4].")
+
+        if sjw > tseg2:
+            raise ValueError(f"sjw (={sjw}) must not be greater than tseg2 (={tseg2}).")
+
+        if nof_samples not in (1, 3):
+            raise ValueError("nof_samples must be 1 or 3")
+
+    @classmethod
+    def from_registers(
+        cls,
+        f_clock: int,
+        btr0: int,
+        btr1: int,
+    ) -> "BitTiming":
+        """Create a BitTiming instance from registers btr0 and btr1.
+
+        :param int f_clock:
+            The CAN system clock frequency in Hz.
+            Usually the oscillator frequency divided by 2.
         :param int btr0:
             The BTR0 register value used by many CAN controllers.
         :param int btr1:
             The BTR1 register value used by many CAN controllers.
         """
-        self._bitrate = bitrate
-        self._brp = brp
-        self._sjw = sjw
-        self._tseg1 = tseg1
-        self._tseg2 = tseg2
-        self._nof_samples = nof_samples
-        self._f_clock = f_clock
+        brp = (btr0 & 0x3F) + 1
+        sjw = (btr0 >> 6) + 1
+        tseg1 = (btr1 & 0xF) + 1
+        tseg2 = ((btr1 >> 4) & 0x7) + 1
+        nof_samples = 3 if btr1 & 0x80 else 1
+        bitrate = f_clock // ((1 + tseg1 + tseg2) * brp)
+        return cls(
+            bitrate=bitrate,
+            f_clock=f_clock,
+            tseg1=tseg1,
+            tseg2=tseg2,
+            sjw=sjw,
+            nof_samples=nof_samples,
+        )
 
-        if btr0 is not None:
-            self._brp = (btr0 & 0x3F) + 1
-            self._sjw = (btr0 >> 6) + 1
-        if btr1 is not None:
-            self._tseg1 = (btr1 & 0xF) + 1
-            self._tseg2 = ((btr1 >> 4) & 0x7) + 1
-            self._nof_samples = 3 if btr1 & 0x80 else 1
+    @classmethod
+    def from_sample_point(
+        cls, f_clock: int, bitrate: int, sample_point: float = 69.0
+    ) -> "BitTiming":
+        """Create a BitTiming instance for a sample point.
 
-        if nof_samples not in (1, 3):
-            raise ValueError("nof_samples must be 1 or 3")
+        :param int f_clock:
+            The CAN system clock frequency in Hz.
+            Usually the oscillator frequency divided by 2.
+        :param int bitrate:
+            Bitrate in bit/s.
+        :param int sample_point:
+            The sample point value in percent.
+        """
+
+        if sample_point < 50.0:
+            raise ValueError(f"sample_point (={sample_point}) must not be below 50%.")
+
+        possible_solutions: List[BitTiming] = []
+        for brp in range(1, 65):
+            nbt = round(int(f_clock / (bitrate * brp)))
+            if nbt < 8:
+                continue
+
+            tseg1 = int(round(sample_point / 100 * nbt)) - 1
+            tseg2 = nbt - tseg1 - 1
+
+            for sjw in range(1, 5):
+                try:
+                    bt = BitTiming(
+                        f_clock=f_clock,
+                        bitrate=bitrate,
+                        tseg1=tseg1,
+                        tseg2=tseg2,
+                        sjw=sjw,
+                    )
+                    if abs(bt.sample_point - sample_point) < 1:
+                        possible_solutions.append(bt)
+                except ValueError:
+                    continue
+
+        if not possible_solutions:
+            raise ValueError(f"No suitable bit timings found.")
+
+        return sorted(
+            possible_solutions, key=lambda x: x.oscillator_tolerance, reverse=True
+        )[0]
 
     @property
     def nbt(self) -> int:
         """Nominal Bit Time."""
-        return self.sync_seg + self.tseg1 + self.tseg2
+        return 1 + self.tseg1 + self.tseg2
 
     @property
-    def bitrate(self) -> Union[int, float]:
+    def bitrate(self) -> int:
         """Bitrate in bits/s."""
-        if self._bitrate:
-            return self._bitrate
-        if self._f_clock and self._brp:
-            return self._f_clock / (self._brp * self.nbt)
-        raise ValueError("bitrate must be specified")
+        return self["bitrate"]
 
     @property
     def brp(self) -> int:
         """Bit Rate Prescaler."""
-        if self._brp:
-            return self._brp
-        if self._f_clock and self._bitrate:
-            return round(self._f_clock / (self._bitrate * self.nbt))
-        raise ValueError("Either bitrate and f_clock or brp must be specified")
+        return int(round(self.f_clock / (self.bitrate * self.nbt)))
 
     @property
     def sjw(self) -> int:
         """Synchronization Jump Width."""
-        if not self._sjw:
-            raise ValueError("sjw must be specified")
-        return self._sjw
+        return self["sjw"]
 
     @property
     def tseg1(self) -> int:
@@ -119,9 +197,7 @@ class BitTiming:
 
         The number of quanta from (but not including) the Sync Segment to the sampling point.
         """
-        if not self._tseg1:
-            raise ValueError("tseg1 must be specified")
-        return self._tseg1
+        return self["tseg1"]
 
     @property
     def tseg2(self) -> int:
@@ -129,16 +205,12 @@ class BitTiming:
 
         The number of quanta from the sampling point to the end of the bit.
         """
-        if not self._tseg2:
-            raise ValueError("tseg2 must be specified")
-        return self._tseg2
+        return self["tseg2"]
 
     @property
     def nof_samples(self) -> int:
         """Number of samples (1 or 3)."""
-        if not self._nof_samples:
-            raise ValueError("nof_samples must be specified")
-        return self._nof_samples
+        return self["nof_samples"]
 
     @property
     def f_clock(self) -> int:
@@ -146,48 +218,41 @@ class BitTiming:
 
         Usually the oscillator frequency divided by 2.
         """
-        if not self._f_clock:
-            raise ValueError("f_clock must be specified")
-        return self._f_clock
+        return self["f_clock"]
 
     @property
     def sample_point(self) -> float:
         """Sample point in percent."""
-        return 100.0 * (self.nbt - self.tseg2) / self.nbt
+        return 100.0 * (1 + self.tseg1) / (1 + self.tseg1 + self.tseg2)
+
+    @property
+    def oscillator_tolerance(self) -> float:
+        """Oscillator tolerance in percent."""
+        df_clock_list = [
+            _oscillator_tolerance_criterion_1(nom_sjw=self.sjw, nbt=self.nbt),
+            _oscillator_tolerance_criterion_2(nbt=self.nbt, nom_tseg2=self.tseg2),
+        ]
+        return min(df_clock_list) * 100
 
     @property
     def btr0(self) -> int:
-        sjw = self.sjw
-        brp = self.brp
-
-        if brp < 1 or brp > 64:
-            raise ValueError("brp must be 1 - 64")
-        if sjw < 1 or sjw > 4:
-            raise ValueError("sjw must be 1 - 4")
-
-        return (sjw - 1) << 6 | brp - 1
+        """Bit timing register 0."""
+        return (self.sjw - 1) << 6 | self.brp - 1
 
     @property
     def btr1(self) -> int:
+        """Bit timing register 1."""
         sam = 1 if self.nof_samples == 3 else 0
-        tseg1 = self.tseg1
-        tseg2 = self.tseg2
-
-        if tseg1 < 1 or tseg1 > 16:
-            raise ValueError("tseg1 must be 1 - 16")
-        if tseg2 < 1 or tseg2 > 8:
-            raise ValueError("tseg2 must be 1 - 8")
-
-        return sam << 7 | (tseg2 - 1) << 4 | tseg1 - 1
+        return sam << 7 | (self.tseg2 - 1) << 4 | self.tseg1 - 1
 
     def __str__(self) -> str:
         segments = []
         try:
-            segments.append(f"{self.bitrate} bits/s")
+            segments.append(f"BR {self.bitrate} bit/s")
         except ValueError:
             pass
         try:
-            segments.append(f"sample point: {self.sample_point:.2f}%")
+            segments.append(f"SP: {self.sample_point:.2f}%")
         except ValueError:
             pass
         try:
@@ -210,23 +275,402 @@ class BitTiming:
             segments.append(f"BTR: {self.btr0:02X}{self.btr1:02X}h")
         except ValueError:
             pass
+        try:
+            segments.append(f"f_clock: {self.f_clock / 1e6:.0f}MHz")
+        except ValueError:
+            pass
+        try:
+            segments.append(f"df_clock: {self.oscillator_tolerance:.2f}%")
+        except ValueError:
+            pass
         return ", ".join(segments)
 
     def __repr__(self) -> str:
-        kwargs = {}
-        if self._f_clock:
-            kwargs["f_clock"] = self._f_clock
-        if self._bitrate:
-            kwargs["bitrate"] = self._bitrate
-        if self._brp:
-            kwargs["brp"] = self._brp
-        if self._tseg1:
-            kwargs["tseg1"] = self._tseg1
-        if self._tseg2:
-            kwargs["tseg2"] = self._tseg2
-        if self._sjw:
-            kwargs["sjw"] = self._sjw
-        if self._nof_samples != 1:
-            kwargs["nof_samples"] = self._nof_samples
-        args = ", ".join(f"{key}={value}" for key, value in kwargs.items())
-        return f"can.BitTiming({args})"
+        args = ", ".join(f"{key}={value}" for key, value in self.items())
+        return f"can.{self.__class__.__name__}({args})"
+
+    def __getitem__(self, key: str) -> int:
+        return cast(int, self._data.__getitem__(key))
+
+    def __len__(self) -> int:
+        return self._data.__len__()
+
+    def __iter__(self) -> Iterator[str]:
+        return self._data.__iter__()
+
+
+class BitTimingFd(Mapping):
+    def __init__(
+        self,
+        f_clock: int,
+        nom_bitrate: int,
+        nom_tseg1: int,
+        nom_tseg2: int,
+        nom_sjw: int,
+        data_bitrate: int,
+        data_tseg1: int,
+        data_tseg2: int,
+        data_sjw: int,
+    ) -> None:
+        self._data: BitTimingFdDict = {
+            "f_clock": f_clock,
+            "nom_bitrate": nom_bitrate,
+            "nom_tseg1": nom_tseg1,
+            "nom_tseg2": nom_tseg2,
+            "nom_sjw": nom_sjw,
+            "data_bitrate": data_bitrate,
+            "data_tseg1": data_tseg1,
+            "data_tseg2": data_tseg2,
+            "data_sjw": data_sjw,
+        }
+
+        if not (5_000 <= nom_bitrate <= 2_000_000):
+            raise ValueError(
+                f"nom_bitrate (={nom_bitrate}) must be in [5,000...2,000,000]."
+            )
+
+        if not (25_000 <= data_bitrate <= 8_000_000):
+            raise ValueError(
+                f"data_bitrate (={data_bitrate}) must be in [25,000...8,000,000]."
+            )
+
+        if data_bitrate < nom_bitrate:
+            raise ValueError(
+                f"data_bitrate (={data_bitrate}) must be greater than or equal to nom_bitrate (={nom_bitrate})"
+            )
+
+        if not (2 <= nom_tseg1 <= 256):
+            raise ValueError(f"nom_tseg1 (={nom_tseg1}) must be in [2...256].")
+
+        if not (1 <= nom_tseg2 <= 128):
+            raise ValueError(f"nom_tseg2 (={nom_tseg2}) must be in [1...128].")
+
+        if not (1 <= data_tseg1 <= 32):
+            raise ValueError(f"data_tseg1 (={data_tseg1}) must be in [1...32].")
+
+        if not (1 <= data_tseg2 <= 16):
+            raise ValueError(f"data_tseg2 (={data_tseg2}) must be in [1...16].")
+
+        nbt = self.nbt
+        if nbt < 8:
+            raise ValueError(f"nominal bit time (={nbt}) must be at least 8.")
+
+        dbt = self.dbt
+        if dbt < 8:
+            raise ValueError(f"data bit time (={dbt}) must be at least 8.")
+
+        nom_brp = self.nom_brp
+        if not (1 <= nom_brp <= 256):
+            raise ValueError(
+                f"nominal bitrate prescaler (={nom_brp}) must be in [1...256]."
+            )
+
+        data_brp = self.data_brp
+        if not (1 <= data_brp <= 256):
+            raise ValueError(
+                f"data bitrate prescaler (={data_brp}) must be in [1...256]."
+            )
+
+        actual_nom_bitrate = f_clock / (nbt * nom_brp)
+        if abs(actual_nom_bitrate - nom_bitrate) > nom_bitrate / 256:
+            raise ValueError(
+                f"the actual nominal bitrate (={actual_nom_bitrate}) diverges "
+                f"from the requested bitrate (={nom_bitrate})"
+            )
+
+        actual_data_bitrate = f_clock / (dbt * data_brp)
+        if abs(actual_data_bitrate - data_bitrate) > data_bitrate / 256:
+            raise ValueError(
+                f"the actual data bitrate (={actual_data_bitrate}) diverges "
+                f"from the requested bitrate (={data_bitrate})"
+            )
+
+        if not (1 <= nom_sjw <= 128):
+            raise ValueError(f"nom_sjw (={nom_sjw}) must be in [1...128].")
+
+        if nom_sjw > nom_tseg2:
+            raise ValueError(
+                f"nom_sjw (={nom_sjw}) must not be greater than nom_tseg2 (={nom_tseg2})."
+            )
+
+        if not (1 <= data_sjw <= 16):
+            raise ValueError(f"data_sjw (={data_sjw}) must be in [1...128].")
+
+        if data_sjw > data_tseg2:
+            raise ValueError(
+                f"data_sjw (={data_sjw}) must not be greater than data_tseg2 (={data_tseg2})."
+            )
+
+    @classmethod
+    def from_sample_point(
+        cls,
+        f_clock: int,
+        nom_bitrate: int,
+        nom_sample_point: float,
+        data_bitrate: int,
+        data_sample_point: float,
+    ) -> "BitTimingFd":
+        if nom_sample_point < 50.0:
+            raise ValueError(
+                f"nom_sample_point (={nom_sample_point}) must not be below 50%."
+            )
+
+        if data_sample_point < 50.0:
+            raise ValueError(
+                f"data_sample_point (={data_sample_point}) must not be below 50%."
+            )
+
+        possible_solutions: List[BitTimingFd] = []
+        for nom_brp in range(1, 257):
+            nbt = round(int(f_clock / (nom_bitrate * nom_brp)))
+            if nbt < 8:
+                continue
+
+            nom_tseg1 = int(round(nom_sample_point / 100 * nbt)) - 1
+            nom_tseg2 = nbt - nom_tseg1 - 1
+
+            for nom_sjw in range(1, 129):
+                for data_brp in range(1, 257):
+                    dbt = round(int(f_clock / (data_bitrate * data_brp)))
+                    if dbt < 8:
+                        continue
+
+                    data_tseg1 = int(round(data_sample_point / 100 * dbt)) - 1
+                    data_tseg2 = dbt - data_tseg1 - 1
+
+                    for data_sjw in range(1, 17):
+                        try:
+                            bt = BitTimingFd(
+                                f_clock=f_clock,
+                                nom_bitrate=nom_bitrate,
+                                nom_tseg1=nom_tseg1,
+                                nom_tseg2=nom_tseg2,
+                                nom_sjw=nom_sjw,
+                                data_bitrate=data_bitrate,
+                                data_tseg1=data_tseg1,
+                                data_tseg2=data_tseg2,
+                                data_sjw=data_sjw,
+                            )
+                            if (
+                                abs(bt.nom_sample_point - nom_sample_point) < 1
+                                and abs(bt.data_sample_point - bt.data_sample_point) < 1
+                            ):
+                                possible_solutions.append(bt)
+                        except ValueError:
+                            continue
+
+        if not possible_solutions:
+            raise ValueError(f"No suitable bit timings found.")
+
+        # prefer using the same prescaler for arbitration and data phase
+        same_prescaler = list(
+            filter(lambda x: x.nom_brp == x.data_brp, possible_solutions)
+        )
+        if same_prescaler:
+            possible_solutions = same_prescaler
+
+        # sort solutions: prefer high tolerance, low prescaler and high sjw
+        for key, reverse in (
+            (lambda x: x.data_brp, False),
+            (lambda x: x.nom_brp, False),
+            (lambda x: x.data_sjw, True),
+            (lambda x: x.nom_sjw, True),
+            (lambda x: x.oscillator_tolerance, True),
+        ):
+            possible_solutions.sort(key=key, reverse=reverse)
+
+        return possible_solutions[0]
+
+    @property
+    def nom_bitrate(self) -> int:
+        return self["nom_bitrate"]
+
+    @property
+    def nom_brp(self) -> int:
+        return int(round(self.f_clock / (self.nom_bitrate * self.nbt)))
+
+    @property
+    def nbt(self) -> int:
+        return 1 + self.nom_tseg1 + self.nom_tseg2
+
+    @property
+    def nom_tseg1(self) -> int:
+        return self["nom_tseg1"]
+
+    @property
+    def nom_tseg2(self) -> int:
+        return self["nom_tseg2"]
+
+    @property
+    def nom_sjw(self) -> int:
+        return self["nom_sjw"]
+
+    @property
+    def nom_sample_point(self) -> float:
+        return 100.0 * (1 + self.nom_tseg1) / (1 + self.nom_tseg1 + self.nom_tseg2)
+
+    @property
+    def data_bitrate(self) -> int:
+        return self["data_bitrate"]
+
+    @property
+    def data_brp(self) -> int:
+        return int(round(self.f_clock / (self.data_bitrate * self.dbt)))
+
+    @property
+    def dbt(self) -> int:
+        return 1 + self.data_tseg1 + self.data_tseg2
+
+    @property
+    def data_tseg1(self) -> int:
+        return self["data_tseg1"]
+
+    @property
+    def data_tseg2(self) -> int:
+        return self["data_tseg2"]
+
+    @property
+    def data_sjw(self) -> int:
+        return self["data_sjw"]
+
+    @property
+    def data_sample_point(self) -> float:
+        return 100.0 * (1 + self.data_tseg1) / (1 + self.data_tseg1 + self.data_tseg2)
+
+    @property
+    def f_clock(self) -> int:
+        """The CAN system clock frequency in Hz.
+
+        Usually the oscillator frequency divided by 2.
+        """
+        return self["f_clock"]
+
+    @property
+    def oscillator_tolerance(self) -> float:
+        """Oscillator tolerance in percent."""
+        df_clock_list = [
+            _oscillator_tolerance_criterion_1(nom_sjw=self.nom_sjw, nbt=self.nbt),
+            _oscillator_tolerance_criterion_2(nbt=self.nbt, nom_tseg2=self.nom_tseg2),
+            _oscillator_tolerance_criterion_3(data_sjw=self.data_sjw, dbt=self.dbt),
+            _oscillator_tolerance_criterion_4(
+                data_tseg2=self.data_tseg2,
+                nbt=self.nbt,
+                data_brp=self.data_brp,
+                nom_brp=self.nom_brp,
+            ),
+            _oscillator_tolerance_criterion_5(
+                data_sjw=self.data_sjw,
+                data_brp=self.data_brp,
+                nom_brp=self.nom_brp,
+                data_tseg2=self.data_tseg2,
+                nom_tseg2=self.nom_tseg2,
+                nbt=self.nbt,
+                dbt=self.dbt,
+            ),
+        ]
+        return max(0.0, min(df_clock_list) * 100)
+
+    def __str__(self) -> str:
+        segments = []
+        try:
+            segments.append(f"NBR: {self.nom_bitrate} bit/s")
+        except ValueError:
+            pass
+        try:
+            segments.append(f"NSP: {self.nom_sample_point:.2f}%")
+        except ValueError:
+            pass
+        try:
+            segments.append(f"NBRP: {self.nom_brp}")
+        except ValueError:
+            pass
+        try:
+            segments.append(f"NTSEG1: {self.nom_tseg1}")
+        except ValueError:
+            pass
+        try:
+            segments.append(f"NTSEG2: {self.nom_tseg2}")
+        except ValueError:
+            pass
+        try:
+            segments.append(f"NSJW: {self.nom_sjw}")
+        except ValueError:
+            pass
+        try:
+            segments.append(f"DBR: {self.data_bitrate} bit/s")
+        except ValueError:
+            pass
+        try:
+            segments.append(f"DSP: {self.data_sample_point:.2f}%")
+        except ValueError:
+            pass
+        try:
+            segments.append(f"DBRP: {self.data_brp}")
+        except ValueError:
+            pass
+        try:
+            segments.append(f"DTSEG1: {self.data_tseg1}")
+        except ValueError:
+            pass
+        try:
+            segments.append(f"DTSEG2: {self.data_tseg2}")
+        except ValueError:
+            pass
+        try:
+            segments.append(f"DSJW: {self.data_sjw}")
+        except ValueError:
+            pass
+        try:
+            segments.append(f"f_clock: {self.f_clock / 1e6:.0f}MHz")
+        except ValueError:
+            pass
+        try:
+            segments.append(f"df_clock: {self.oscillator_tolerance:.2f}%")
+        except ValueError:
+            pass
+        return ", ".join(segments)
+
+    def __repr__(self) -> str:
+        args = ", ".join(f"{key}={value}" for key, value in self.items())
+        return f"can.{self.__class__.__name__}({args})"
+
+    def __getitem__(self, key: str) -> int:
+        return cast(int, self._data.__getitem__(key))
+
+    def __len__(self) -> int:
+        return self._data.__len__()
+
+    def __iter__(self) -> Iterator[str]:
+        return self._data.__iter__()
+
+
+def _oscillator_tolerance_criterion_1(nom_sjw: int, nbt: int) -> float:
+    return nom_sjw / (20 * nbt)
+
+
+def _oscillator_tolerance_criterion_2(nbt: int, nom_tseg2: int) -> float:
+    return nom_tseg2 / (2 * (13 * nbt - nom_tseg2))
+
+
+def _oscillator_tolerance_criterion_3(data_sjw: int, dbt: int) -> float:
+    return data_sjw / (20 * dbt)
+
+
+def _oscillator_tolerance_criterion_4(
+    data_tseg2: int, nbt: int, data_brp: int, nom_brp: int
+) -> float:
+    return data_tseg2 / (2 * ((2 * nbt - data_tseg2) * data_brp / nom_brp + 7 * nbt))
+
+
+def _oscillator_tolerance_criterion_5(
+    data_sjw: int,
+    data_brp: int,
+    nom_brp: int,
+    nom_tseg2: int,
+    data_tseg2: int,
+    nbt: int,
+    dbt: int,
+) -> float:
+    return (data_sjw - (nom_brp / data_brp - 1)) / (
+        2 * ((2 * nbt - nom_tseg2) * nom_brp / data_brp + data_tseg2 + 4 * dbt)
+    )

--- a/can/bit_timing.py
+++ b/can/bit_timing.py
@@ -363,10 +363,14 @@ class BitTiming(Mapping):
         """
         # try the most simple solution first: another bitrate prescaler
         try:
-            brp = int(round(self.brp * f_clock / self.f_clock))
-            bt = BitTiming(**{**self, "f_clock": f_clock, "brp": brp})
-            if self.bitrate == bt.bitrate:
-                return bt
+            return BitTiming.from_bitrate_and_segments(
+                f_clock=f_clock,
+                bitrate=self.bitrate,
+                tseg1=self.tseg1,
+                tseg2=self.tseg2,
+                sjw=self.sjw,
+                nof_samples=self.nof_samples,
+            )
         except ValueError:
             pass
 
@@ -947,16 +951,17 @@ class BitTimingFd(Mapping):
         """
         # try the most simple solution first: another bitrate prescaler
         try:
-            nom_brp = int(round(self.nom_brp * f_clock / self.f_clock))
-            data_brp = int(round(self.data_brp * f_clock / self.f_clock))
-            bt = BitTimingFd(
-                **{**self, "f_clock": f_clock, "nom_brp": nom_brp, "data_brp": data_brp}
+            return BitTimingFd.from_bitrate_and_segments(
+                f_clock=f_clock,
+                nom_bitrate=self.nom_bitrate,
+                nom_tseg1=self.nom_tseg1,
+                nom_tseg2=self.nom_tseg2,
+                nom_sjw=self.nom_sjw,
+                data_bitrate=self.data_bitrate,
+                data_tseg1=self.data_tseg1,
+                data_tseg2=self.data_tseg2,
+                data_sjw=self.data_sjw,
             )
-            if (
-                self.nom_bitrate == bt.nom_bitrate
-                and self.data_bitrate == bt.data_bitrate
-            ):
-                return bt
         except ValueError:
             pass
 

--- a/can/bit_timing.py
+++ b/can/bit_timing.py
@@ -299,39 +299,16 @@ class BitTiming(Mapping):
         return sam << 7 | (self.tseg2 - 1) << 4 | self.tseg1 - 1
 
     def __str__(self) -> str:
-        segments = []
-        try:
-            segments.append(f"BR {self.bitrate} bit/s")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"SP: {self.sample_point:.2f}%")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"BRP: {self.brp}")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"TSEG1: {self.tseg1}")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"TSEG2: {self.tseg2}")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"SJW: {self.sjw}")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"BTR: {self.btr0:02X}{self.btr1:02X}h")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"f_clock: {self.f_clock / 1e6:.0f}MHz")
-        except ValueError:
-            pass
+        segments = [
+            f"BR {self.bitrate} bit/s",
+            f"SP: {self.sample_point:.2f}%",
+            f"BRP: {self.brp}",
+            f"TSEG1: {self.tseg1}",
+            f"TSEG2: {self.tseg2}",
+            f"SJW: {self.sjw}",
+            f"BTR: {self.btr0:02X}{self.btr1:02X}h",
+            f"f_clock: {self.f_clock / 1e6:.0f}MHz",
+        ]
         return ", ".join(segments)
 
     def __repr__(self) -> str:
@@ -804,59 +781,21 @@ class BitTimingFd(Mapping):
         return max(0.0, min(df_clock_list) * 100)
 
     def __str__(self) -> str:
-        segments = []
-        try:
-            segments.append(f"NBR: {self.nom_bitrate} bit/s")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"NSP: {self.nom_sample_point:.2f}%")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"NBRP: {self.nom_brp}")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"NTSEG1: {self.nom_tseg1}")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"NTSEG2: {self.nom_tseg2}")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"NSJW: {self.nom_sjw}")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"DBR: {self.data_bitrate} bit/s")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"DSP: {self.data_sample_point:.2f}%")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"DBRP: {self.data_brp}")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"DTSEG1: {self.data_tseg1}")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"DTSEG2: {self.data_tseg2}")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"DSJW: {self.data_sjw}")
-        except ValueError:
-            pass
-        try:
-            segments.append(f"f_clock: {self.f_clock / 1e6:.0f}MHz")
-        except ValueError:
-            pass
+        segments = [
+            f"NBR: {self.nom_bitrate} bit/s",
+            f"NSP: {self.nom_sample_point:.2f}%",
+            f"NBRP: {self.nom_brp}",
+            f"NTSEG1: {self.nom_tseg1}",
+            f"NTSEG2: {self.nom_tseg2}",
+            f"NSJW: {self.nom_sjw}",
+            f"DBR: {self.data_bitrate} bit/s",
+            f"DSP: {self.data_sample_point:.2f}%",
+            f"DBRP: {self.data_brp}",
+            f"DTSEG1: {self.data_tseg1}",
+            f"DTSEG2: {self.data_tseg2}",
+            f"DSJW: {self.data_sjw}",
+            f"f_clock: {self.f_clock / 1e6:.0f}MHz",
+        ]
         return ", ".join(segments)
 
     def __repr__(self) -> str:

--- a/can/interfaces/canalystii.py
+++ b/can/interfaces/canalystii.py
@@ -72,8 +72,7 @@ class CANalystIIBus(BusABC):
             if isinstance(timing, BitTiming):
                 if timing.f_clock != 8_000_000:
                     try:
-                        # try different prescaler values
-                        timing = BitTiming(**{**timing, "f_clock": 8_000_000})
+                        timing = timing.recreate_with_f_clock(8_000_000)
                     except ValueError:
                         raise CanInitializationError(
                             f"timing.f_clock value {timing.f_clock} "

--- a/can/interfaces/canalystii.py
+++ b/can/interfaces/canalystii.py
@@ -21,7 +21,7 @@ class CANalystIIBus(BusABC):
         channel: Union[int, Sequence[int], str] = (0, 1),
         device: int = 0,
         bitrate: Optional[int] = None,
-        timing: Optional[BitTiming] = None,
+        timing: Optional[Union[BitTiming, BitTimingFd]] = None,
         can_filters: Optional[CanFilters] = None,
         rx_queue_size: Optional[int] = None,
         **kwargs: Dict[str, Any],

--- a/can/interfaces/canalystii.py
+++ b/can/interfaces/canalystii.py
@@ -21,7 +21,7 @@ class CANalystIIBus(BusABC):
         channel: Union[int, Sequence[int], str] = (0, 1),
         device: int = 0,
         bitrate: Optional[int] = None,
-        timing: Optional[Union[BitTiming, BitTimingFd]] = None,
+        timing: Optional[BitTiming] = None,
         can_filters: Optional[CanFilters] = None,
         rx_queue_size: Optional[int] = None,
         **kwargs: Dict[str, Any],

--- a/can/interfaces/canalystii.py
+++ b/can/interfaces/canalystii.py
@@ -71,10 +71,14 @@ class CANalystIIBus(BusABC):
         for channel in self.channels:
             if isinstance(timing, BitTiming):
                 if timing.f_clock != 8_000_000:
-                    raise CanInitializationError(
-                        f"timing.f_clock value {timing.f_clock} "
-                        "doesn't match expected device f_clock 8MHz."
-                    )
+                    try:
+                        # try different prescaler values
+                        timing = BitTiming(**{**timing, "f_clock": 8_000_000})
+                    except ValueError:
+                        raise CanInitializationError(
+                            f"timing.f_clock value {timing.f_clock} "
+                            "doesn't match expected device f_clock 8MHz."
+                        ) from None
 
                 self.device.init(channel, timing0=timing.btr0, timing1=timing.btr1)
             elif isinstance(timing, BitTimingFd):

--- a/can/interfaces/canalystii.py
+++ b/can/interfaces/canalystii.py
@@ -15,7 +15,9 @@ logger = logging.getLogger(__name__)
 
 
 class CANalystIIBus(BusABC):
-    @deprecated_args_alias(bit_timing="timing")
+    @deprecated_args_alias(
+        deprecation_start="4.2.0", deprecation_end="5.0.0", bit_timing="timing"
+    )
     def __init__(
         self,
         channel: Union[int, Sequence[int], str] = (0, 1),

--- a/can/interfaces/cantact.py
+++ b/can/interfaces/cantact.py
@@ -44,7 +44,9 @@ class CantactBus(BusABC):
             channels.append({"interface": "cantact", "channel": f"ch:{i}"})
         return channels
 
-    @deprecated_args_alias(bit_timing="timing")
+    @deprecated_args_alias(
+        deprecation_start="4.2.0", deprecation_end="5.0.0", bit_timing="timing"
+    )
     def __init__(
         self,
         channel: int,

--- a/can/interfaces/cantact.py
+++ b/can/interfaces/cantact.py
@@ -88,10 +88,14 @@ class CantactBus(BusABC):
         with error_check("Cannot setup the cantact.Interface", CanInitializationError):
             if isinstance(timing, BitTiming):
                 if timing.f_clock != 24_000_000:
-                    raise CanInitializationError(
-                        f"timing.f_clock value {timing.f_clock} "
-                        "doesn't match expected device f_clock 24MHz."
-                    )
+                    try:
+                        # try different prescaler values
+                        timing = BitTiming(**{**timing, "f_clock": 24_000_000})
+                    except ValueError:
+                        raise CanInitializationError(
+                            f"timing.f_clock value {timing.f_clock} "
+                            "doesn't match expected device f_clock 24MHz."
+                        ) from None
                 # use custom bit timing
                 self.interface.set_bit_timing(
                     int(channel),

--- a/can/interfaces/cantact.py
+++ b/can/interfaces/cantact.py
@@ -74,7 +74,8 @@ class CantactBus(BusABC):
         else:
             if cantact is None:
                 raise CanInterfaceNotImplementedError(
-                    "The CANtact module is not installed. Install it using `python -m pip install cantact`"
+                    "The CANtact module is not installed. "
+                    "Install it using `python -m pip install cantact`"
                 )
             with error_check(
                 "Cannot create the cantact.Interface", CanInitializationError
@@ -89,8 +90,7 @@ class CantactBus(BusABC):
             if isinstance(timing, BitTiming):
                 if timing.f_clock != 24_000_000:
                     try:
-                        # try different prescaler values
-                        timing = BitTiming(**{**timing, "f_clock": 24_000_000})
+                        timing = timing.recreate_with_f_clock(24_000_000)
                     except ValueError:
                         raise CanInitializationError(
                             f"timing.f_clock value {timing.f_clock} "

--- a/can/interfaces/cantact.py
+++ b/can/interfaces/cantact.py
@@ -13,7 +13,7 @@ from ..exceptions import (
     CanInterfaceNotImplementedError,
     error_check,
 )
-from ..util import deprecated_args_alias
+from ..util import deprecated_args_alias, check_or_adjust_timing_clock
 
 logger = logging.getLogger(__name__)
 
@@ -88,14 +88,8 @@ class CantactBus(BusABC):
         # Configure the interface
         with error_check("Cannot setup the cantact.Interface", CanInitializationError):
             if isinstance(timing, BitTiming):
-                if timing.f_clock != 24_000_000:
-                    try:
-                        timing = timing.recreate_with_f_clock(24_000_000)
-                    except ValueError:
-                        raise CanInitializationError(
-                            f"timing.f_clock value {timing.f_clock} "
-                            "doesn't match expected device f_clock 24MHz."
-                        ) from None
+                timing = check_or_adjust_timing_clock(timing, valid_clocks=[24_000_000])
+
                 # use custom bit timing
                 self.interface.set_bit_timing(
                     int(channel),

--- a/can/interfaces/cantact.py
+++ b/can/interfaces/cantact.py
@@ -48,7 +48,7 @@ class CantactBus(BusABC):
     def __init__(
         self,
         channel: int,
-        bitrate: int = 500000,
+        bitrate: int = 500_000,
         poll_interval: float = 0.01,
         monitor: bool = False,
         timing: Optional[Union[BitTiming, BitTimingFd]] = None,

--- a/can/typechecking.py
+++ b/can/typechecking.py
@@ -48,3 +48,24 @@ class AutoDetectedConfig(typing_extensions.TypedDict):
 
 
 ReadableBytesLike = typing.Union[bytes, bytearray, memoryview]
+
+
+class BitTimingDict(typing_extensions.TypedDict):
+    f_clock: int
+    bitrate: int
+    tseg1: int
+    tseg2: int
+    sjw: int
+    nof_samples: int
+
+
+class BitTimingFdDict(typing_extensions.TypedDict):
+    f_clock: int
+    nom_bitrate: int
+    nom_tseg1: int
+    nom_tseg2: int
+    nom_sjw: int
+    data_bitrate: int
+    data_tseg1: int
+    data_tseg2: int
+    data_sjw: int

--- a/can/typechecking.py
+++ b/can/typechecking.py
@@ -52,7 +52,7 @@ ReadableBytesLike = typing.Union[bytes, bytearray, memoryview]
 
 class BitTimingDict(typing_extensions.TypedDict):
     f_clock: int
-    bitrate: int
+    brp: int
     tseg1: int
     tseg2: int
     sjw: int
@@ -61,11 +61,11 @@ class BitTimingDict(typing_extensions.TypedDict):
 
 class BitTimingFdDict(typing_extensions.TypedDict):
     f_clock: int
-    nom_bitrate: int
+    nom_brp: int
     nom_tseg1: int
     nom_tseg2: int
     nom_sjw: int
-    data_bitrate: int
+    data_brp: int
     data_tseg1: int
     data_tseg2: int
     data_sjw: int

--- a/can/util.py
+++ b/can/util.py
@@ -238,23 +238,24 @@ def _create_bus_config(config: Dict[str, Any]) -> typechecking.BusConfig:
         if not 0 < port < 65535:
             raise ValueError("Port config must be inside 0-65535 range!")
 
-    try:
-        if set(typechecking.BitTimingFdDict.__annotations__).issubset(set(config)):
-            config["timing"] = can.BitTimingFd(
-                **{
-                    key: int(config[key])
-                    for key in typechecking.BitTimingFdDict.__annotations__
-                }
-            )
-        elif set(typechecking.BitTimingDict.__annotations__).issubset(set(config)):
-            config["timing"] = can.BitTiming(
-                **{
-                    key: int(config[key])
-                    for key in typechecking.BitTimingDict.__annotations__
-                }
-            )
-    except (ValueError, TypeError):
-        pass
+    if config.get("timing", None) is None:
+        try:
+            if set(typechecking.BitTimingFdDict.__annotations__).issubset(config):
+                config["timing"] = can.BitTimingFd(
+                    **{
+                        key: int(config[key])
+                        for key in typechecking.BitTimingFdDict.__annotations__
+                    }
+                )
+            elif set(typechecking.BitTimingDict.__annotations__).issubset(config):
+                config["timing"] = can.BitTiming(
+                    **{
+                        key: int(config[key])
+                        for key in typechecking.BitTimingDict.__annotations__
+                    }
+                )
+        except (ValueError, TypeError):
+            pass
 
     if "bitrate" in config:
         config["bitrate"] = int(config["bitrate"])

--- a/can/util.py
+++ b/can/util.py
@@ -227,12 +227,22 @@ def _create_bus_config(config: Dict[str, Any]) -> typechecking.BusConfig:
             raise ValueError("Port config must be inside 0-65535 range!")
 
     try:
-        config["timing"] = can.BitTimingFd(**config)
+        if set(typechecking.BitTimingFdDict.__annotations__).issubset(set(config)):
+            config["timing"] = can.BitTimingFd(
+                **{
+                    key: int(config[key])
+                    for key in typechecking.BitTimingFdDict.__annotations__
+                }
+            )
+        elif set(typechecking.BitTimingDict.__annotations__).issubset(set(config)):
+            config["timing"] = can.BitTiming(
+                **{
+                    key: int(config[key])
+                    for key in typechecking.BitTimingDict.__annotations__
+                }
+            )
     except (ValueError, TypeError):
-        try:
-            config["timing"] = can.BitTiming(**config)
-        except (ValueError, TypeError):
-            pass
+        pass
 
     if "bitrate" in config:
         config["bitrate"] = int(config["bitrate"])

--- a/can/util.py
+++ b/can/util.py
@@ -226,6 +226,14 @@ def _create_bus_config(config: Dict[str, Any]) -> typechecking.BusConfig:
         if not 0 < port < 65535:
             raise ValueError("Port config must be inside 0-65535 range!")
 
+    try:
+        config["timing"] = can.BitTimingFd(**config)
+    except (ValueError, TypeError):
+        try:
+            config["timing"] = can.BitTiming(**config)
+        except (ValueError, TypeError):
+            pass
+
     if "bitrate" in config:
         config["bitrate"] = int(config["bitrate"])
     if "fd" in config:

--- a/doc/bit_timing.rst
+++ b/doc/bit_timing.rst
@@ -92,8 +92,10 @@ Check :doc:`configuration` for more information about saving and loading configu
     :class-doc-from: both
     :show-inheritance:
     :members:
+    :member-order: bysource
 
 .. autoclass:: can.BitTimingFd
     :class-doc-from: both
     :show-inheritance:
     :members:
+    :member-order: bysource

--- a/doc/bit_timing.rst
+++ b/doc/bit_timing.rst
@@ -12,9 +12,9 @@ of the communication system and the physical communication channel.
 
 These parameters include:
 
-* **tseg1**: The time segment (TSEG1) is the amount of time from the start
-  of the bit until the sample point. It is expressed in time quanta (TQ).
-* **tseg2**: The time segment (TSEG2) is the amount of time from the
+* **tseg1**: The time segment 1 (TSEG1) is the amount of time from the end
+  of the sync segment until the sample point. It is expressed in time quanta (TQ).
+* **tseg2**: The time segment 2 (TSEG2) is the amount of time from the
   sample point until the end of the bit. It is expressed in TQ.
 * **sjw**: The synchronization jump width (SJW) is the maximum number
   of TQ that the controller can resynchronize every bit.
@@ -39,19 +39,27 @@ leaving 2 TQ for the information processing by the bus nodes.
    different bit rates. As a result, there are two separate sample points
    to consider.
 
+Another important parameter is **f_clock**: The CAN system clock frequency
+in Hz. This frequency is used to derive the TQ size from the bit rate.
+The relationship is ``f_clock = (tseg1+tseg2+1) * bitrate * brp``.
+The bit rate prescaler value (``brp``) is usually determined by the controller
+and is chosen to ensure that the resulting bit time is an integer value.
+Typical CAN clock frequencies are 8-80 MHz.
+
 In most cases, the recommended settings for a predefined set of common
 bit rates will work just fine. In some cases, however, it may be necessary
 to specify custom bit timings. The :class:`can.BitTiming` and
 :class:`can.BitTimingFd` classes can be used for this purpose to specify
 bit timings in a relatively interface agnostic manner.
 
-It is possible to specify the same settings for a CAN 2.0 bus
+It is possible to specify CAN 2.0 bit timings
 using the config file:
 
 
 .. code-block:: none
 
     [default]
+    interface=canalystii
     f_clock=8000000
     bitrate=1000000
     tseg1=5
@@ -64,6 +72,7 @@ The same is possible for CAN FD:
 .. code-block:: none
 
     [default]
+    interface=pcan
     f_clock=80000000
     nom_bitrate=500000
     nom_tseg1=119
@@ -73,6 +82,8 @@ The same is possible for CAN FD:
     data_tseg1=29
     data_tseg2=10
     data_sjw=10
+
+Check :doc:`configuration` for more information about saving and loading configurations.
 
 
 .. autoclass:: can.BitTiming

--- a/doc/bit_timing.rst
+++ b/doc/bit_timing.rst
@@ -48,8 +48,8 @@ Typical CAN clock frequencies are 8-80 MHz.
 
 In most cases, the recommended settings for a predefined set of common
 bit rates will work just fine. In some cases, however, it may be necessary
-to specify custom bit timings. The :class:`can.BitTiming` and
-:class:`can.BitTimingFd` classes can be used for this purpose to specify
+to specify custom bit timings. The :class:`~can.BitTiming` and
+:class:`~can.BitTimingFd` classes can be used for this purpose to specify
 bit timings in a relatively interface agnostic manner.
 
 It is possible to specify CAN 2.0 bit timings
@@ -59,7 +59,6 @@ using the config file:
 .. code-block:: none
 
     [default]
-    interface=canalystii
     f_clock=8000000
     bitrate=1000000
     tseg1=5
@@ -72,7 +71,6 @@ The same is possible for CAN FD:
 .. code-block:: none
 
     [default]
-    interface=pcan
     f_clock=80000000
     nom_bitrate=500000
     nom_tseg1=119
@@ -82,6 +80,10 @@ The same is possible for CAN FD:
     data_tseg1=29
     data_tseg2=10
     data_sjw=10
+
+A :class:`dict` of the relevant config parameters can be easily obtained by calling
+``dict(timing)`` or ``{**timing}`` where ``timing`` is the :class:`~can.BitTiming` or
+:class:`~can.BitTimingFd` instance.
 
 Check :doc:`configuration` for more information about saving and loading configurations.
 

--- a/doc/bit_timing.rst
+++ b/doc/bit_timing.rst
@@ -44,6 +44,7 @@ using the config file:
 
 .. autoclass:: can.BitTiming
 
+.. autoclass:: can.BitTimingFd
 
 .. _Wikipedia: https://en.wikipedia.org/wiki/CAN_bus#Bit_timing
 .. _Kvaser: https://www.kvaser.com/about-can/the-can-protocol/can-bit-timing/

--- a/doc/bit_timing.rst
+++ b/doc/bit_timing.rst
@@ -84,6 +84,3 @@ The same is possible for CAN FD:
     :class-doc-from: both
     :show-inheritance:
     :members:
-
-.. _Wikipedia: https://en.wikipedia.org/wiki/CAN_bus#Bit_timing
-.. _Kvaser: https://www.kvaser.com/about-can/the-can-protocol/can-bit-timing/

--- a/doc/bit_timing.rst
+++ b/doc/bit_timing.rst
@@ -42,7 +42,7 @@ leaving 2 TQ for the information processing by the bus nodes.
 Another important parameter is **f_clock**: The CAN system clock frequency
 in Hz. This frequency is used to derive the TQ size from the bit rate.
 The relationship is ``f_clock = (tseg1+tseg2+1) * bitrate * brp``.
-The bit rate prescaler value (``brp``) is usually determined by the controller
+The bit rate prescaler value **brp** is usually determined by the controller
 and is chosen to ensure that the resulting bit time is an integer value.
 Typical CAN clock frequencies are 8-80 MHz.
 
@@ -60,7 +60,7 @@ using the config file:
 
     [default]
     f_clock=8000000
-    bitrate=1000000
+    brp=1
     tseg1=5
     tseg2=2
     sjw=1
@@ -72,11 +72,11 @@ The same is possible for CAN FD:
 
     [default]
     f_clock=80000000
-    nom_bitrate=500000
+    nom_brp=1
     nom_tseg1=119
     nom_tseg2=40
     nom_sjw=40
-    data_bitrate=2000000
+    data_brp=1
     data_tseg1=29
     data_tseg2=10
     data_sjw=10

--- a/doc/bit_timing.rst
+++ b/doc/bit_timing.rst
@@ -27,7 +27,7 @@ These parameters include:
 For example, consider a bit with a total duration of 8 TQ and a sample
 point at 75%. The values for TSEG1, TSEG2 and SJW would be 5, 2, and 2,
 respectively. The sample point would be 6 TQ after the start of the bit,
-leaving 2 TQ for the signal to stabilize before the end of the bit.
+leaving 2 TQ for the information processing by the bus nodes.
 
 .. note::
    The values for TSEG1, TSEG2 and SJW are chosen such that the

--- a/doc/bit_timing.rst
+++ b/doc/bit_timing.rst
@@ -24,6 +24,17 @@ These parameters include:
   The sample point depends on the bus length and propagation time as well
   as the information processing time of the nodes.
 
+.. figure:: images/bit_timing_light.svg
+   :align: center
+   :class: only-light
+
+.. figure:: images/bit_timing_dark.svg
+   :align: center
+   :class: only-dark
+
+   Bit Timing and Sample Point
+
+
 For example, consider a bit with a total duration of 8 TQ and a sample
 point at 75%. The values for TSEG1, TSEG2 and SJW would be 5, 2, and 2,
 respectively. The sample point would be 6 TQ after the start of the bit,

--- a/doc/bit_timing.rst
+++ b/doc/bit_timing.rst
@@ -1,50 +1,89 @@
 Bit Timing Configuration
 ========================
 
-The CAN protocol allows the bitrate, sample point and number of samples to be
-optimized for a given application. You can read more on Wikipedia_, Kvaser_
-and other sources.
+.. attention::
+    This feature is experimental. The implementation might change in future
+    versions.
 
-In most cases the recommended settings for a predefined set of common
-bitrates will work just fine. In some cases it may however be necessary to specify
-custom settings. The :class:`can.BitTiming` class can be used for this purpose to
-specify them in a relatively interface agnostic manner.
+The CAN protocol, specified in ISO 11898, allows the bitrate, sample point
+and number of samples to be optimized for a given application. These
+parameters, known as bit timings, can be adjusted to meet the requirements
+of the communication system and the physical communication channel.
 
-It is also possible to specify the same settings for a CAN 2.0 bus
+These parameters include:
+
+* **tseg1**: The time segment (TSEG1) is the amount of time from the start
+  of the bit until the sample point. It is expressed in time quanta (TQ).
+* **tseg2**: The time segment (TSEG2) is the amount of time from the
+  sample point until the end of the bit. It is expressed in TQ.
+* **sjw**: The synchronization jump width (SJW) is the maximum number
+  of TQ that the controller can resynchronize every bit.
+* **sample point**: The sample point is defined as the point in time
+  within a bit where the bus controller samples the bus for dominant or
+  recessive levels. It is typically expressed as a percentage of the bit time.
+  The sample point depends on the bus length and propagation time as well
+  as the information processing time of the nodes.
+
+For example, consider a bit with a total duration of 8 TQ and a sample
+point at 75%. The values for TSEG1, TSEG2 and SJW would be 5, 2, and 2,
+respectively. The sample point would be 6 TQ after the start of the bit,
+leaving 2 TQ for the signal to stabilize before the end of the bit.
+
+.. note::
+   The values for TSEG1, TSEG2 and SJW are chosen such that the
+   sample point is at least 50% of the total bit time. This ensures that
+   there is sufficient time for the signal to stabilize before it is sampled.
+
+.. note::
+   In CAN FD, the arbitration (nominal) phase and the data phase can have
+   different bit rates. As a result, there are two separate sample points
+   to consider.
+
+In most cases, the recommended settings for a predefined set of common
+bit rates will work just fine. In some cases, however, it may be necessary
+to specify custom bit timings. The :class:`can.BitTiming` and
+:class:`can.BitTimingFd` classes can be used for this purpose to specify
+bit timings in a relatively interface agnostic manner.
+
+It is possible to specify the same settings for a CAN 2.0 bus
 using the config file:
 
 
 .. code-block:: none
 
     [default]
-    bitrate=1000000
     f_clock=8000000
+    bitrate=1000000
     tseg1=5
     tseg2=2
     sjw=1
     nof_samples=1
 
+The same is possible for CAN FD:
 
 .. code-block:: none
 
     [default]
-    brp=1
-    tseg1=5
-    tseg2=2
-    sjw=1
-    nof_samples=1
-
-
-.. code-block:: none
-
-    [default]
-    btr0=0x00
-    btr1=0x14
+    f_clock=80000000
+    nom_bitrate=500000
+    nom_tseg1=119
+    nom_tseg2=40
+    nom_sjw=40
+    data_bitrate=2000000
+    data_tseg1=29
+    data_tseg2=10
+    data_sjw=10
 
 
 .. autoclass:: can.BitTiming
+    :class-doc-from: both
+    :show-inheritance:
+    :members:
 
 .. autoclass:: can.BitTimingFd
+    :class-doc-from: both
+    :show-inheritance:
+    :members:
 
 .. _Wikipedia: https://en.wikipedia.org/wiki/CAN_bus#Bit_timing
 .. _Kvaser: https://www.kvaser.com/about-can/the-can-protocol/can-bit-timing/

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -125,6 +125,7 @@ nitpick_ignore = [
     ("py:class", "can.typechecking.CanFilter"),
     ("py:class", "can.typechecking.CanFilterExtended"),
     ("py:class", "can.typechecking.AutoDetectedConfig"),
+    ("py:class", "can.util.T"),
     # intersphinx fails to reference some builtins
     ("py:class", "asyncio.events.AbstractEventLoop"),
     ("py:class", "_thread.allocate_lock"),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -120,6 +120,7 @@ autodoc_typehints = "description"
 # disable specific warnings
 nitpick_ignore = [
     # Ignore warnings for type aliases. Remove once Sphinx supports PEP613
+    ("py:class", "BusConfig"),
     ("py:class", "can.typechecking.BusConfig"),
     ("py:class", "can.typechecking.CanFilter"),
     ("py:class", "can.typechecking.CanFilterExtended"),

--- a/doc/images/bit_timing_dark.svg
+++ b/doc/images/bit_timing_dark.svg
@@ -1,0 +1,96 @@
+<svg width="2136" height="641" xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink" overflow="hidden">
+    <defs>
+        <clipPath id="clip0">
+            <rect x="550" y="423" width="2136" height="641" />
+        </clipPath>
+    </defs>
+    <g clip-path="url(#clip0)" transform="translate(-550 -423)">
+        <path
+            d="M578.5 735.834C578.5 725.708 586.708 717.5 596.834 717.5L820.166 717.5C830.292 717.5 838.5 725.708 838.5 735.834L838.5 809.166C838.5 819.292 830.292 827.5 820.166 827.5L596.834 827.5C586.708 827.5 578.5 819.292 578.5 809.166Z"
+            stroke="#FFFFFF" stroke-opacity="0.2" stroke-width="6.875" stroke-miterlimit="8"
+            fill="#595959"
+            fill-rule="evenodd" />
+        <text fill="#FFFFFF" font-family="Calibri,Calibri_MSFontService,sans-serif"
+            font-weight="400" font-size="46" transform="matrix(1 0 0 1 624.561 787)">sync_seg</text>
+        <path
+            d="M838.5 735.834C838.5 725.708 846.708 717.5 856.834 717.5L1600.17 717.5C1610.29 717.5 1618.5 725.708 1618.5 735.834L1618.5 809.166C1618.5 819.291 1610.29 827.5 1600.17 827.5L856.834 827.5C846.708 827.5 838.5 819.291 838.5 809.166Z"
+            stroke="#FFFFFF" stroke-opacity="0.2" stroke-width="6.875" stroke-miterlimit="8"
+            fill="#70AD47"
+            fill-rule="evenodd" />
+        <text fill="#FFFFFF" font-family="Calibri,Calibri_MSFontService,sans-serif"
+            font-weight="400" font-size="46" transform="matrix(1 0 0 1 1141.09 787)">prop_seg</text>
+        <path
+            d="M1618.5 735.833C1618.5 725.708 1626.71 717.5 1636.83 717.5L2119.17 717.5C2129.29 717.5 2137.5 725.708 2137.5 735.833L2137.5 809.166C2137.5 819.292 2129.29 827.5 2119.17 827.5L1636.83 827.5C1626.71 827.5 1618.5 819.292 1618.5 809.166Z"
+            stroke="#FFFFFF" stroke-opacity="0.2" stroke-width="6.875" stroke-miterlimit="8"
+            fill="#ED7D31"
+            fill-rule="evenodd" />
+        <text fill="#FFFFFF" font-family="Calibri,Calibri_MSFontService,sans-serif"
+            font-weight="400" font-size="46" transform="matrix(1 0 0 1 1767.78 787)">phase_seg1</text>
+        <path
+            d="M2137.5 735.834C2137.5 725.708 2145.71 717.5 2155.83 717.5L2639.17 717.5C2649.29 717.5 2657.5 725.708 2657.5 735.834L2657.5 809.166C2657.5 819.292 2649.29 827.5 2639.17 827.5L2155.83 827.5C2145.71 827.5 2137.5 819.292 2137.5 809.166Z"
+            stroke="#FFFFFF" stroke-opacity="0.2" stroke-width="6.875" stroke-miterlimit="8"
+            fill="#4472C4"
+            fill-rule="evenodd" />
+        <text fill="#FFFFFF" font-family="Calibri,Calibri_MSFontService,sans-serif"
+            font-weight="400" font-size="46" transform="matrix(1 0 0 1 2287.47 787)">phase_seg2</text>
+        <path d="M0 0 0.000360892 343.918" stroke="#FFFFFF" stroke-width="10.3125"
+            stroke-miterlimit="8" fill="none" fill-rule="evenodd"
+            transform="matrix(1 0 0 -1 578 771.918)" />
+        <path d="M0 0 0.000360892 343.918" stroke="#FFFFFF" stroke-width="10.3125"
+            stroke-miterlimit="8" fill="none" fill-rule="evenodd"
+            transform="matrix(1 0 0 -1 2657 771.918)" />
+        <text font-family="Calibri,Calibri_MSFontService,sans-serif" font-weight="400"
+            font-size="46" fill="#FFFFFF" transform="matrix(1 0 0 1 1485.98 487)">Nominal Bit Time</text>
+        <path
+            d="M1.4341e-06-3.4375 842.134-3.43715 842.134 3.43785-1.4341e-06 3.4375ZM837.551-13.7497 865.051 0.000360892 837.551 13.7503Z"
+            transform="matrix(-1 0 0 1 1443.55 472.5)" fill="#FFFFFF" />
+        <path
+            d="M1849.5 469.063 2634.15 469.063 2634.15 475.938 1849.5 475.938ZM2629.57 458.75 2657.07 472.501 2629.57 486.25Z"
+            fill="#FFFFFF" />
+        <path d="M0 0 0.000360892 215.959" stroke="#FFFFFF" stroke-width="10.3125"
+            stroke-miterlimit="8" fill="none" fill-rule="evenodd"
+            transform="matrix(1 0 0 -1 578 987.959)" />
+        <path d="M0 0 0.000360892 215.959" stroke="#FFFFFF" stroke-width="10.3125"
+            stroke-miterlimit="8" fill="none" fill-rule="evenodd"
+            transform="matrix(1 0 0 -1 838 987.959)" />
+        <path d="M0 0 0.000360892 215.959" stroke="#FFFFFF" stroke-width="10.3125"
+            stroke-miterlimit="8" fill="none" fill-rule="evenodd"
+            transform="matrix(1 0 0 -1 838 771.959)" />
+        <path d="M0 0 0.000360892 215.669" stroke="#FFFFFF" stroke-width="10.3125"
+            stroke-miterlimit="8" fill="none" fill-rule="evenodd"
+            transform="matrix(1 0 0 -1 2137 771.669)" />
+        <text font-family="Calibri,Calibri_MSFontService,sans-serif" font-weight="400"
+            font-size="46" fill="#FFFFFF" transform="matrix(1 0 0 1 1437.03 642)">tseg1</text>
+        <path
+            d="M2.27942e-06-3.4375 521.33-3.43715 521.33 3.43785-2.27942e-06 3.4375ZM516.747-13.7497 544.247 0.000360892 516.747 13.7503Z"
+            transform="matrix(-1 0 0 1 1382.75 627.5)" fill="#FFFFFF" />
+        <path
+            d="M1593.5 624.062 2114.83 624.063 2114.83 630.938 1593.5 630.937ZM2110.25 613.75 2137.75 627.5 2110.25 641.25Z"
+            fill="#FFFFFF" />
+        <text font-family="Calibri,Calibri_MSFontService,sans-serif" font-weight="400"
+            font-size="46" fill="#FFFFFF" transform="matrix(1 0 0 1 2346.48 642)">tseg2</text>
+        <path
+            d="M8.02342e-06-3.4375 131.702-3.43719 131.702 3.43781-8.02342e-06 3.4375ZM127.118-13.7497 154.618 0.000360892 127.118 13.7503Z"
+            transform="matrix(-1 0 0 1 2292.12 627.5)" fill="#FFFFFF" />
+        <path
+            d="M2503.5 624.062 2635.07 624.063 2635.07 630.938 2503.5 630.937ZM2630.48 613.75 2657.98 627.5 2630.48 641.25Z"
+            fill="#FFFFFF" />
+        <text font-family="Calibri,Calibri_MSFontService,sans-serif" font-weight="400"
+            font-size="46" fill="#FFFFFF" transform="matrix(1 0 0 1 664.665 944)">1 TQ</text>
+        <path
+            d="M2.38056e-05-3.4375 29.1959-3.4373 29.1958 3.4377-2.38056e-05 3.4375ZM24.6126-13.7498 52.1125 0.000360892 24.6124 13.7502Z"
+            transform="matrix(-1 0 0 1 630.613 929.5)" fill="#FFFFFF" />
+        <path
+            d="M786.5 926.062 815.696 926.063 815.696 932.938 786.5 932.938ZM811.113 915.75 838.612 929.5 811.112 943.25Z"
+            fill="#FFFFFF" />
+        <path
+            d="M5.15625-1.43952e-05 5.15654 103.488-5.15596 103.488-5.15625 1.43952e-05ZM15.469 98.3316 0.000360892 129.269-15.4685 98.3317Z"
+            transform="matrix(1 0 0 -1 2137 960.269)" fill="#FFFFFF" />
+        <text font-family="Calibri,Calibri_MSFontService,sans-serif" font-weight="400"
+            font-size="46" fill="#FFFFFF" transform="matrix(1 0 0 1 1970.05 1024)">75% Sample Point</text>
+        <path d="M0 0 0.000360892 215.959" stroke="#FFFFFF" stroke-width="10.3125"
+            stroke-miterlimit="8" fill="none" fill-rule="evenodd"
+            transform="matrix(1 0 0 -1 2657 987.959)" />
+    </g>
+</svg>

--- a/doc/images/bit_timing_light.svg
+++ b/doc/images/bit_timing_light.svg
@@ -1,0 +1,92 @@
+<svg width="2136" height="641" xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink" overflow="hidden">
+    <defs>
+        <clipPath id="clip0">
+            <rect x="550" y="423" width="2136" height="641" />
+        </clipPath>
+    </defs>
+    <g clip-path="url(#clip0)" transform="translate(-550 -423)">
+        <path
+            d="M578.5 735.834C578.5 725.708 586.708 717.5 596.834 717.5L820.166 717.5C830.292 717.5 838.5 725.708 838.5 735.834L838.5 809.166C838.5 819.292 830.292 827.5 820.166 827.5L596.834 827.5C586.708 827.5 578.5 819.292 578.5 809.166Z"
+            stroke="#FFFFFF" stroke-opacity="0.2" stroke-width="6.875" stroke-miterlimit="8"
+            fill="#595959"
+            fill-rule="evenodd" />
+        <text fill="#FFFFFF" font-family="Calibri,Calibri_MSFontService,sans-serif"
+            font-weight="400" font-size="46" transform="matrix(1 0 0 1 624.561 787)">sync_seg</text>
+        <path
+            d="M838.5 735.834C838.5 725.708 846.708 717.5 856.834 717.5L1600.17 717.5C1610.29 717.5 1618.5 725.708 1618.5 735.834L1618.5 809.166C1618.5 819.291 1610.29 827.5 1600.17 827.5L856.834 827.5C846.708 827.5 838.5 819.291 838.5 809.166Z"
+            stroke="#FFFFFF" stroke-opacity="0.2" stroke-width="6.875" stroke-miterlimit="8"
+            fill="#70AD47"
+            fill-rule="evenodd" />
+        <text fill="#FFFFFF" font-family="Calibri,Calibri_MSFontService,sans-serif"
+            font-weight="400" font-size="46" transform="matrix(1 0 0 1 1141.09 787)">prop_seg</text>
+        <path
+            d="M1618.5 735.833C1618.5 725.708 1626.71 717.5 1636.83 717.5L2119.17 717.5C2129.29 717.5 2137.5 725.708 2137.5 735.833L2137.5 809.166C2137.5 819.292 2129.29 827.5 2119.17 827.5L1636.83 827.5C1626.71 827.5 1618.5 819.292 1618.5 809.166Z"
+            stroke="#FFFFFF" stroke-opacity="0.2" stroke-width="6.875" stroke-miterlimit="8"
+            fill="#ED7D31"
+            fill-rule="evenodd" />
+        <text fill="#FFFFFF" font-family="Calibri,Calibri_MSFontService,sans-serif"
+            font-weight="400" font-size="46" transform="matrix(1 0 0 1 1767.78 787)">phase_seg1</text>
+        <path
+            d="M2137.5 735.834C2137.5 725.708 2145.71 717.5 2155.83 717.5L2639.17 717.5C2649.29 717.5 2657.5 725.708 2657.5 735.834L2657.5 809.166C2657.5 819.292 2649.29 827.5 2639.17 827.5L2155.83 827.5C2145.71 827.5 2137.5 819.292 2137.5 809.166Z"
+            stroke="#FFFFFF" stroke-opacity="0.2" stroke-width="6.875" stroke-miterlimit="8"
+            fill="#4472C4"
+            fill-rule="evenodd" />
+        <text fill="#FFFFFF" font-family="Calibri,Calibri_MSFontService,sans-serif"
+            font-weight="400" font-size="46" transform="matrix(1 0 0 1 2287.47 787)">phase_seg2</text>
+        <path d="M0 0 0.000360892 343.918" stroke="#000000" stroke-width="10.3125"
+            stroke-miterlimit="8" fill="none" fill-rule="evenodd"
+            transform="matrix(1 0 0 -1 578 771.918)" />
+        <path d="M0 0 0.000360892 343.918" stroke="#000000" stroke-width="10.3125"
+            stroke-miterlimit="8" fill="none" fill-rule="evenodd"
+            transform="matrix(1 0 0 -1 2657 771.918)" />
+        <text font-family="Calibri,Calibri_MSFontService,sans-serif" font-weight="400"
+            font-size="46" transform="matrix(1 0 0 1 1485.98 487)">Nominal Bit Time</text>
+        <path
+            d="M1.4341e-06-3.4375 842.134-3.43715 842.134 3.43785-1.4341e-06 3.4375ZM837.551-13.7497 865.051 0.000360892 837.551 13.7503Z"
+            transform="matrix(-1 0 0 1 1443.55 472.5)" />
+        <path
+            d="M1849.5 469.063 2634.15 469.063 2634.15 475.938 1849.5 475.938ZM2629.57 458.75 2657.07 472.501 2629.57 486.25Z" />
+        <path d="M0 0 0.000360892 215.959" stroke="#000000" stroke-width="10.3125"
+            stroke-miterlimit="8" fill="none" fill-rule="evenodd"
+            transform="matrix(1 0 0 -1 578 987.959)" />
+        <path d="M0 0 0.000360892 215.959" stroke="#000000" stroke-width="10.3125"
+            stroke-miterlimit="8" fill="none" fill-rule="evenodd"
+            transform="matrix(1 0 0 -1 838 987.959)" />
+        <path d="M0 0 0.000360892 215.959" stroke="#000000" stroke-width="10.3125"
+            stroke-miterlimit="8" fill="none" fill-rule="evenodd"
+            transform="matrix(1 0 0 -1 838 771.959)" />
+        <path d="M0 0 0.000360892 215.669" stroke="#000000" stroke-width="10.3125"
+            stroke-miterlimit="8" fill="none" fill-rule="evenodd"
+            transform="matrix(1 0 0 -1 2137 771.669)" />
+        <text font-family="Calibri,Calibri_MSFontService,sans-serif" font-weight="400"
+            font-size="46" transform="matrix(1 0 0 1 1437.03 642)">tseg1</text>
+        <path
+            d="M2.27942e-06-3.4375 521.33-3.43715 521.33 3.43785-2.27942e-06 3.4375ZM516.747-13.7497 544.247 0.000360892 516.747 13.7503Z"
+            transform="matrix(-1 0 0 1 1382.75 627.5)" />
+        <path
+            d="M1593.5 624.062 2114.83 624.063 2114.83 630.938 1593.5 630.937ZM2110.25 613.75 2137.75 627.5 2110.25 641.25Z" />
+        <text font-family="Calibri,Calibri_MSFontService,sans-serif" font-weight="400"
+            font-size="46" transform="matrix(1 0 0 1 2346.48 642)">tseg2</text>
+        <path
+            d="M8.02342e-06-3.4375 131.702-3.43719 131.702 3.43781-8.02342e-06 3.4375ZM127.118-13.7497 154.618 0.000360892 127.118 13.7503Z"
+            transform="matrix(-1 0 0 1 2292.12 627.5)" />
+        <path
+            d="M2503.5 624.062 2635.07 624.063 2635.07 630.938 2503.5 630.937ZM2630.48 613.75 2657.98 627.5 2630.48 641.25Z" />
+        <text font-family="Calibri,Calibri_MSFontService,sans-serif" font-weight="400"
+            font-size="46" transform="matrix(1 0 0 1 664.665 944)">1 TQ</text>
+        <path
+            d="M2.38056e-05-3.4375 29.1959-3.4373 29.1958 3.4377-2.38056e-05 3.4375ZM24.6126-13.7498 52.1125 0.000360892 24.6124 13.7502Z"
+            transform="matrix(-1 0 0 1 630.613 929.5)" />
+        <path
+            d="M786.5 926.062 815.696 926.063 815.696 932.938 786.5 932.938ZM811.113 915.75 838.612 929.5 811.112 943.25Z" />
+        <path
+            d="M5.15625-1.43952e-05 5.15654 103.488-5.15596 103.488-5.15625 1.43952e-05ZM15.469 98.3316 0.000360892 129.269-15.4685 98.3317Z"
+            transform="matrix(1 0 0 -1 2137 960.269)" />
+        <text font-family="Calibri,Calibri_MSFontService,sans-serif" font-weight="400"
+            font-size="46" transform="matrix(1 0 0 1 1970.05 1024)">75% Sample Point</text>
+        <path d="M0 0 0.000360892 215.959" stroke="#000000" stroke-width="10.3125"
+            stroke-miterlimit="8" fill="none" fill-rule="evenodd"
+            transform="matrix(1 0 0 -1 2657 987.959)" />
+    </g>
+</svg>

--- a/test/test_bit_timing.py
+++ b/test/test_bit_timing.py
@@ -92,6 +92,19 @@ def test_from_btr():
     assert timing.btr1 == 0x14
 
 
+
+import struct
+from can.interfaces.pcan.pcan import PCAN_BITRATES
+
+def test_btr_persistence():
+    f_clock = 8_000_000
+    for btr0btr1 in PCAN_BITRATES.values():
+        btr1, btr0 = struct.unpack("BB", btr0btr1)
+
+        t = can.BitTiming.from_registers(f_clock, btr0, btr1)
+        assert t.btr0 == btr0
+        assert t.btr1 == btr1
+
 def test_from_sample_point():
     timing = can.BitTiming.from_sample_point(
         f_clock=16_000_000,

--- a/test/test_bit_timing.py
+++ b/test/test_bit_timing.py
@@ -48,34 +48,39 @@ def test_sja1000():
 
 
 def test_can_fd():
-    timing = can.BitTiming(
-        f_clock=80000000, bitrate=500000, tseg1=119, tseg2=40, sjw=40
+    timing = can.BitTimingFd(
+        f_clock=80_000_000,
+        nom_bitrate=500_000,
+        nom_tseg1=119,
+        nom_tseg2=40,
+        nom_sjw=40,
+        data_bitrate=2_000_000,
+        data_tseg1=29,
+        data_tseg2=10,
+        data_sjw=10,
     )
-    assert timing.f_clock == 80000000
-    assert timing.bitrate == 500000
-    assert timing.brp == 1
-    assert timing.nbt == 160
-    assert timing.tseg1 == 119
-    assert timing.tseg2 == 40
-    assert timing.sjw == 40
-    assert timing.sample_point == 75
 
-    timing = can.BitTiming(
-        f_clock=80000000, bitrate=2000000, tseg1=29, tseg2=10, sjw=10
-    )
-    assert timing.f_clock == 80000000
-    assert timing.bitrate == 2000000
-    assert timing.brp == 1
-    assert timing.nbt == 40
-    assert timing.tseg1 == 29
-    assert timing.tseg2 == 10
-    assert timing.sjw == 10
-    assert timing.sample_point == 75
+    assert timing.f_clock == 80_000_000
+    assert timing.nom_bitrate == 500_000
+    assert timing.nom_brp == 1
+    assert timing.nbt == 160
+    assert timing.nom_tseg1 == 119
+    assert timing.nom_tseg2 == 40
+    assert timing.nom_sjw == 40
+    assert timing.nom_sample_point == 75
+    assert timing.f_clock == 80_000_000
+    assert timing.data_bitrate == 2_000_000
+    assert timing.data_brp == 1
+    assert timing.dbt == 40
+    assert timing.data_tseg1 == 29
+    assert timing.data_tseg2 == 10
+    assert timing.data_sjw == 10
+    assert timing.data_sample_point == 75
 
 
 def test_from_btr():
-    timing = can.BitTiming(f_clock=8000000, btr0=0x00, btr1=0x14)
-    assert timing.bitrate == 1000000
+    timing = can.BitTiming.from_registers(f_clock=8_000_000, btr0=0x00, btr1=0x14)
+    assert timing.bitrate == 1_000_000
     assert timing.brp == 1
     assert timing.nbt == 8
     assert timing.tseg1 == 5
@@ -88,7 +93,7 @@ def test_from_btr():
 
 def test_string_representation():
     timing = can.BitTiming(f_clock=8000000, bitrate=1000000, tseg1=5, tseg2=2, sjw=1)
-    assert (
-        str(timing)
-        == "1000000 bits/s, sample point: 75.00%, BRP: 1, TSEG1: 5, TSEG2: 2, SJW: 1, BTR: 0014h"
+    assert str(timing) == (
+        "BR 1000000 bit/s, SP: 75.00%, BRP: 1, TSEG1: 5, TSEG2: 2, SJW: 1, "
+        "BTR: 0014h, f_clock: 8MHz, df_clock: 0.62%"
     )

--- a/test/test_bit_timing.py
+++ b/test/test_bit_timing.py
@@ -92,9 +92,9 @@ def test_from_btr():
     assert timing.btr1 == 0x14
 
 
-
 import struct
 from can.interfaces.pcan.pcan import PCAN_BITRATES
+
 
 def test_btr_persistence():
     f_clock = 8_000_000
@@ -104,6 +104,7 @@ def test_btr_persistence():
         t = can.BitTiming.from_registers(f_clock, btr0, btr1)
         assert t.btr0 == btr0
         assert t.btr1 == btr1
+
 
 def test_from_sample_point():
     timing = can.BitTiming.from_sample_point(

--- a/test/test_bit_timing.py
+++ b/test/test_bit_timing.py
@@ -114,6 +114,23 @@ def test_from_sample_point():
     assert fd_timing.data_bitrate == 8_000_000
     assert 69 < fd_timing.data_sample_point < 71
 
+    # check that there is a solution for every sample point
+    for sp in range(50, 100):
+        can.BitTiming.from_sample_point(
+            f_clock=16_000_000, bitrate=500_000, sample_point=sp
+        )
+
+    # check that there is a solution for every sample point
+    for nsp in range(50, 100):
+        for dsp in range(50, 100):
+            can.BitTimingFd.from_sample_point(
+                f_clock=80_000_000,
+                nom_bitrate=500_000,
+                nom_sample_point=nsp,
+                data_bitrate=2_000_000,
+                data_sample_point=dsp,
+            )
+
 
 def test_equality():
     t1 = can.BitTiming.from_registers(f_clock=8_000_000, btr0=0x00, btr1=0x14)
@@ -166,5 +183,22 @@ def test_string_representation():
     timing = can.BitTiming(f_clock=8000000, bitrate=1000000, tseg1=5, tseg2=2, sjw=1)
     assert str(timing) == (
         "BR 1000000 bit/s, SP: 75.00%, BRP: 1, TSEG1: 5, TSEG2: 2, SJW: 1, "
-        "BTR: 0014h, f_clock: 8MHz, df_clock: 0.62%"
+        "BTR: 0014h, f_clock: 8MHz"
+    )
+
+    fd_timing = can.BitTimingFd(
+        f_clock=80_000_000,
+        nom_bitrate=500_000,
+        nom_tseg1=119,
+        nom_tseg2=40,
+        nom_sjw=40,
+        data_bitrate=2_000_000,
+        data_tseg1=29,
+        data_tseg2=10,
+        data_sjw=10,
+    )
+    assert str(fd_timing) == (
+        "NBR: 500000 bit/s, NSP: 75.00%, NBRP: 1, NTSEG1: 119, NTSEG2: 40, NSJW: 40, "
+        "DBR: 2000000 bit/s, DSP: 75.00%, DBRP: 1, DTSEG1: 29, DTSEG2: 10, DSJW: 10, "
+        "f_clock: 80MHz"
     )

--- a/test/test_bit_timing.py
+++ b/test/test_bit_timing.py
@@ -91,6 +91,77 @@ def test_from_btr():
     assert timing.btr1 == 0x14
 
 
+def test_from_sample_point():
+    timing = can.BitTiming.from_sample_point(
+        f_clock=16_000_000,
+        bitrate=500_000,
+        sample_point=69.0,
+    )
+    assert timing.f_clock == 16_000_000
+    assert timing.bitrate == 500_000
+    assert 68 < timing.sample_point < 70
+
+    fd_timing = can.BitTimingFd.from_sample_point(
+        f_clock=80_000_000,
+        nom_bitrate=1_000_000,
+        nom_sample_point=75.0,
+        data_bitrate=8_000_000,
+        data_sample_point=70.0,
+    )
+    assert fd_timing.f_clock == 80_000_000
+    assert fd_timing.nom_bitrate == 1_000_000
+    assert 74 < fd_timing.nom_sample_point < 76
+    assert fd_timing.data_bitrate == 8_000_000
+    assert 69 < fd_timing.data_sample_point < 71
+
+
+def test_equality():
+    t1 = can.BitTiming.from_registers(f_clock=8_000_000, btr0=0x00, btr1=0x14)
+    t2 = can.BitTiming(
+        f_clock=8_000_000, bitrate=1_000_000, tseg1=5, tseg2=2, sjw=1, nof_samples=1
+    )
+    t3 = can.BitTiming(
+        f_clock=16_000_000, bitrate=1_000_000, tseg1=5, tseg2=2, sjw=1, nof_samples=1
+    )
+    assert t1 == t2
+    assert t1 != t3
+    assert t2 != t3
+    assert t1 != 10
+
+    t4 = can.BitTimingFd(
+        f_clock=80_000_000,
+        nom_bitrate=500_000,
+        nom_tseg1=119,
+        nom_tseg2=40,
+        nom_sjw=40,
+        data_bitrate=2_000_000,
+        data_tseg1=29,
+        data_tseg2=10,
+        data_sjw=10,
+    )
+    t5 = can.BitTimingFd(
+        f_clock=80_000_000,
+        nom_bitrate=500_000,
+        nom_tseg1=119,
+        nom_tseg2=40,
+        nom_sjw=40,
+        data_bitrate=2_000_000,
+        data_tseg1=29,
+        data_tseg2=10,
+        data_sjw=10,
+    )
+    t6 = can.BitTimingFd.from_sample_point(
+        f_clock=80_000_000,
+        nom_bitrate=1_000_000,
+        nom_sample_point=75.0,
+        data_bitrate=8_000_000,
+        data_sample_point=70.0,
+    )
+    assert t4 == t5
+    assert t4 != t6
+    assert t4 != t1
+
+
 def test_string_representation():
     timing = can.BitTiming(f_clock=8000000, bitrate=1000000, tseg1=5, tseg2=2, sjw=1)
     assert str(timing) == (

--- a/test/test_bit_timing.py
+++ b/test/test_bit_timing.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import pytest
 
 import can
 
@@ -202,3 +203,90 @@ def test_string_representation():
         "DBR: 2000000 bit/s, DSP: 75.00%, DBRP: 1, DTSEG1: 29, DTSEG2: 10, DSJW: 10, "
         "f_clock: 80MHz"
     )
+
+
+def test_repr():
+    timing = can.BitTiming(f_clock=8000000, bitrate=1000000, tseg1=5, tseg2=2, sjw=1)
+    assert repr(timing) == (
+        "can.BitTiming(f_clock=8000000, bitrate=1000000, tseg1=5, tseg2=2, sjw=1, nof_samples=1)"
+    )
+
+    fd_timing = can.BitTimingFd(
+        f_clock=80_000_000,
+        nom_bitrate=500_000,
+        nom_tseg1=119,
+        nom_tseg2=40,
+        nom_sjw=40,
+        data_bitrate=2_000_000,
+        data_tseg1=29,
+        data_tseg2=10,
+        data_sjw=10,
+    )
+    assert repr(fd_timing) == (
+        "can.BitTimingFd(f_clock=80000000, nom_bitrate=500000, nom_tseg1=119, nom_tseg2=40, "
+        "nom_sjw=40, data_bitrate=2000000, data_tseg1=29, data_tseg2=10, data_sjw=10)"
+    )
+
+
+def test_mapping():
+    timing = can.BitTiming(
+        f_clock=8_000_000, bitrate=1_000_000, tseg1=5, tseg2=2, sjw=1
+    )
+    timing_dict = dict(timing)
+    assert timing_dict["f_clock"] == timing["f_clock"]
+    assert timing_dict["bitrate"] == timing["bitrate"]
+    assert timing_dict["tseg1"] == timing["tseg1"]
+    assert timing_dict["tseg2"] == timing["tseg2"]
+    assert timing_dict["sjw"] == timing["sjw"]
+    assert timing == can.BitTiming(**timing_dict)
+
+    fd_timing = can.BitTimingFd(
+        f_clock=80_000_000,
+        nom_bitrate=500_000,
+        nom_tseg1=119,
+        nom_tseg2=40,
+        nom_sjw=40,
+        data_bitrate=2_000_000,
+        data_tseg1=29,
+        data_tseg2=10,
+        data_sjw=10,
+    )
+    fd_timing_dict = dict(fd_timing)
+    assert fd_timing_dict["f_clock"] == fd_timing["f_clock"]
+    assert fd_timing_dict["nom_bitrate"] == fd_timing["nom_bitrate"]
+    assert fd_timing_dict["nom_tseg1"] == fd_timing["nom_tseg1"]
+    assert fd_timing_dict["nom_tseg2"] == fd_timing["nom_tseg2"]
+    assert fd_timing_dict["nom_sjw"] == fd_timing["nom_sjw"]
+    assert fd_timing_dict["data_bitrate"] == fd_timing["data_bitrate"]
+    assert fd_timing_dict["data_tseg1"] == fd_timing["data_tseg1"]
+    assert fd_timing_dict["data_tseg2"] == fd_timing["data_tseg2"]
+    assert fd_timing_dict["data_sjw"] == fd_timing["data_sjw"]
+    assert fd_timing == can.BitTimingFd(**fd_timing_dict)
+
+
+def test_oscillator_tolerance():
+    timing = can.BitTiming(
+        f_clock=16_000_000, bitrate=500_000, tseg1=10, tseg2=5, sjw=4
+    )
+    osc_tol = timing.oscillator_tolerance(
+        node_loop_delay_ns=250,
+        bus_length_m=10.0,
+    )
+    assert osc_tol == pytest.approx(1.23, abs=1e-2)
+
+    fd_timing = can.BitTimingFd(
+        f_clock=80_000_000,
+        nom_bitrate=500_000,
+        nom_tseg1=27,
+        nom_tseg2=4,
+        nom_sjw=4,
+        data_bitrate=2_000_000,
+        data_tseg1=6,
+        data_tseg2=1,
+        data_sjw=1,
+    )
+    osc_tol = fd_timing.oscillator_tolerance(
+        node_loop_delay_ns=250,
+        bus_length_m=10.0,
+    )
+    assert osc_tol == pytest.approx(0.48543689320388345, abs=1e-2)

--- a/test/test_bit_timing.py
+++ b/test/test_bit_timing.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
+
+import struct
+
 import pytest
 
 import can
+from can.interfaces.pcan.pcan import PCAN_BITRATES
 
 
 def test_sja1000():
@@ -90,10 +94,6 @@ def test_from_btr():
     assert timing.sample_point == 75
     assert timing.btr0 == 0x00
     assert timing.btr1 == 0x14
-
-
-import struct
-from can.interfaces.pcan.pcan import PCAN_BITRATES
 
 
 def test_btr_persistence():

--- a/test/test_cantact.py
+++ b/test/test_cantact.py
@@ -23,9 +23,7 @@ class CantactTest(unittest.TestCase):
     def test_bus_creation_bittiming(self):
         cantact.MockInterface.set_bitrate.reset_mock()
 
-        bt = can.BitTiming(
-            f_clock=24_000_000, bitrate=500_000, tseg1=13, tseg2=2, sjw=1
-        )
+        bt = can.BitTiming(f_clock=24_000_000, brp=3, tseg1=13, tseg2=2, sjw=1)
         bus = can.Bus(channel=0, interface="cantact", timing=bt, _testing=True)
         self.assertIsInstance(bus, cantact.CantactBus)
         cantact.MockInterface.set_bitrate.assert_not_called()

--- a/test/test_cantact.py
+++ b/test/test_cantact.py
@@ -23,8 +23,10 @@ class CantactTest(unittest.TestCase):
     def test_bus_creation_bittiming(self):
         cantact.MockInterface.set_bitrate.reset_mock()
 
-        bt = can.BitTiming(tseg1=13, tseg2=2, brp=6, sjw=1)
-        bus = can.Bus(channel=0, interface="cantact", bit_timing=bt, _testing=True)
+        bt = can.BitTiming(
+            f_clock=24_000_000, bitrate=500_000, tseg1=13, tseg2=2, sjw=1
+        )
+        bus = can.Bus(channel=0, interface="cantact", timing=bt, _testing=True)
         self.assertIsInstance(bus, cantact.CantactBus)
         cantact.MockInterface.set_bitrate.assert_not_called()
         cantact.MockInterface.set_bit_timing.assert_called()

--- a/test/test_interface_canalystii.py
+++ b/test/test_interface_canalystii.py
@@ -39,8 +39,10 @@ class CanalystIITest(unittest.TestCase):
     def test_initialize_with_timing_registers(self):
         with create_mock_device() as mock_device:
             instance = mock_device.return_value
-            timing = can.BitTiming(btr0=0x03, btr1=0x6F)
-            bus = CANalystIIBus(bitrate=None, bit_timing=timing)
+            timing = can.BitTiming.from_registers(
+                f_clock=8_000_000, btr0=0x03, btr1=0x6F
+            )
+            bus = CANalystIIBus(bitrate=None, timing=timing)
             instance.init.assert_has_calls(
                 [
                     call(0, timing0=0x03, timing1=0x6F),
@@ -50,14 +52,8 @@ class CanalystIITest(unittest.TestCase):
 
     def test_missing_bitrate(self):
         with self.assertRaises(ValueError) as cm:
-            bus = CANalystIIBus(0, bitrate=None, bit_timing=None)
+            bus = CANalystIIBus(0, bitrate=None, timing=None)
         self.assertIn("bitrate", str(cm.exception))
-
-    def test_invalid_bit_timing(self):
-        with create_mock_device() as mock_device:
-            with self.assertRaises(ValueError) as cm:
-                invalid_timings = can.BitTiming()
-                CANalystIIBus(0, bit_timing=invalid_timings)
 
     def test_receive_message(self):
         driver_message = driver.Message(


### PR DESCRIPTION
This is a continuation of #614 and #615. I would like to hear your opinions before i waste my time on writing tests and docs.

I made the following changes:

- Create a separate class for CANFD. In my opinion the bit timing requirements for CAN2.0 and CANFD are just too different to use the same class for both.
- Validate bit timings in `__init__` method
- Add multiple constructors to avoid too many optional parameters. It is now possible to create an instance though `BitTiming(**kwargs)`, `BitTiming.from_registers(**kwargs)` and `BitTiming.from_sample_point(**kwargs)`
- The bit timing classes inherit from `typing.Mapping`. Now the user can call `dict(timing)` to get a dictionary of the bit timing parameters. This should make it easier to save the parameters to a config file.
- Solve the configuration loading problems of #1460

Interface implementations should add a single parameter like `timing: Union[BitTiming, BitTimingFd]`. It would take precedence over other parameters and provide a simple API for the user. The docstring of the parameter should tell the users which values for `f_clock` are accepted.