### PR TITLE
Add deprecation period to deprecated_args_alias

### DIFF
--- a/can/interface.py
+++ b/can/interface.py
@@ -100,8 +100,11 @@ class Bus(BusABC):  # pylint: disable=abstract-method
     """
 
     @staticmethod
-    @util.deprecated_args_alias(  # Deprecated since python-can 4.2
-        bustype="interface", context="config_context"
+    @util.deprecated_args_alias(
+        deprecation_start="4.2.0",
+        deprecation_end="5.0.0",
+        bustype="interface",
+        context="config_context",
     )
     def __new__(  # type: ignore
         cls: Any,

--- a/can/interfaces/ixxat/canlib_vcinpl.py
+++ b/can/interfaces/ixxat/canlib_vcinpl.py
@@ -417,6 +417,8 @@ class IXXATBus(BusABC):
     }
 
     @deprecated_args_alias(
+        deprecation_start="4.0.0",
+        deprecation_end="5.0.0",
         UniqueHardwareId="unique_hardware_id",
         rxFifoSize="rx_fifo_size",
         txFifoSize="tx_fifo_size",

--- a/can/interfaces/ixxat/canlib_vcinpl2.py
+++ b/can/interfaces/ixxat/canlib_vcinpl2.py
@@ -417,6 +417,8 @@ class IXXATBus(BusABC):
     """
 
     @deprecated_args_alias(
+        deprecation_start="4.0.0",
+        deprecation_end="5.0.0",
         UniqueHardwareId="unique_hardware_id",
         rxFifoSize="rx_fifo_size",
         txFifoSize="tx_fifo_size",

--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -75,7 +75,11 @@ class VectorBus(BusABC):
         tseg2Dbr="tseg2_dbr",
     )
 
-    @deprecated_args_alias(**deprecated_args)
+    @deprecated_args_alias(
+        deprecation_start="4.0.0",
+        deprecation_end="5.0.0",
+        **deprecated_args,
+    )
     def __init__(
         self,
         channel: Union[int, Sequence[int], str],

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -3,17 +3,26 @@
 import unittest
 import warnings
 
-from can.util import _create_bus_config, _rename_kwargs, channel2int
+import pytest
+
+from can.util import (
+    _create_bus_config,
+    _rename_kwargs,
+    channel2int,
+    deprecated_args_alias,
+)
 
 
 class RenameKwargsTest(unittest.TestCase):
     expected_kwargs = dict(a=1, b=2, c=3, d=4)
 
-    def _test(self, kwargs, aliases):
+    def _test(self, start: str, end: str, kwargs, aliases):
 
         # Test that we do get the DeprecationWarning when called with deprecated kwargs
-        with self.assertWarnsRegex(DeprecationWarning, "is deprecated"):
-            _rename_kwargs("unit_test", kwargs, aliases)
+        with self.assertWarnsRegex(
+            DeprecationWarning, "is deprecated.*?" + start + ".*?" + end
+        ):
+            _rename_kwargs("unit_test", start, end, kwargs, aliases)
 
         # Test that the aliases contains the deprecated values and
         # the obsolete kwargs have been removed
@@ -25,30 +34,98 @@ class RenameKwargsTest(unittest.TestCase):
         # Cause all warnings to always be triggered.
         warnings.simplefilter("error", DeprecationWarning)
         try:
-            _rename_kwargs("unit_test", kwargs, aliases)
+            _rename_kwargs("unit_test", start, end, kwargs, aliases)
         finally:
             warnings.resetwarnings()
 
     def test_rename(self):
         kwargs = dict(old_a=1, old_b=2, c=3, d=4)
         aliases = {"old_a": "a", "old_b": "b"}
-        self._test(kwargs, aliases)
+        self._test("1.0", "2.0", kwargs, aliases)
 
     def test_obsolete(self):
         kwargs = dict(a=1, b=2, c=3, d=4, z=10)
         aliases = {"z": None}
-        self._test(kwargs, aliases)
+        self._test("1.0", "2.0", kwargs, aliases)
 
     def test_rename_and_obsolete(self):
         kwargs = dict(old_a=1, old_b=2, c=3, d=4, z=10)
         aliases = {"old_a": "a", "old_b": "b", "z": None}
-        self._test(kwargs, aliases)
+        self._test("1.0", "2.0", kwargs, aliases)
 
     def test_with_new_and_alias_present(self):
         kwargs = dict(old_a=1, a=1, b=2, c=3, d=4, z=10)
         aliases = {"old_a": "a", "old_b": "b", "z": None}
         with self.assertRaises(TypeError):
-            self._test(kwargs, aliases)
+            self._test("1.0", "2.0", kwargs, aliases)
+
+
+class DeprecatedArgsAliasTest(unittest.TestCase):
+    def test_decorator(self):
+        @deprecated_args_alias("1.0.0", old_a="a")
+        def _test_func1(a):
+            pass
+
+        with pytest.warns(DeprecationWarning) as record:
+            _test_func1(old_a=1)
+            assert len(record) == 1
+            assert (
+                record[0].message.args[0]
+                == "The 'old_a' argument is deprecated since python-can v1.0.0. Use 'a' instead."
+            )
+
+        @deprecated_args_alias("1.6.0", "3.4.0", old_a="a", old_b=None)
+        def _test_func2(a):
+            pass
+
+        with pytest.warns(DeprecationWarning) as record:
+            _test_func2(old_a=1, old_b=2)
+            assert len(record) == 2
+            assert record[0].message.args[0] == (
+                "The 'old_a' argument is deprecated since python-can v1.6.0, and scheduled for "
+                "removal in python-can v3.4.0. Use 'a' instead."
+            )
+            assert record[1].message.args[0] == (
+                "The 'old_b' argument is deprecated since python-can v1.6.0, and scheduled for "
+                "removal in python-can v3.4.0."
+            )
+
+        @deprecated_args_alias("1.6.0", "3.4.0", old_a="a")
+        @deprecated_args_alias("2.0.0", "4.0.0", old_b=None)
+        def _test_func3(a):
+            pass
+
+        with pytest.warns(DeprecationWarning) as record:
+            _test_func3(old_a=1, old_b=2)
+            assert len(record) == 2
+            assert record[0].message.args[0] == (
+                "The 'old_a' argument is deprecated since python-can v1.6.0, and scheduled "
+                "for removal in python-can v3.4.0. Use 'a' instead."
+            )
+            assert record[1].message.args[0] == (
+                "The 'old_b' argument is deprecated since python-can v2.0.0, and scheduled "
+                "for removal in python-can v4.0.0."
+            )
+
+        with pytest.warns(DeprecationWarning) as record:
+            _test_func3(old_a=1)
+            assert len(record) == 1
+            assert record[0].message.args[0] == (
+                "The 'old_a' argument is deprecated since python-can v1.6.0, and scheduled "
+                "for removal in python-can v3.4.0. Use 'a' instead."
+            )
+
+        with pytest.warns(DeprecationWarning) as record:
+            _test_func3(a=1, old_b=2)
+            assert len(record) == 1
+            assert record[0].message.args[0] == (
+                "The 'old_b' argument is deprecated since python-can v2.0.0, and scheduled "
+                "for removal in python-can v4.0.0."
+            )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _test_func3(a=1)
 
 
 class TestBusConfig(unittest.TestCase):


### PR DESCRIPTION
I added two parameters to `deprecated_args_alias` so the warning looks like this:

> The 'old_a' argument is deprecated since python-can v1.6.0, and scheduled for removal in python-can v3.4.0. Use 'a' instead.

@pierreluctg @felixdivo What do you think?