### PR TITLE
Use ip link JSON output for SocketCAN find_available_interfaces

### DIFF
--- a/can/interfaces/socketcan/utils.py
+++ b/can/interfaces/socketcan/utils.py
@@ -3,15 +3,15 @@ Defines common socketcan functions.
 """
 
 import errno
+import json
 import logging
 import os
-import re
 import struct
 import subprocess
-from typing import cast, Iterable, Optional
+from typing import cast, Optional, List
 
-from can.interfaces.socketcan.constants import CAN_EFF_FLAG
 from can import typechecking
+from can.interfaces.socketcan.constants import CAN_EFF_FLAG
 
 log = logging.getLogger(__name__)
 
@@ -38,34 +38,29 @@ def pack_filters(can_filters: Optional[typechecking.CanFilters] = None) -> bytes
     return struct.pack(can_filter_fmt, *filter_data)
 
 
-_PATTERN_CAN_INTERFACE = re.compile(r"(sl|v|vx)?can\d+")
+def find_available_interfaces() -> List[str]:
+    """Returns the names of all open can/vcan interfaces
 
-
-def find_available_interfaces() -> Iterable[str]:
-    """Returns the names of all open can/vcan interfaces using
-    the ``ip link list`` command. If the lookup fails, an error
+    The function calls the ``ip link list`` command. If the lookup fails, an error
     is logged to the console and an empty list is returned.
+
+    :return: The list of available and active CAN interfaces or an empty list of the command failed
     """
 
     try:
-        # adding "type vcan" would exclude physical can devices
-        command = ["ip", "-o", "link", "list", "up"]
-        output = subprocess.check_output(command, text=True)
-
+        command = ["ip", "-json", "link", "list", "up"]
+        output_str = subprocess.check_output(command, text=True)
     except Exception as e:  # subprocess.CalledProcessError is too specific
-        log.error("failed to fetch opened can devices: %s", e)
+        log.exception("failed to fetch opened can devices from ip link")
         return []
 
-    else:
-        # log.debug("find_available_interfaces(): output=\n%s", output)
-        # output contains some lines like "1: vcan42: <NOARP,UP,LOWER_UP> ..."
-        # extract the "vcan42" of each line
-        interfaces = [line.split(": ", 3)[1] for line in output.splitlines()]
-        log.debug(
-            "find_available_interfaces(): detected these interfaces (before filtering): %s",
-            interfaces,
-        )
-        return filter(_PATTERN_CAN_INTERFACE.match, interfaces)
+    output_json = json.loads(output_str)
+    log.debug(
+        f"find_available_interfaces(): detected these interfaces (before filtering): {output_str}"
+    )
+
+    interfaces = [i["ifname"] for i in output_json if i["link_type"] == "can"]
+    return interfaces
 
 
 def error_code_to_str(code: Optional[int]) -> str:

--- a/can/interfaces/socketcan/utils.py
+++ b/can/interfaces/socketcan/utils.py
@@ -50,13 +50,18 @@ def find_available_interfaces() -> List[str]:
     try:
         command = ["ip", "-json", "link", "list", "up"]
         output_str = subprocess.check_output(command, text=True)
-    except Exception as e:  # subprocess.CalledProcessError is too specific
+    except Exception:  # subprocess.CalledProcessError is too specific
         log.exception("failed to fetch opened can devices from ip link")
         return []
 
-    output_json = json.loads(output_str)
+    try:
+        output_json = json.loads(output_str)
+    except json.JSONDecodeError:
+        log.exception(f"Failed to parse ip link JSON output: {output_str}")
+        return []
+
     log.debug(
-        f"find_available_interfaces(): detected these interfaces (before filtering): {output_str}"
+        f"find_available_interfaces(): detected these interfaces (before filtering): {output_json}"
     )
 
     interfaces = [i["ifname"] for i in output_json if i["link_type"] == "can"]

--- a/can/interfaces/socketcan/utils.py
+++ b/can/interfaces/socketcan/utils.py
@@ -58,11 +58,12 @@ def find_available_interfaces() -> List[str]:
     try:
         output_json = json.loads(output_str)
     except json.JSONDecodeError:
-        log.exception(f"Failed to parse ip link JSON output: {output_str}")
+        log.exception("Failed to parse ip link JSON output: %s", output_str)
         return []
 
     log.debug(
-        f"find_available_interfaces(): detected these interfaces (before filtering): {output_json}"
+        "find_available_interfaces(): detected these interfaces (before filtering): %s",
+        output_json,
     )
 
     interfaces = [i["ifname"] for i in output_json if i["link_type"] == "can"]

--- a/test/test_socketcan_helpers.py
+++ b/test/test_socketcan_helpers.py
@@ -4,11 +4,12 @@
 Tests helpers in `can.interfaces.socketcan.socketcan_common`.
 """
 
+import gzip
+from base64 import b64decode
 import unittest
 from unittest import mock
 
 from subprocess import CalledProcessError
-
 
 from can.interfaces.socketcan.utils import find_available_interfaces, error_code_to_str
 
@@ -30,17 +31,36 @@ class TestSocketCanHelpers(unittest.TestCase):
             string = error_code_to_str(error_code)
             self.assertTrue(string)  # not None or empty
 
-    @unittest.skipUnless(IS_LINUX, "socketcan is only available on Linux")
+    @unittest.skipUnless(
+        TEST_INTERFACE_SOCKETCAN, "socketcan is only available on Linux"
+    )
     def test_find_available_interfaces(self):
         result = find_available_interfaces()
-        self.assertGreaterEqual(len(result), 0)
-        for entry in result:
-            self.assertRegex(entry, r"(sl|v|vx)?can\d+")
-        if TEST_INTERFACE_SOCKETCAN:
-            self.assertGreaterEqual(len(result), 3)
-            self.assertIn("vcan0", result)
-            self.assertIn("vxcan0", result)
-            self.assertIn("slcan0", result)
+
+        self.assertGreaterEqual(len(result), 3)
+        self.assertIn("vcan0", result)
+        self.assertIn("vxcan0", result)
+        self.assertIn("slcan0", result)
+
+    def test_find_available_interfaces_w_patch(self):
+        # Contains lo, eth0, wlan0, vcan0, mycustomCan123
+        ip_output_gz_b64 = (
+            "H4sIAAAAAAAAA+2UzW+CMBjG7/wVhrNL+BC29IboEqNSwzQejDEViiMC5aNsmmX/+wpZTGUwDAcP"
+            "y5qmh+d5++bN80u7EXpsfZRnsUTf8yMXn0TQk/u8GqEQM1EMiMjpXoAOGZM3F6mUZxAuhoY55UpL"
+            "fbWoKjO4Hts7pl/kLdc+pDlrrmuaqnNq4vqZU8wSkSTHOeYHIjFOM4poOevKmlpwbfF+4EfHkLil"
+            "PRo/G6vZkrcPKcnjwnOxh/KA8h49JQGOimAkSaq03NFz/B0PiffIOfIXkeumOCtiEiUJXG++bp8S"
+            "5Dooo/WVZeFnvxmYUgsM01fpBmQWfDAN256M7SqioQ2NkWm8LKvGnIU3qTN+xylrV/FdaHrJzmFk"
+            "gkacozuzZMnhtAGkLANFAaoKBgOgaUDXG0F6Hrje7SDVWpDvAYpuIdmJV4dn2cSx9VUuGiFCe25Y"
+            "fwTi4KmW4ptzG0ULGvYPLN1APSqdMN3/82TRtOeqSbW5hmcnzygJTRTJivofcEvAgrAVvgD8aLkv"
+            "/AcAAA=="
+        )
+        ip_output = gzip.decompress(b64decode(ip_output_gz_b64)).decode("ascii")
+
+        with mock.patch("subprocess.check_output") as check_output:
+            check_output.return_value = ip_output
+            ifs = find_available_interfaces()
+
+            self.assertEqual(ifs, ["vcan0", "mycustomCan123"])
 
     def test_find_available_interfaces_exception(self):
         with mock.patch("subprocess.check_output") as check_output:

--- a/test/test_socketcan_helpers.py
+++ b/test/test_socketcan_helpers.py
@@ -5,6 +5,10 @@ Tests helpers in `can.interfaces.socketcan.socketcan_common`.
 """
 
 import unittest
+from unittest import mock
+
+from subprocess import CalledProcessError
+
 
 from can.interfaces.socketcan.utils import find_available_interfaces, error_code_to_str
 
@@ -28,7 +32,7 @@ class TestSocketCanHelpers(unittest.TestCase):
 
     @unittest.skipUnless(IS_LINUX, "socketcan is only available on Linux")
     def test_find_available_interfaces(self):
-        result = list(find_available_interfaces())
+        result = find_available_interfaces()
         self.assertGreaterEqual(len(result), 0)
         for entry in result:
             self.assertRegex(entry, r"(sl|v|vx)?can\d+")
@@ -37,6 +41,13 @@ class TestSocketCanHelpers(unittest.TestCase):
             self.assertIn("vcan0", result)
             self.assertIn("vxcan0", result)
             self.assertIn("slcan0", result)
+
+    def test_find_available_interfaces_exception(self):
+        with mock.patch("subprocess.check_output") as check_output:
+            check_output.side_effect = Exception("Something went wrong :-/")
+
+            result = find_available_interfaces()
+            self.assertEqual([], result)
 
 
 if __name__ == "__main__":

--- a/test/test_socketcan_helpers.py
+++ b/test/test_socketcan_helpers.py
@@ -60,12 +60,15 @@ class TestSocketCanHelpers(unittest.TestCase):
             check_output.return_value = ip_output
             ifs = find_available_interfaces()
 
-            self.assertEqual(ifs, ["vcan0", "mycustomCan123"])
+            self.assertEqual(["vcan0", "mycustomCan123"], ifs)
 
     def test_find_available_interfaces_exception(self):
         with mock.patch("subprocess.check_output") as check_output:
-            check_output.side_effect = Exception("Something went wrong :-/")
+            check_output.return_value = "<h1>Not JSON</h1>"
+            result = find_available_interfaces()
+            self.assertEqual([], result)
 
+            check_output.side_effect = Exception("Something went wrong :-/")
             result = find_available_interfaces()
             self.assertEqual([], result)
 


### PR DESCRIPTION
Until now, the helper method to find locally available SocketCAN interfaces uses string manipulations to parse the `ip link` output. Additionally, it uses a regular expression to parse the interface name and determine which of these interfaces are CAN interfaces. As a result, it does not properly detect CAN interfaces with customized names (see #1475 ).

https://github.com/hardbyte/python-can/blob/5e5b950228302c21529ca1bb6f234f9bd7e0a372/can/interfaces/socketcan/utils.py#L41-L69

In #1475 , @1atabey1 proposed a more reliable approach to instead use the interface `link_type` for CAN interface detection. This pull request additionally uses the `ip link` ([Changelog](https://lwn.net/Articles/738897/)) JSON output option to make parsing the information easier.

JSON output has been available in `ip link` since version 4.14.0. All Debian / Ubuntu versions with the minimum supported Python version 3.7 also ship with an `ip link` version > 4.14.0.