### PR TITLE
Update PCAN Basic to 4.6.2.753

### DIFF
--- a/can/interfaces/pcan/basic.py
+++ b/can/interfaces/pcan/basic.py
@@ -8,15 +8,15 @@
 #
 #  ------------------------------------------------------------------
 #  Author : Keneth Wagner
+#  Last change: 2022-07-06
 #  ------------------------------------------------------------------
 #
-#  Copyright (C) 1999-2021  PEAK-System Technik GmbH, Darmstadt
+#  Copyright (C) 1999-2022  PEAK-System Technik GmbH, Darmstadt
 #  more Info at http://www.peak-system.com
 
 # Module Imports
 from ctypes import *
 from ctypes.util import find_library
-from string import *
 import platform
 
 import logging
@@ -282,6 +282,12 @@ PCAN_ATTACHED_CHANNELS_COUNT = TPCANParameter(
 PCAN_ATTACHED_CHANNELS = TPCANParameter(
     0x2B
 )  # Get information about PCAN channels attached to a system
+PCAN_ALLOW_ECHO_FRAMES = TPCANParameter(
+    0x2C
+)  # Echo messages reception status within a PCAN-Channel
+PCAN_DEVICE_PART_NUMBER = TPCANParameter(
+    0x2D
+)  # Get the part number associated to a device
 
 # DEPRECATED parameters
 #
@@ -354,8 +360,8 @@ MAX_LENGTH_HARDWARE_NAME = int(
     33
 )  # Maximum length of the name of a device: 32 characters + terminator
 MAX_LENGTH_VERSION_STRING = int(
-    18
-)  # Maximum length of a version string: 17 characters + terminator
+    256
+)  # Maximum length of a version string: 255 characters + terminator
 
 # PCAN message types
 #
@@ -377,6 +383,9 @@ PCAN_MESSAGE_BRS = TPCANMessageType(
 PCAN_MESSAGE_ESI = TPCANMessageType(
     0x10
 )  # The PCAN message represents a FD error state indicator(CAN FD transmitter was error active)
+PCAN_MESSAGE_ECHO = TPCANMessageType(
+    0x20
+)  # The PCAN message represents an echo CAN Frame
 PCAN_MESSAGE_ERRFRAME = TPCANMessageType(
     0x40
 )  # The PCAN message represents an error frame
@@ -654,33 +663,38 @@ class PCANBasic:
     """PCAN-Basic API class implementation"""
 
     def __init__(self):
-        # Loads the PCANBasic API
-        #
         if platform.system() == "Windows":
-            # Loads the API on Windows
-            _dll_path = find_library("PCANBasic")
-            self.__m_dllBasic = windll.LoadLibrary(_dll_path) if _dll_path else None
-            aReg = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
-            try:
-                aKey = winreg.OpenKey(aReg, r"SOFTWARE\PEAK-System\PEAK-Drivers")
-                winreg.CloseKey(aKey)
-            except OSError:
-                logger.error("Exception: The PEAK-driver couldn't be found!")
-            finally:
-                winreg.CloseKey(aReg)
-        elif "CYGWIN" in platform.system():
-            self.__m_dllBasic = cdll.LoadLibrary("PCANBasic.dll")
-            # Unfortunately cygwin python has no winreg module, so we can't
-            # check for the registry key.
-        elif platform.system() == "Linux":
-            # Loads the API on Linux
-            self.__m_dllBasic = cdll.LoadLibrary("libpcanbasic.so")
-        elif platform.system() == "Darwin":
-            self.__m_dllBasic = cdll.LoadLibrary(find_library("libPCBUSB.dylib"))
+            load_library_func = windll.LoadLibrary
+
+            # look for Peak drivers in Windows registry
+            with winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE) as reg:
+                try:
+                    with winreg.OpenKey(reg, r"SOFTWARE\PEAK-System\PEAK-Drivers"):
+                        pass
+                except OSError:
+                    raise OSError("The PEAK-driver could not be found!") from None
         else:
-            self.__m_dllBasic = cdll.LoadLibrary("libpcanbasic.so")
-        if self.__m_dllBasic is None:
-            logger.error("Exception: The PCAN-Basic DLL couldn't be loaded!")
+            load_library_func = cdll.LoadLibrary
+
+        if platform.system() == "Windows" or "CYGWIN" in platform.system():
+            lib_name = "PCANBasic.dll"
+        elif platform.system() == "Darwin":
+            # PCBUSB library is a third-party software created
+            # and maintained by the MacCAN project
+            lib_name = "libPCBUSB.dylib"
+        else:
+            lib_name = "libpcanbasic.so"
+
+        lib_path = find_library(lib_name)
+        if not lib_path:
+            raise OSError(f"{lib_name} library not found.")
+
+        try:
+            self.__m_dllBasic = load_library_func(lib_path)
+        except OSError:
+            raise OSError(
+                f"The PCAN-Basic API could not be loaded. ({lib_path})"
+            ) from None
 
     # Initializes a PCAN Channel
     #
@@ -965,6 +979,7 @@ class PCANBasic:
                 or Parameter == PCAN_BITRATE_INFO_FD
                 or Parameter == PCAN_IP_ADDRESS
                 or Parameter == PCAN_FIRMWARE_VERSION
+                or Parameter == PCAN_DEVICE_PART_NUMBER
             ):
                 mybuffer = create_string_buffer(256)
 
@@ -973,6 +988,12 @@ class PCANBasic:
                 if TPCANStatus(res[0]) != PCAN_ERROR_OK:
                     return (TPCANStatus(res[0]),)
                 mybuffer = (TPCANChannelInformation * res[1])()
+
+            elif (
+                Parameter == PCAN_ACCEPTANCE_FILTER_11BIT
+                or PCAN_ACCEPTANCE_FILTER_29BIT
+            ):
+                mybuffer = c_int64(0)
 
             else:
                 mybuffer = c_int(0)
@@ -1017,6 +1038,11 @@ class PCANBasic:
                 or Parameter == PCAN_TRACE_LOCATION
             ):
                 mybuffer = create_string_buffer(256)
+            elif (
+                Parameter == PCAN_ACCEPTANCE_FILTER_11BIT
+                or PCAN_ACCEPTANCE_FILTER_29BIT
+            ):
+                mybuffer = c_int64(0)
             else:
                 mybuffer = c_int(0)
 

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -6,16 +6,19 @@ import logging
 import time
 from datetime import datetime
 import platform
-
 from typing import Optional
 
 from packaging import version
 
-from ...message import Message
-from ...bus import BusABC, BusState
-from ...util import len2dlc, dlc2len
-from ...exceptions import CanError, CanOperationError, CanInitializationError
-
+from can import (
+    BusABC,
+    BusState,
+    CanError,
+    CanOperationError,
+    CanInitializationError,
+    Message,
+)
+from can.util import len2dlc, dlc2len
 
 from .basic import (
     PCAN_BITRATES,
@@ -78,7 +81,6 @@ try:
 except ImportError as error:
     log.warning(
         "uptime library not available, timestamps are relative to boot time and not to Epoch UTC",
-        exc_info=True,
     )
     boottimeEpoch = 0
 
@@ -278,7 +280,7 @@ class PcanBus(BusABC):
                 # TODO Remove Filter when MACCan actually supports it:
                 #  https://github.com/mac-can/PCBUSB-Library/
                 log.debug(
-                    "Ignoring error. PCAN_ALLOW_ERROR_FRAMES is still unsupported by OSX Library PCANUSB v0.10"
+                    "Ignoring error. PCAN_ALLOW_ERROR_FRAMES is still unsupported by OSX Library PCANUSB v0.11.2"
                 )
 
         if kwargs.get("auto_reset", False):
@@ -624,6 +626,7 @@ class PcanBus(BusABC):
             library_handle = PCANBasic()
         except OSError:
             return channels
+
         interfaces = []
         for i in range(16):
             interfaces.append(

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -647,6 +647,12 @@ class PcanBus(BusABC):
                     "interface": "pcan",
                     "channel": channel_name,
                     "supports_fd": bool(channel.device_features & FEATURE_FD_CAPABLE),
+                    "controller_number": channel.controller_number,
+                    "device_features": channel.device_features,
+                    "device_id": channel.device_id,
+                    "device_name": channel.device_name.decode("latin-1"),
+                    "device_type": channel.device_type,
+                    "channel_condition": channel.channel_condition,
                 }
                 interfaces.append(channel_config)
             return interfaces

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -637,9 +637,15 @@ class PcanBus(BusABC):
                 return interfaces
             channel_information: List[TPCANChannelInformation] = list(value)
             for channel in channel_information:
+                # find channel name in PCAN_CHANNEL_NAMES by value
+                channel_name = next(
+                    _channel_name
+                    for _channel_name, channel_id in PCAN_CHANNEL_NAMES.items()
+                    if channel_id.value == channel.channel_handle
+                )
                 channel_config = {
                     "interface": "pcan",
-                    "channel": channel.device_name + str(channel.controller_number),
+                    "channel": channel_name,
                     "supports_fd": bool(channel.device_features & FEATURE_FD_CAPABLE),
                 }
                 interfaces.append(channel_config)

--- a/test/test_pcan.py
+++ b/test/test_pcan.py
@@ -349,6 +349,12 @@ class TestPCANBus(unittest.TestCase):
             assert configs[0]["interface"] == "pcan"
             assert configs[0]["channel"] == "PCAN_USBBUS1"
             assert configs[0]["supports_fd"]
+            assert configs[0]["controller_number"] == 0
+            assert configs[0]["device_features"] == 1
+            assert configs[0]["device_id"] == 1122867
+            assert configs[0]["device_name"] == "PCAN-USB FD"
+            assert configs[0]["device_type"] == 5
+            assert configs[0]["channel_condition"] == 1
 
     @parameterized.expand([("valid", PCAN_ERROR_OK, "OK"), ("invalid", 0x00005, None)])
     def test_status_string(self, name, status, expected_result) -> None:

--- a/test/test_pcan.py
+++ b/test/test_pcan.py
@@ -338,7 +338,6 @@ class TestPCANBus(unittest.TestCase):
             configs = PcanBus._detect_available_configs()
             self.assertEqual(len(configs), 50)
         else:
-            # TODO: mock GetValue with proper value for PCAN_ATTACHED_CHANNELS
             value = (TPCANChannelInformation * 1).from_buffer_copy(
                 b"Q\x00\x05\x00\x01\x00\x00\x00PCAN-USB FD\x00\x00\x00\x00"
                 b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"


### PR DESCRIPTION
@lumagi Since you have a PEAK device, could you check whether `"channel": channel.device_name + str(channel.controller_number)` is correct? 

It is used in `can.detect_available_configs("pcan")`