### PR TITLE
Stop using root logger in usb2can

### DIFF
--- a/can/interfaces/usb2can/serial_selector.py
+++ b/can/interfaces/usb2can/serial_selector.py
@@ -4,10 +4,12 @@
 import logging
 from typing import List
 
+log = logging.getLogger("can.usb2can")
+
 try:
     import win32com.client
 except ImportError:
-    logging.warning("win32com.client module required for usb2can")
+    log.warning("win32com.client module required for usb2can")
     raise
 
 


### PR DESCRIPTION
Replace the logger used (`root`) to raise import error in usb2can serial selector. It will now use the logger `can.usb2can`.