### PR TITLE
Enable SocketCAN interface tests in GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,18 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox
+    - name: Setup SocketCAN
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        sudo apt-get -y install linux-modules-extra-$(uname -r)
+        sudo ./test/open_vcan.sh
     - name: Test with pytest via tox
       run: |
         tox -e gh
-
+      env:
+        # SocketCAN tests currently fail with PyPy because it does not support raw CAN sockets
+        # See: https://foss.heptapod.net/pypy/pypy/-/issues/3809
+        TEST_SOCKETCAN: "${{ matrix.os == 'ubuntu-latest' && ! startsWith(matrix.python-version, 'pypy' ) }}"
     - name: Coveralls Parallel
       uses: coverallsapp/github-action@master
       with:

--- a/test/test_cyclic_socketcan.py
+++ b/test/test_cyclic_socketcan.py
@@ -256,14 +256,8 @@ class CyclicSocketCan(unittest.TestCase):
         task_a = self._send_bus.send_periodic(messages_a, self.PERIOD)
         time.sleep(0.1)
 
-        # Try to start it again, task_id is not incremented in this case
-        with self.assertRaises(can.CanOperationError) as ctx:
-            task_a.start()
-        self.assertEqual(
-            "A periodic task for task ID 1 is already in progress by the SocketCAN Linux layer",
-            str(ctx.exception),
-        )
-
+        # Task restarting is permitted as of #1440
+        task_a.start()
         task_a.stop()
 
     def test_create_same_id(self):

--- a/test/test_socketcan.py
+++ b/test/test_socketcan.py
@@ -6,6 +6,7 @@ Test functions in `can.interfaces.socketcan.socketcan`.
 import ctypes
 import struct
 import unittest
+import warnings
 from unittest.mock import patch
 import can
 
@@ -368,7 +369,10 @@ class SocketCANTest(unittest.TestCase):
             can.Bus(interface="socketcan", channel="vcan0", bitrate=500000)
         except OSError as e:
             if "unknown address family" not in str(e):
-                raise
+                warnings.warn(
+                    "Please check if PyPy has implemented raw CAN socket support! "
+                    "See: https://foss.heptapod.net/pypy/pypy/-/issues/3809"
+                )
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ passenv =
     GITHUB_*
     COVERALLS_*
     PY_COLORS
+    TEST_SOCKETCAN
 
 [testenv:travis]
 passenv =


### PR DESCRIPTION
See #1479
I still need to investigate why the CPython tests fail.