### PR TITLE
Handle extended arbitration id properly

### DIFF
--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -27,11 +27,12 @@ def convert_ascii_message_to_can_message(ascii_msg: str) -> can.Message:
         frame_string = ascii_msg[8:-2]
         parts = frame_string.split(" ", 3)
         can_id, timestamp = int(parts[0], 16), float(parts[1])
+        is_ext = (len(parts[0]) != 3)
 
         data = bytearray.fromhex(parts[2])
         can_dlc = len(data)
         can_message = can.Message(
-            timestamp=timestamp, arbitration_id=can_id, data=data, dlc=can_dlc
+            timestamp=timestamp, arbitration_id=can_id, data=data, dlc=can_dlc, is_extended_id=is_ext
         )
         return can_message
 
@@ -40,11 +41,15 @@ def convert_can_message_to_ascii_message(can_message: can.Message) -> str:
     # Note: socketcan bus adds extended flag, remote_frame_flag & error_flag to id
     # not sure if that is necessary here
     can_id = can_message.arbitration_id
+    if can_message.is_extended_id or (can_id > 0x7FF):
+        can_id_string = f"{can_id:08X}"
+    else:
+        can_id_string = f"{can_id:03X}"
     # Note: seems like we cannot add CANFD_BRS (bitrate_switch) and CANFD_ESI (error_state_indicator) flags
     data = can_message.data
     length = can_message.dlc
     bytes_string = " ".join(f"{x:x}" for x in data[0:length])
-    return f"< send {can_id:X} {length:X} {bytes_string} >"
+    return f"< send {can_id_string} {length:X} {bytes_string} >"
 
 
 def connect_to_server(s, host, port):

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -27,12 +27,16 @@ def convert_ascii_message_to_can_message(ascii_msg: str) -> can.Message:
         frame_string = ascii_msg[8:-2]
         parts = frame_string.split(" ", 3)
         can_id, timestamp = int(parts[0], 16), float(parts[1])
-        is_ext = (len(parts[0]) != 3)
+        is_ext = len(parts[0]) != 3
 
         data = bytearray.fromhex(parts[2])
         can_dlc = len(data)
         can_message = can.Message(
-            timestamp=timestamp, arbitration_id=can_id, data=data, dlc=can_dlc, is_extended_id=is_ext
+            timestamp=timestamp,
+            arbitration_id=can_id,
+            data=data,
+            dlc=can_dlc,
+            is_extended_id=is_ext,
         )
         return can_message
 


### PR DESCRIPTION
socketcand uses the length of the arbitration id field to indicate whether a frame is using extended id or not. 3 characters for standard, 8 for extended.

Prior to this fix, the arbitration id would be truncated to the lower 11 bits, or at times even garbage.