### PR TITLE
Vector: refactor bit timing setup

### DIFF
--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -573,21 +573,22 @@ class VectorBus(BusABC):
             # The error message depends on the currently active CAN settings.
             # If the active operation mode is CAN FD, show the active CAN FD timings,
             # otherwise show CAN 2.0 timings.
-            _is_fd = bool(
+            if bool(
                 bus_params_data.can_op_mode
                 & xldefine.XL_CANFD_BusParams_CanOpMode.XL_BUS_PARAMS_CANOPMODE_CANFD
-            )
-            _bus_params_data = bus_params.canfd if _is_fd else bus_params.can
-            active_settings = ", ".join(
-                [
-                    f"{key}: {getattr(val, 'name', val)}"  # print int or Enum/Flag name
-                    for key, val in _bus_params_data._asdict().items()  # type: ignore[attr-defined]
-                ]
+            ):
+                active_settings = bus_params.canfd._asdict()
+                active_settings["can_op_mode"] = "CAN FD"
+            else:
+                active_settings = bus_params.can._asdict()
+                active_settings["can_op_mode"] = "CAN 2.0"
+            settings_string = ", ".join(
+                [f"{key}: {val}" for key, val in active_settings.items()]
             )
             raise CanInitializationError(
                 f"The requested settings could not be set for channel {channel}. "
                 f"Another application might have set incompatible settings. "
-                f"These are the currently active settings: {active_settings}."
+                f"These are the currently active settings: {settings_string}."
             )
 
     def _apply_filters(self, filters: Optional[CanFilters]) -> None:

--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -510,10 +510,10 @@ class VectorBus(BusABC):
         self,
         channel: int,
         bitrate: int,
-        sample_point: float | None = None,
+        sample_point: Optional[float] = None,
         fd: bool = False,
-        data_bitrate: int | None = None,
-        data_sample_point: float | None = None,
+        data_bitrate: Optional[int] = None,
+        data_sample_point: Optional[float] = None,
     ) -> None:
         """Compare requested CAN settings to active settings in driver."""
         bus_params = self._read_bus_params(channel)

--- a/can/interfaces/vector/xldriver.py
+++ b/can/interfaces/vector/xldriver.py
@@ -201,7 +201,17 @@ xlCanSetChannelParams.argtypes = [
     ctypes.POINTER(xlclass.XLchipParams),
 ]
 xlCanSetChannelParams.restype = xlclass.XLstatus
-xlCanSetChannelParams.errcheck = check_status_operation
+xlCanSetChannelParams.errcheck = check_status_initialization
+
+xlCanSetChannelParamsC200 = _xlapi_dll.xlCanSetChannelParamsC200
+xlCanSetChannelParamsC200.argtypes = [
+    xlclass.XLportHandle,
+    xlclass.XLaccess,
+    ctypes.c_ubyte,
+    ctypes.c_ubyte,
+]
+xlCanSetChannelParams.restype = xlclass.XLstatus
+xlCanSetChannelParams.errcheck = check_status_initialization
 
 xlCanTransmit = _xlapi_dll.xlCanTransmit
 xlCanTransmit.argtypes = [

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -193,12 +193,12 @@ def test_bus_creation_fd_bitrate_timings_mocked(mock_xldriver) -> None:
         fd=True,
         bitrate=500_000,
         data_bitrate=2_000_000,
-        sjw_abr=10,
-        tseg1_abr=11,
-        tseg2_abr=12,
-        sjw_dbr=13,
-        tseg1_dbr=14,
-        tseg2_dbr=15,
+        sjw_abr=16,
+        tseg1_abr=127,
+        tseg2_abr=32,
+        sjw_dbr=6,
+        tseg1_dbr=27,
+        tseg2_dbr=12,
         _testing=True,
     )
     assert isinstance(bus, canlib.VectorBus)
@@ -222,12 +222,12 @@ def test_bus_creation_fd_bitrate_timings_mocked(mock_xldriver) -> None:
     canFdConf = xlCanFdSetConfiguration_args[2]
     assert canFdConf.arbitrationBitRate == 500000
     assert canFdConf.dataBitRate == 2000000
-    assert canFdConf.sjwAbr == 10
-    assert canFdConf.tseg1Abr == 11
-    assert canFdConf.tseg2Abr == 12
-    assert canFdConf.sjwDbr == 13
-    assert canFdConf.tseg1Dbr == 14
-    assert canFdConf.tseg2Dbr == 15
+    assert canFdConf.sjwAbr == 16
+    assert canFdConf.tseg1Abr == 127
+    assert canFdConf.tseg2Abr == 32
+    assert canFdConf.sjwDbr == 6
+    assert canFdConf.tseg1Dbr == 27
+    assert canFdConf.tseg2Dbr == 12
 
 
 @pytest.mark.skipif(not XLDRIVER_FOUND, reason="Vector XL API is unavailable")
@@ -239,12 +239,12 @@ def test_bus_creation_fd_bitrate_timings() -> None:
         fd=True,
         bitrate=500_000,
         data_bitrate=2_000_000,
-        sjw_abr=10,
-        tseg1_abr=11,
-        tseg2_abr=12,
-        sjw_dbr=13,
-        tseg1_dbr=14,
-        tseg2_dbr=15,
+        sjw_abr=16,
+        tseg1_abr=127,
+        tseg2_abr=32,
+        sjw_dbr=6,
+        tseg1_dbr=27,
+        tseg2_dbr=12,
     )
 
     xl_channel_config = _find_xl_channel_config(
@@ -259,18 +259,45 @@ def test_bus_creation_fd_bitrate_timings() -> None:
         & xldefine.XL_CANFD_BusParams_CanOpMode.XL_BUS_PARAMS_CANOPMODE_CANFD
     )
     assert xl_channel_config.busParams.data.canFD.arbitrationBitRate == 500_000
-    assert xl_channel_config.busParams.data.canFD.sjwAbr == 10
-    assert xl_channel_config.busParams.data.canFD.tseg1Abr == 11
-    assert xl_channel_config.busParams.data.canFD.tseg2Abr == 12
-    assert xl_channel_config.busParams.data.canFD.sjwDbr == 13
-    assert xl_channel_config.busParams.data.canFD.tseg1Dbr == 14
-    assert xl_channel_config.busParams.data.canFD.tseg2Dbr == 15
+    assert xl_channel_config.busParams.data.canFD.sjwAbr == 16
+    assert xl_channel_config.busParams.data.canFD.tseg1Abr == 127
+    assert xl_channel_config.busParams.data.canFD.tseg2Abr == 32
+    assert xl_channel_config.busParams.data.canFD.sjwDbr == 6
+    assert xl_channel_config.busParams.data.canFD.tseg1Dbr == 27
+    assert xl_channel_config.busParams.data.canFD.tseg2Dbr == 12
     assert xl_channel_config.busParams.data.canFD.dataBitRate == 2_000_000
 
     bus.shutdown()
 
 
-def test_bus_creation_timing_mocked(mock_xldriver) -> None:
+def test_bus_creation_timing_8mhz_mocked(mock_xldriver) -> None:
+    timing = can.BitTiming.from_bitrate_and_segments(
+        f_clock=8_000_000,
+        bitrate=125_000,
+        tseg1=13,
+        tseg2=2,
+        sjw=1,
+    )
+    bus = can.Bus(channel=0, interface="vector", timing=timing, _testing=True)
+    assert isinstance(bus, canlib.VectorBus)
+    can.interfaces.vector.canlib.xldriver.xlOpenDriver.assert_called()
+    can.interfaces.vector.canlib.xldriver.xlGetApplConfig.assert_called()
+
+    can.interfaces.vector.canlib.xldriver.xlOpenPort.assert_called()
+    xlOpenPort_args = can.interfaces.vector.canlib.xldriver.xlOpenPort.call_args[0]
+    assert xlOpenPort_args[5] == xldefine.XL_InterfaceVersion.XL_INTERFACE_VERSION.value
+    assert xlOpenPort_args[6] == xldefine.XL_BusTypes.XL_BUS_TYPE_CAN.value
+
+    can.interfaces.vector.canlib.xldriver.xlCanFdSetConfiguration.assert_not_called()
+    can.interfaces.vector.canlib.xldriver.xlCanSetChannelParamsC200.assert_called()
+    btr0, btr1 = (
+        can.interfaces.vector.canlib.xldriver.xlCanSetChannelParamsC200.call_args[0]
+    )[2:]
+    assert btr0 == timing.btr0
+    assert btr1 == timing.btr1
+
+
+def test_bus_creation_timing_16mhz_mocked(mock_xldriver) -> None:
     timing = can.BitTiming.from_bitrate_and_segments(
         f_clock=16_000_000,
         bitrate=125_000,
@@ -302,30 +329,31 @@ def test_bus_creation_timing_mocked(mock_xldriver) -> None:
 
 @pytest.mark.skipif(not XLDRIVER_FOUND, reason="Vector XL API is unavailable")
 def test_bus_creation_timing() -> None:
-    timing = can.BitTiming.from_bitrate_and_segments(
-        f_clock=16_000_000,
-        bitrate=125_000,
-        tseg1=13,
-        tseg2=2,
-        sjw=1,
-    )
-    bus = can.Bus(
-        channel=0,
-        serial=_find_virtual_can_serial(),
-        interface="vector",
-        timing=timing,
-    )
-    assert isinstance(bus, canlib.VectorBus)
+    for f_clock in [8_000_000, 16_000_000]:
+        timing = can.BitTiming.from_bitrate_and_segments(
+            f_clock=f_clock,
+            bitrate=125_000,
+            tseg1=13,
+            tseg2=2,
+            sjw=1,
+        )
+        bus = can.Bus(
+            channel=0,
+            serial=_find_virtual_can_serial(),
+            interface="vector",
+            timing=timing,
+        )
+        assert isinstance(bus, canlib.VectorBus)
 
-    xl_channel_config = _find_xl_channel_config(
-        serial=_find_virtual_can_serial(), channel=0
-    )
-    assert xl_channel_config.busParams.data.can.bitRate == 125_000
-    assert xl_channel_config.busParams.data.can.sjw == 1
-    assert xl_channel_config.busParams.data.can.tseg1 == 13
-    assert xl_channel_config.busParams.data.can.tseg2 == 2
+        xl_channel_config = _find_xl_channel_config(
+            serial=_find_virtual_can_serial(), channel=0
+        )
+        assert xl_channel_config.busParams.data.can.bitRate == 125_000
+        assert xl_channel_config.busParams.data.can.sjw == 1
+        assert xl_channel_config.busParams.data.can.tseg1 == 13
+        assert xl_channel_config.busParams.data.can.tseg2 == 2
 
-    bus.shutdown()
+        bus.shutdown()
 
 
 def test_bus_creation_timingfd_mocked(mock_xldriver) -> None:


### PR DESCRIPTION
Follow-up to #1470 

Use the BitTiming/BitTimingFd objects internally to simplify code paths. This way we can deprecate the `fd`, `data_bitrate`, `sjw_abr`, `tseg1_abr`, `tseg2_abr`, `sjw_dbr`, `tseg1_dbr`, and `tseg2_dbr` parameters in the future without much effort.