### PR TITLE
Print all recorded warnings for failing test

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -245,7 +245,9 @@ class TestCheckAdjustTimingClock(unittest.TestCase):
             new_timing = check_or_adjust_timing_clock(
                 timing, valid_clocks=[8_000, 80_000_000]
             )
-            assert len(record) == 1
+            assert len(record) == 1, "; ".join(
+                [record[i].message.args[0] for i in range(len(record))]
+            )  # print all warnings, if more than one warning is present
             assert (
                 record[0].message.args[0]
                 == "Adjusted f_clock in BitTimingFd from 160000000 to 80000000"


### PR DESCRIPTION
`TestCheckAdjustTimingClock::test_adjust_timing_fd` sporadically fails on PyPy because more than one warning is recorded.
This will print all warnings if/when it happens again.