### PR TITLE
Linting with refurb

### DIFF
--- a/can/bit_timing.py
+++ b/can/bit_timing.py
@@ -1,6 +1,7 @@
 # pylint: disable=too-many-lines
 import math
 from typing import List, Mapping, Iterator, cast
+import contextlib
 
 from can.typechecking import BitTimingFdDict, BitTimingDict
 
@@ -365,7 +366,7 @@ class BitTiming(Mapping):
             if no suitable bit timings were found.
         """
         # try the most simple solution first: another bitrate prescaler
-        try:
+        with contextlib.suppress(ValueError):
             return BitTiming.from_bitrate_and_segments(
                 f_clock=f_clock,
                 bitrate=self.bitrate,
@@ -374,8 +375,6 @@ class BitTiming(Mapping):
                 sjw=self.sjw,
                 nof_samples=self.nof_samples,
             )
-        except ValueError:
-            pass
 
         # create a new timing instance with the same sample point
         bt = BitTiming.from_sample_point(
@@ -960,7 +959,7 @@ class BitTimingFd(Mapping):
             if no suitable bit timings were found.
         """
         # try the most simple solution first: another bitrate prescaler
-        try:
+        with contextlib.suppress(ValueError):
             return BitTimingFd.from_bitrate_and_segments(
                 f_clock=f_clock,
                 nom_bitrate=self.nom_bitrate,
@@ -972,8 +971,6 @@ class BitTimingFd(Mapping):
                 data_tseg2=self.data_tseg2,
                 data_sjw=self.data_sjw,
             )
-        except ValueError:
-            pass
 
         # create a new timing instance with the same sample points
         bt = BitTimingFd.from_sample_point(

--- a/can/bus.py
+++ b/can/bus.py
@@ -10,6 +10,7 @@ from abc import ABC, ABCMeta, abstractmethod
 import can
 import logging
 import threading
+import contextlib
 from time import time
 from enum import Enum, auto
 
@@ -249,10 +250,8 @@ class BusABC(metaclass=ABCMeta):
         def wrapped_stop_method(remove_task: bool = True) -> None:
             nonlocal task, periodic_tasks, original_stop_method
             if remove_task:
-                try:
-                    periodic_tasks.remove(task)
-                except ValueError:
-                    pass  # allow the task to be already removed
+                with contextlib.suppress(ValueError):
+                    periodic_tasks.remove(task)  # allow the task to be already removed
             original_stop_method()
 
         task.stop = wrapped_stop_method  # type: ignore

--- a/can/interfaces/robotell.py
+++ b/can/interfaces/robotell.py
@@ -155,9 +155,9 @@ class robotellBus(BusABC):
             self._writeconfig(configid, msgid_value, msgid_mask)
 
     def _getconfigsize(self, configid):
-        if configid == self._CAN_ART_ID or configid == self._CAN_ABOM_ID:
+        if configid in (self._CAN_ART_ID, self._CAN_ABOM_ID):
             return 1
-        if configid == self._CAN_BAUD_ID or configid == self._CAN_INIT_FLASH_ID:
+        if configid in (self._CAN_BAUD_ID, self._CAN_INIT_FLASH_ID):
             return 4
         if configid == self._CAN_SERIALBPS_ID:
             return 4
@@ -315,11 +315,7 @@ class robotellBus(BusABC):
         packet.append(self._PACKET_HEAD)
         packet.append(self._PACKET_HEAD)
         for msgbyte in msgbuf:
-            if (
-                msgbyte == self._PACKET_ESC
-                or msgbyte == self._PACKET_HEAD
-                or msgbyte == self._PACKET_TAIL
-            ):
+            if msgbyte in (self._PACKET_ESC, self._PACKET_HEAD, self._PACKET_TAIL):
                 packet.append(self._PACKET_ESC)
             packet.append(msgbyte)
         packet.append(self._PACKET_TAIL)

--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -17,6 +17,7 @@ import zlib
 import datetime
 import time
 import logging
+import contextlib
 from typing import List, BinaryIO, Generator, Union, Tuple, Optional, cast, Any
 
 from ..message import Message
@@ -199,11 +200,9 @@ class BLFReader(MessageReader):
     def _parse_container(self, data):
         if self._tail:
             data = b"".join((self._tail, data))
-        try:
+        # suppress if not enough data in the container to unpack a struct
+        with contextlib.suppress(struct.error):
             yield from self._parse_data(data)
-        except struct.error:
-            # There was not enough data in the container to unpack a struct
-            pass
         # Save the remaining data that could not be processed
         self._tail = data[self._pos :]
 

--- a/can/io/canutils.py
+++ b/can/io/canutils.py
@@ -165,7 +165,7 @@ class CanutilsLogWriter(FileIOMessageWriter):
             timestamp = msg.timestamp
 
         channel = msg.channel if msg.channel is not None else self.channel
-        if isinstance(channel, (int, str)) and channel.isdigit():
+        if isinstance(channel, int) or isinstance(channel, str) and channel.isdigit():
             channel = f"can{channel}"
 
         framestr = f"({timestamp:f}) {channel}"

--- a/can/io/canutils.py
+++ b/can/io/canutils.py
@@ -165,7 +165,7 @@ class CanutilsLogWriter(FileIOMessageWriter):
             timestamp = msg.timestamp
 
         channel = msg.channel if msg.channel is not None else self.channel
-        if isinstance(channel, int) or isinstance(channel, str) and channel.isdigit():
+        if isinstance(channel, (int, str)) and channel.isdigit():
             channel = f"can{channel}"
 
         framestr = f"({timestamp:f}) {channel}"

--- a/can/message.py
+++ b/can/message.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 from . import typechecking
 
+import contextlib
 from copy import deepcopy
 from math import isinf, isnan
 
@@ -144,10 +145,8 @@ class Message:  # pylint: disable=too-many-instance-attributes; OK for a datacla
             field_strings.append(f"'{self.data.decode('utf-8', 'replace')}'")
 
         if self.channel is not None:
-            try:
+            with contextlib.suppress(UnicodeEncodeError):
                 field_strings.append(f"Channel: {self.channel}")
-            except UnicodeEncodeError:
-                pass
 
         return "    ".join(field_strings).strip()
 

--- a/can/notifier.py
+++ b/can/notifier.py
@@ -5,6 +5,7 @@ This module contains the implementation of :class:`~can.Notifier`.
 import asyncio
 import logging
 import threading
+import contextlib
 import time
 from typing import Callable, Iterable, List, Optional, Union, Awaitable
 
@@ -65,11 +66,9 @@ class Notifier:
             CAN bus instance.
         """
         reader: int = -1
-        try:
+        # Bus doesn't support fileno, we fall back to thread based reader
+        with contextlib.suppress(NotImplementedError):
             reader = bus.fileno()
-        except NotImplementedError:
-            # Bus doesn't support fileno, we fall back to thread based reader
-            pass
 
         if self._loop is not None and reader >= 0:
             # Use bus file descriptor to watch for messages

--- a/can/player.py
+++ b/can/player.py
@@ -7,6 +7,7 @@ Similar to canplayer in the can-utils package.
 
 import sys
 import argparse
+import contextlib
 from datetime import datetime
 import errno
 from typing import cast, Iterable
@@ -97,15 +98,13 @@ def main() -> None:
 
             print(f"Can LogReader (Started on {datetime.now()})")
 
-            try:
+            with contextlib.suppress(KeyboardInterrupt):
                 for message in in_sync:
                     if message.is_error_frame and not error_frames:
                         continue
                     if verbosity >= 3:
                         print(message)
                     bus.send(message)
-            except KeyboardInterrupt:
-                pass
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup, find_packages
 
 logging.basicConfig(level=logging.WARNING)
 
-with open("can/__init__.py", encoding="utf-8") as fd:
+with open(join("can", "__init__.py"), encoding="utf-8") as fd:
     version = re.search(
         r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', fd.read(), re.MULTILINE
     ).group(1)


### PR DESCRIPTION
Took the liberty of running the [refurb](https://github.com/dosisod/refurb) library against this repository and cleaned up try/except/pass statements and some if statements that can be replaced with iterables. Also changed a hardcoded "/" in setup.py to os.path.join. 

Everything here should be nonfunctional but would be awesome to have refurb exist in the CI as output. Also would be nice to have something like isort here so can implement that too.