### PR TITLE
Support CANdapter extended length arbitration ID

### DIFF
--- a/can/interfaces/slcan.py
+++ b/can/interfaces/slcan.py
@@ -205,7 +205,7 @@ class slcanBus(BusABC):
 
         if not string:
             pass
-        elif string[0] == "T" or string[0] == "x":
+        elif string[0] in ("T", "x"):
             # extended frame
             canId = int(string[1:9], 16)
             dlc = int(string[9])

--- a/can/interfaces/slcan.py
+++ b/can/interfaces/slcan.py
@@ -205,7 +205,7 @@ class slcanBus(BusABC):
 
         if not string:
             pass
-        elif string[0] in ("T", "x"):
+        elif string[0] in ("T", "x"): # x is an alternative extended message identifier for CANDapter
             # extended frame
             canId = int(string[1:9], 16)
             dlc = int(string[9])

--- a/can/interfaces/slcan.py
+++ b/can/interfaces/slcan.py
@@ -205,7 +205,7 @@ class slcanBus(BusABC):
 
         if not string:
             pass
-        elif string[0] == "T":
+        elif string[0] == "T" or string[0] == "x":
             # extended frame
             canId = int(string[1:9], 16)
             dlc = int(string[9])

--- a/can/interfaces/slcan.py
+++ b/can/interfaces/slcan.py
@@ -205,7 +205,10 @@ class slcanBus(BusABC):
 
         if not string:
             pass
-        elif string[0] in ("T", "x"): # x is an alternative extended message identifier for CANDapter
+        elif string[0] in (
+            "T",
+            "x",  # x is an alternative extended message identifier for CANDapter
+        ):
             # extended frame
             canId = int(string[1:9], 16)
             dlc = int(string[9])

--- a/test/test_slcan.py
+++ b/test/test_slcan.py
@@ -43,6 +43,16 @@ class slcanTestCase(unittest.TestCase):
         self.assertEqual(msg.dlc, 2)
         self.assertSequenceEqual(msg.data, [0xAA, 0x55])
 
+        # Ewert Energy Systems CANDapter specific
+        elf.serial.write(b"x12ABCDEF2AA55\r")
+        msg = self.bus.recv(TIMEOUT)
+        self.assertIsNotNone(msg)
+        self.assertEqual(msg.arbitration_id, 0x12ABCDEF)
+        self.assertEqual(msg.is_extended_id, True)
+        self.assertEqual(msg.is_remote_frame, False)
+        self.assertEqual(msg.dlc, 2)
+        self.assertSequenceEqual(msg.data, [0xAA, 0x55])
+
     def test_send_extended(self):
         msg = can.Message(
             arbitration_id=0x12ABCDEF, is_extended_id=True, data=[0xAA, 0x55]

--- a/test/test_slcan.py
+++ b/test/test_slcan.py
@@ -44,7 +44,7 @@ class slcanTestCase(unittest.TestCase):
         self.assertSequenceEqual(msg.data, [0xAA, 0x55])
 
         # Ewert Energy Systems CANDapter specific
-        elf.serial.write(b"x12ABCDEF2AA55\r")
+        self.serial.write(b"x12ABCDEF2AA55\r")
         msg = self.bus.recv(TIMEOUT)
         self.assertIsNotNone(msg)
         self.assertEqual(msg.arbitration_id, 0x12ABCDEF)


### PR DESCRIPTION
Add support for [Ewert Energy CANdapter](https://www.ewertenergy.com/products/candapter/downloads/candapter_manual.pdf) extended arbitration ID ASCII identifier of `x` for the slcan interface implementation.

Fixes #1506 