### PR TITLE
Export symbols to satisfy type checkers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,9 @@ jobs:
     - name: mypy 3.11
       run: |
         mypy --python-version 3.11 .
+    - name: ruff
+      run: |
+        ruff check can
     - name: pylint
       run: |
         pylint --rcfile=.pylintrc \

--- a/.pylintrc
+++ b/.pylintrc
@@ -439,7 +439,7 @@ known-standard-library=
 known-third-party=enchant
 
 # Allow explicit reexports by alias from a package __init__
-allow-reexport-from-package=yes
+allow-reexport-from-package=no
 
 [CLASSES]
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -438,6 +438,8 @@ known-standard-library=
 # Force import order to recognize a module as part of a third party library.
 known-third-party=enchant
 
+# Allow explicit reexports by alias from a package __init__
+allow-reexport-from-package=yes
 
 [CLASSES]
 

--- a/can/__init__.py
+++ b/can/__init__.py
@@ -20,6 +20,8 @@ from . import broadcastmanager as broadcastmanager
 from . import interface as interface
 from .bit_timing import BitTiming as BitTiming
 from .bit_timing import BitTimingFd as BitTimingFd
+from .broadcastmanager import ModifiableCyclicTaskABC as ModifiableCyclicTaskABC
+from .broadcastmanager import RestartableCyclicTaskABC as RestartableCyclicTaskABC
 from .bus import BusABC as BusABC
 from .bus import BusState as BusState
 from .exceptions import CanError as CanError

--- a/can/__init__.py
+++ b/can/__init__.py
@@ -9,58 +9,101 @@ import logging
 from typing import Any, Dict
 
 __version__ = "4.1.0"
+__all__ = [
+    "ASCReader",
+    "ASCWriter",
+    "AsyncBufferedReader",
+    "BitTiming",
+    "BitTimingFd",
+    "BLFReader",
+    "BLFWriter",
+    "broadcastmanager",
+    "BufferedReader",
+    "Bus",
+    "BusABC",
+    "BusState",
+    "CanError",
+    "CanInitializationError",
+    "CanInterfaceNotImplementedError",
+    "CanOperationError",
+    "CanTimeoutError",
+    "CanutilsLogReader",
+    "CanutilsLogWriter",
+    "CSVReader",
+    "CSVWriter",
+    "CyclicSendTaskABC",
+    "detect_available_configs",
+    "interface",
+    "LimitedDurationCyclicSendTaskABC",
+    "Listener",
+    "Logger",
+    "LogReader",
+    "ModifiableCyclicTaskABC",
+    "Message",
+    "MessageSync",
+    "Notifier",
+    "Printer",
+    "RedirectReader",
+    "RestartableCyclicTaskABC",
+    "set_logging_level",
+    "SizedRotatingLogger",
+    "SqliteReader",
+    "SqliteWriter",
+    "ThreadSafeBus",
+    "typechecking",
+    "TRCFileVersion",
+    "TRCReader",
+    "TRCWriter",
+    "util",
+    "VALID_INTERFACES",
+]
 
 log = logging.getLogger("can")
 
 rc: Dict[str, Any] = {}
 
-from . import typechecking as typechecking  # isort:skip
-from . import util as util  # isort:skip
-from . import broadcastmanager as broadcastmanager
-from . import interface as interface
-from .bit_timing import BitTiming as BitTiming
-from .bit_timing import BitTimingFd as BitTimingFd
-from .broadcastmanager import CyclicSendTaskABC as CyclicSendTaskABC
+from . import typechecking  # isort:skip
+from . import util  # isort:skip
+from . import broadcastmanager, interface
+from .bit_timing import BitTiming, BitTimingFd
 from .broadcastmanager import (
-    LimitedDurationCyclicSendTaskABC as LimitedDurationCyclicSendTaskABC,
+    CyclicSendTaskABC,
+    LimitedDurationCyclicSendTaskABC,
+    ModifiableCyclicTaskABC,
+    RestartableCyclicTaskABC,
 )
-from .broadcastmanager import ModifiableCyclicTaskABC as ModifiableCyclicTaskABC
-from .broadcastmanager import RestartableCyclicTaskABC as RestartableCyclicTaskABC
-from .bus import BusABC as BusABC
-from .bus import BusState as BusState
-from .exceptions import CanError as CanError
-from .exceptions import CanInitializationError as CanInitializationError
+from .bus import BusABC, BusState
 from .exceptions import (
-    CanInterfaceNotImplementedError as CanInterfaceNotImplementedError,
+    CanError,
+    CanInitializationError,
+    CanInterfaceNotImplementedError,
+    CanOperationError,
+    CanTimeoutError,
 )
-from .exceptions import CanOperationError as CanOperationError
-from .exceptions import CanTimeoutError as CanTimeoutError
-from .interface import Bus as Bus
-from .interface import detect_available_configs as detect_available_configs
-from .interfaces import VALID_INTERFACES as VALID_INTERFACES
-from .io import ASCReader as ASCReader
-from .io import ASCWriter as ASCWriter
-from .io import BLFReader as BLFReader
-from .io import BLFWriter as BLFWriter
-from .io import CanutilsLogReader as CanutilsLogReader
-from .io import CanutilsLogWriter as CanutilsLogWriter
-from .io import CSVReader as CSVReader
-from .io import CSVWriter as CSVWriter
-from .io import Logger as Logger
-from .io import LogReader as LogReader
-from .io import MessageSync as MessageSync
-from .io import Printer as Printer
-from .io import SizedRotatingLogger as SizedRotatingLogger
-from .io import SqliteReader as SqliteReader
-from .io import SqliteWriter as SqliteWriter
-from .io import TRCFileVersion as TRCFileVersion
-from .io import TRCReader as TRCReader
-from .io import TRCWriter as TRCWriter
-from .listener import AsyncBufferedReader as AsyncBufferedReader
-from .listener import BufferedReader as BufferedReader
-from .listener import Listener as Listener
-from .listener import RedirectReader as RedirectReader
-from .message import Message as Message
-from .notifier import Notifier as Notifier
-from .thread_safe_bus import ThreadSafeBus as ThreadSafeBus
-from .util import set_logging_level as set_logging_level
+from .interface import Bus, detect_available_configs
+from .interfaces import VALID_INTERFACES
+from .io import (
+    ASCReader,
+    ASCWriter,
+    BLFReader,
+    BLFWriter,
+    CanutilsLogReader,
+    CanutilsLogWriter,
+    CSVReader,
+    CSVWriter,
+    Logger,
+    LogReader,
+    MessageSync,
+    Printer,
+    SizedRotatingLogger,
+    SqliteReader,
+    SqliteWriter,
+    TRCFileVersion,
+    TRCReader,
+    TRCWriter,
+)
+from .listener import AsyncBufferedReader, BufferedReader, Listener, RedirectReader
+from .message import Message
+from .notifier import Notifier
+from .thread_safe_bus import ThreadSafeBus
+from .util import set_logging_level

--- a/can/__init__.py
+++ b/can/__init__.py
@@ -6,7 +6,7 @@ messages on a can bus.
 """
 
 import logging
-from typing import Dict, Any
+from typing import Any, Dict
 
 __version__ = "4.1.0"
 
@@ -14,39 +14,47 @@ log = logging.getLogger("can")
 
 rc: Dict[str, Any] = {}
 
-from .listener import Listener, BufferedReader, RedirectReader, AsyncBufferedReader
-
+from . import typechecking as typechecking  # isort:skip
+from . import util as util  # isort:skip
+from . import broadcastmanager as broadcastmanager
+from . import interface as interface
+from .bit_timing import BitTiming as BitTiming
+from .bit_timing import BitTimingFd as BitTimingFd
+from .bus import BusABC as BusABC
+from .bus import BusState as BusState
+from .exceptions import CanError as CanError
+from .exceptions import CanInitializationError as CanInitializationError
 from .exceptions import (
-    CanError,
-    CanInterfaceNotImplementedError,
-    CanInitializationError,
-    CanOperationError,
-    CanTimeoutError,
+    CanInterfaceNotImplementedError as CanInterfaceNotImplementedError,
 )
-
-from .util import set_logging_level
-
-from .message import Message
-from .bus import BusABC, BusState
-from .thread_safe_bus import ThreadSafeBus
-from .notifier import Notifier
-from .interfaces import VALID_INTERFACES
-from . import interface
-from .interface import Bus, detect_available_configs
-from .bit_timing import BitTiming, BitTimingFd
-
-from .io import Logger, SizedRotatingLogger, Printer, LogReader, MessageSync
-from .io import ASCWriter, ASCReader
-from .io import BLFReader, BLFWriter
-from .io import CanutilsLogReader, CanutilsLogWriter
-from .io import CSVWriter, CSVReader
-from .io import SqliteWriter, SqliteReader
-from .io import TRCReader, TRCWriter, TRCFileVersion
-
-from .broadcastmanager import (
-    CyclicSendTaskABC,
-    LimitedDurationCyclicSendTaskABC,
-    ModifiableCyclicTaskABC,
-    MultiRateCyclicSendTaskABC,
-    RestartableCyclicTaskABC,
-)
+from .exceptions import CanOperationError as CanOperationError
+from .exceptions import CanTimeoutError as CanTimeoutError
+from .interface import Bus as Bus
+from .interface import detect_available_configs as detect_available_configs
+from .interfaces import VALID_INTERFACES as VALID_INTERFACES
+from .io import ASCReader as ASCReader
+from .io import ASCWriter as ASCWriter
+from .io import BLFReader as BLFReader
+from .io import BLFWriter as BLFWriter
+from .io import CanutilsLogReader as CanutilsLogReader
+from .io import CanutilsLogWriter as CanutilsLogWriter
+from .io import CSVReader as CSVReader
+from .io import CSVWriter as CSVWriter
+from .io import Logger as Logger
+from .io import LogReader as LogReader
+from .io import MessageSync as MessageSync
+from .io import Printer as Printer
+from .io import SizedRotatingLogger as SizedRotatingLogger
+from .io import SqliteReader as SqliteReader
+from .io import SqliteWriter as SqliteWriter
+from .io import TRCFileVersion as TRCFileVersion
+from .io import TRCReader as TRCReader
+from .io import TRCWriter as TRCWriter
+from .listener import AsyncBufferedReader as AsyncBufferedReader
+from .listener import BufferedReader as BufferedReader
+from .listener import Listener as Listener
+from .listener import RedirectReader as RedirectReader
+from .message import Message as Message
+from .notifier import Notifier as Notifier
+from .thread_safe_bus import ThreadSafeBus as ThreadSafeBus
+from .util import set_logging_level as set_logging_level

--- a/can/__init__.py
+++ b/can/__init__.py
@@ -20,6 +20,10 @@ from . import broadcastmanager as broadcastmanager
 from . import interface as interface
 from .bit_timing import BitTiming as BitTiming
 from .bit_timing import BitTimingFd as BitTimingFd
+from .broadcastmanager import CyclicSendTaskABC as CyclicSendTaskABC
+from .broadcastmanager import (
+    LimitedDurationCyclicSendTaskABC as LimitedDurationCyclicSendTaskABC,
+)
 from .broadcastmanager import ModifiableCyclicTaskABC as ModifiableCyclicTaskABC
 from .broadcastmanager import RestartableCyclicTaskABC as RestartableCyclicTaskABC
 from .bus import BusABC as BusABC

--- a/can/bit_timing.py
+++ b/can/bit_timing.py
@@ -1,8 +1,8 @@
 # pylint: disable=too-many-lines
 import math
-from typing import List, Mapping, Iterator, cast
+from typing import Iterator, List, Mapping, cast
 
-from can.typechecking import BitTimingFdDict, BitTimingDict
+from can.typechecking import BitTimingDict, BitTimingFdDict
 
 
 class BitTiming(Mapping):

--- a/can/broadcastmanager.py
+++ b/can/broadcastmanager.py
@@ -10,7 +10,7 @@ import logging
 import sys
 import threading
 import time
-from typing import Optional, Sequence, Tuple, Union, Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Optional, Sequence, Tuple, Union
 
 from typing_extensions import Final
 

--- a/can/bus.py
+++ b/can/bus.py
@@ -1,19 +1,18 @@
 """
 Contains the ABC bus implementation and its documentation.
 """
+
 import contextlib
-from typing import cast, Any, Iterator, List, Optional, Sequence, Tuple, Union
-
-import can.typechecking
-
-from abc import ABC, ABCMeta, abstractmethod
-import can
 import logging
 import threading
-from time import time
+from abc import ABC, ABCMeta, abstractmethod
 from enum import Enum, auto
+from time import time
+from typing import Any, Iterator, List, Optional, Sequence, Tuple, Union, cast
 
-from can.broadcastmanager import ThreadBasedCyclicSendTask, CyclicSendTaskABC
+import can
+import can.typechecking
+from can.broadcastmanager import CyclicSendTaskABC, ThreadBasedCyclicSendTask
 from can.message import Message
 
 LOG = logging.getLogger(__name__)

--- a/can/ctypesutil.py
+++ b/can/ctypesutil.py
@@ -5,7 +5,6 @@ This module contains common `ctypes` utils.
 import ctypes
 import logging
 import sys
-
 from typing import Any, Callable, Optional, Tuple, Union
 
 log = logging.getLogger("can.ctypesutil")

--- a/can/exceptions.py
+++ b/can/exceptions.py
@@ -17,9 +17,7 @@ For example, validating typical arguments and parameters might result in a
 
 import sys
 from contextlib import contextmanager
-
-from typing import Optional
-from typing import Type
+from typing import Optional, Type
 
 if sys.version_info >= (3, 9):
     from collections.abc import Generator

--- a/can/interface.py
+++ b/can/interface.py
@@ -6,12 +6,12 @@ CyclicSendTasks.
 
 import importlib
 import logging
-from typing import Any, cast, Iterable, Type, Optional, Union, List
+from typing import Any, Iterable, List, Optional, Type, Union, cast
 
 from . import util
 from .bus import BusABC
-from .interfaces import BACKENDS
 from .exceptions import CanInterfaceNotImplementedError
+from .interfaces import BACKENDS
 from .typechecking import AutoDetectedConfig, Channel
 
 log = logging.getLogger("can.interface")

--- a/can/interfaces/__init__.py
+++ b/can/interfaces/__init__.py
@@ -3,7 +3,7 @@ Interfaces contain low level implementations that interact with CAN hardware.
 """
 
 import sys
-from typing import cast, Dict, Tuple
+from typing import Dict, Tuple, cast
 
 # interface_name => (module, classname)
 BACKENDS: Dict[str, Tuple[str, str]] = {

--- a/can/interfaces/canalystii.py
+++ b/can/interfaces/canalystii.py
@@ -1,15 +1,15 @@
 from collections import deque
-from ctypes import c_ubyte
 import logging
 import time
-from typing import Any, Dict, Optional, Deque, Sequence, Tuple, Union
-
-from can import BitTiming, BusABC, Message, BitTimingFd
-from can.exceptions import CanTimeoutError
-from can.typechecking import CanFilters
-from can.util import deprecated_args_alias, check_or_adjust_timing_clock
+from ctypes import c_ubyte
+from typing import Any, Deque, Dict, Optional, Sequence, Tuple, Union
 
 import canalystii as driver
+
+from can import BitTiming, BitTimingFd, BusABC, Message
+from can.exceptions import CanTimeoutError
+from can.typechecking import CanFilters
+from can.util import check_or_adjust_timing_clock, deprecated_args_alias
 
 logger = logging.getLogger(__name__)
 

--- a/can/interfaces/canalystii.py
+++ b/can/interfaces/canalystii.py
@@ -1,6 +1,6 @@
-from collections import deque
 import logging
 import time
+from collections import deque
 from ctypes import c_ubyte
 from typing import Any, Deque, Dict, Optional, Sequence, Tuple, Union
 

--- a/can/interfaces/cantact.py
+++ b/can/interfaces/cantact.py
@@ -2,18 +2,19 @@
 Interface for CANtact devices from Linklayer Labs
 """
 
-import time
 import logging
-from typing import Optional, Union, Any
+import time
+from typing import Any, Optional, Union
 from unittest.mock import Mock
 
-from can import BusABC, Message, BitTiming, BitTimingFd
+from can import BitTiming, BitTimingFd, BusABC, Message
+
 from ..exceptions import (
     CanInitializationError,
     CanInterfaceNotImplementedError,
     error_check,
 )
-from ..util import deprecated_args_alias, check_or_adjust_timing_clock
+from ..util import check_or_adjust_timing_clock, deprecated_args_alias
 
 logger = logging.getLogger(__name__)
 

--- a/can/interfaces/etas/__init__.py
+++ b/can/interfaces/etas/__init__.py
@@ -3,7 +3,8 @@ import time
 from typing import Dict, List, Optional, Tuple
 
 import can
-from ...exceptions import CanInitializationError
+from can.exceptions import CanInitializationError
+
 from .boa import *
 
 
@@ -290,6 +291,7 @@ class EtasBus(can.BusABC):
         #     raise CanOperationError(f"OCI_AdaptCANConfiguration failed with error 0x{ec:X}")
         raise NotImplementedError("Setting state is not implemented.")
 
+    @staticmethod
     def _detect_available_configs() -> List[can.typechecking.AutoDetectedConfig]:
         nodeRange = CSI_NodeRange(CSI_NODE_MIN, CSI_NODE_MAX)
         tree = ctypes.POINTER(CSI_Tree)()

--- a/can/interfaces/gs_usb.py
+++ b/can/interfaces/gs_usb.py
@@ -1,14 +1,14 @@
+import logging
 from typing import Optional, Tuple
 
-from gs_usb.gs_usb import GsUsb
-from gs_usb.gs_usb_frame import GsUsbFrame, GS_USB_NONE_ECHO_ID
-from gs_usb.constants import CAN_ERR_FLAG, CAN_RTR_FLAG, CAN_EFF_FLAG, CAN_MAX_DLC
-import can
 import usb
-import logging
+from gs_usb.constants import CAN_EFF_FLAG, CAN_ERR_FLAG, CAN_MAX_DLC, CAN_RTR_FLAG
+from gs_usb.gs_usb import GsUsb
+from gs_usb.gs_usb_frame import GS_USB_NONE_ECHO_ID, GsUsbFrame
+
+import can
 
 from ..exceptions import CanInitializationError, CanOperationError
-
 
 logger = logging.getLogger(__name__)
 

--- a/can/interfaces/ics_neovi/__init__.py
+++ b/can/interfaces/ics_neovi/__init__.py
@@ -1,7 +1,11 @@
 """
 """
 
-from .neovi_bus import ICSApiError as ICSApiError
-from .neovi_bus import ICSInitializationError as ICSInitializationError
-from .neovi_bus import ICSOperationError as ICSOperationError
-from .neovi_bus import NeoViBus as NeoViBus
+__all__ = [
+    "ICSApiError",
+    "ICSInitializationError",
+    "ICSOperationError",
+    "NeoViBus",
+]
+
+from .neovi_bus import ICSApiError, ICSInitializationError, ICSOperationError, NeoViBus

--- a/can/interfaces/ics_neovi/__init__.py
+++ b/can/interfaces/ics_neovi/__init__.py
@@ -1,7 +1,7 @@
 """
 """
 
-from .neovi_bus import NeoViBus
-from .neovi_bus import ICSApiError
-from .neovi_bus import ICSInitializationError
-from .neovi_bus import ICSOperationError
+from .neovi_bus import ICSApiError as ICSApiError
+from .neovi_bus import ICSInitializationError as ICSInitializationError
+from .neovi_bus import ICSOperationError as ICSOperationError
+from .neovi_bus import NeoViBus as NeoViBus

--- a/can/interfaces/ics_neovi/neovi_bus.py
+++ b/can/interfaces/ics_neovi/neovi_bus.py
@@ -11,17 +11,18 @@ Implementation references:
 import logging
 import os
 import tempfile
-from collections import deque, defaultdict, Counter
+from collections import Counter, defaultdict, deque
 from itertools import cycle
 from threading import Event
 from warnings import warn
 
-from can import Message, BusABC
+from can import BusABC, Message
+
 from ...exceptions import (
     CanError,
-    CanTimeoutError,
-    CanOperationError,
     CanInitializationError,
+    CanOperationError,
+    CanTimeoutError,
 )
 
 logger = logging.getLogger(__name__)

--- a/can/interfaces/iscan.py
+++ b/can/interfaces/iscan.py
@@ -3,16 +3,17 @@ Interface for isCAN from *Thorsis Technologies GmbH*, former *ifak system GmbH*.
 """
 
 import ctypes
-import time
 import logging
+import time
 from typing import Optional, Tuple, Union
 
-from can import BusABC, Message
 from can import (
+    BusABC,
     CanError,
-    CanInterfaceNotImplementedError,
     CanInitializationError,
+    CanInterfaceNotImplementedError,
     CanOperationError,
+    Message,
 )
 
 logger = logging.getLogger(__name__)

--- a/can/interfaces/ixxat/__init__.py
+++ b/can/interfaces/ixxat/__init__.py
@@ -4,7 +4,9 @@ Ctypes wrapper module for IXXAT Virtual CAN Interface V4 on win32 systems
 Copyright (C) 2016-2021 Giuseppe Corbelli <giuseppe.corbelli@weightpack.com>
 """
 
-from can.interfaces.ixxat.canlib import IXXATBus
+from can.interfaces.ixxat.canlib import IXXATBus as IXXATBus
+
+# import this and not the one from vcinpl2 for backward compatibility
 from can.interfaces.ixxat.canlib_vcinpl import (
-    get_ixxat_hwids,
-)  # import this and not the one from vcinpl2 for backward compatibility
+    get_ixxat_hwids as get_ixxat_hwids,
+)

--- a/can/interfaces/ixxat/__init__.py
+++ b/can/interfaces/ixxat/__init__.py
@@ -4,9 +4,12 @@ Ctypes wrapper module for IXXAT Virtual CAN Interface V4 on win32 systems
 Copyright (C) 2016-2021 Giuseppe Corbelli <giuseppe.corbelli@weightpack.com>
 """
 
-from can.interfaces.ixxat.canlib import IXXATBus as IXXATBus
+__all__ = [
+    "get_ixxat_hwids",
+    "IXXATBus",
+]
+
+from can.interfaces.ixxat.canlib import IXXATBus
 
 # import this and not the one from vcinpl2 for backward compatibility
-from can.interfaces.ixxat.canlib_vcinpl import (
-    get_ixxat_hwids as get_ixxat_hwids,
-)
+from can.interfaces.ixxat.canlib_vcinpl import get_ixxat_hwids

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -1,10 +1,9 @@
+from typing import Optional
+
 import can.interfaces.ixxat.canlib_vcinpl as vcinpl
 import can.interfaces.ixxat.canlib_vcinpl2 as vcinpl2
-
 from can import BusABC, Message
 from can.bus import BusState
-
-from typing import Optional
 
 
 class IXXATBus(BusABC):

--- a/can/interfaces/ixxat/canlib_vcinpl.py
+++ b/can/interfaces/ixxat/canlib_vcinpl.py
@@ -13,16 +13,17 @@ import ctypes
 import functools
 import logging
 import sys
-from typing import Optional, Callable, Tuple
+from typing import Callable, Optional, Tuple
 
 from can import BusABC, Message
-from can.bus import BusState
-from can.exceptions import CanInterfaceNotImplementedError, CanInitializationError
 from can.broadcastmanager import (
     LimitedDurationCyclicSendTaskABC,
     RestartableCyclicTaskABC,
 )
-from can.ctypesutil import CLibrary, HANDLE, PHANDLE, HRESULT as ctypes_HRESULT
+from can.bus import BusState
+from can.ctypesutil import HANDLE, PHANDLE, CLibrary
+from can.ctypesutil import HRESULT as ctypes_HRESULT
+from can.exceptions import CanInitializationError, CanInterfaceNotImplementedError
 from can.util import deprecated_args_alias
 
 from . import constants, structures

--- a/can/interfaces/ixxat/canlib_vcinpl2.py
+++ b/can/interfaces/ixxat/canlib_vcinpl2.py
@@ -13,17 +13,17 @@ import ctypes
 import functools
 import logging
 import sys
-from typing import Optional, Callable, Tuple
+from typing import Callable, Optional, Tuple
 
+import can.util
 from can import BusABC, Message
-from can.exceptions import CanInterfaceNotImplementedError, CanInitializationError
 from can.broadcastmanager import (
     LimitedDurationCyclicSendTaskABC,
     RestartableCyclicTaskABC,
 )
-from can.ctypesutil import CLibrary, HANDLE, PHANDLE, HRESULT as ctypes_HRESULT
-
-import can.util
+from can.ctypesutil import HANDLE, PHANDLE, CLibrary
+from can.ctypesutil import HRESULT as ctypes_HRESULT
+from can.exceptions import CanInitializationError, CanInterfaceNotImplementedError
 from can.util import deprecated_args_alias
 
 from . import constants, structures

--- a/can/interfaces/kvaser/canlib.py
+++ b/can/interfaces/kvaser/canlib.py
@@ -6,15 +6,15 @@ specific to Python.
 Copyright (C) 2010 Dynamic Controls
 """
 
+import ctypes
+import logging
 import sys
 import time
-import logging
-import ctypes
 
-from can import BusABC
-from ...exceptions import CanError, CanInitializationError, CanOperationError
-from can import Message
+from can import BusABC, Message
 from can.util import time_perfcounter_correlation
+
+from ...exceptions import CanError, CanInitializationError, CanOperationError
 from . import constants as canstat
 from . import structures
 

--- a/can/interfaces/neousys/__init__.py
+++ b/can/interfaces/neousys/__init__.py
@@ -1,3 +1,5 @@
 """ Neousys CAN bus driver """
 
-from can.interfaces.neousys.neousys import NeousysBus as NeousysBus
+__all__ = ["NeousysBus"]
+
+from can.interfaces.neousys.neousys import NeousysBus

--- a/can/interfaces/neousys/__init__.py
+++ b/can/interfaces/neousys/__init__.py
@@ -1,3 +1,3 @@
 """ Neousys CAN bus driver """
 
-from can.interfaces.neousys.neousys import NeousysBus
+from can.interfaces.neousys.neousys import NeousysBus as NeousysBus

--- a/can/interfaces/neousys/neousys.py
+++ b/can/interfaces/neousys/neousys.py
@@ -14,21 +14,20 @@
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=wrong-import-position
 
-import queue
 import logging
 import platform
-from time import time
-
+import queue
 from ctypes import (
-    byref,
     CFUNCTYPE,
+    POINTER,
+    Structure,
+    byref,
     c_ubyte,
     c_uint,
     c_ushort,
-    POINTER,
     sizeof,
-    Structure,
 )
+from time import time
 
 try:
     from ctypes import WinDLL
@@ -36,12 +35,12 @@ except ImportError:
     from ctypes import CDLL
 
 from can import BusABC, Message
+
 from ...exceptions import (
     CanInitializationError,
-    CanOperationError,
     CanInterfaceNotImplementedError,
+    CanOperationError,
 )
-
 
 logger = logging.getLogger(__name__)
 

--- a/can/interfaces/nican.py
+++ b/can/interfaces/nican.py
@@ -16,17 +16,17 @@ TODO: We could implement this interface such that setting other filters
 import ctypes
 import logging
 import sys
-
-from can import BusABC, Message
-import can.typechecking
-from ..exceptions import (
-    CanError,
-    CanInterfaceNotImplementedError,
-    CanOperationError,
-    CanInitializationError,
-)
 from typing import Optional, Tuple, Type
 
+import can.typechecking
+from can import BusABC, Message
+
+from ..exceptions import (
+    CanError,
+    CanInitializationError,
+    CanInterfaceNotImplementedError,
+    CanOperationError,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/can/interfaces/nixnet.py
+++ b/can/interfaces/nixnet.py
@@ -13,14 +13,14 @@ import os
 import time
 from queue import SimpleQueue
 from types import ModuleType
-from typing import Optional, List, Union, Tuple, Any
+from typing import Any, List, Optional, Tuple, Union
 
 import can.typechecking
-from can import BusABC, Message, BitTiming, BitTimingFd
+from can import BitTiming, BitTimingFd, BusABC, Message
 from can.exceptions import (
     CanInitializationError,
-    CanOperationError,
     CanInterfaceNotImplementedError,
+    CanOperationError,
 )
 from can.util import check_or_adjust_timing_clock, deprecated_args_alias
 

--- a/can/interfaces/pcan/__init__.py
+++ b/can/interfaces/pcan/__init__.py
@@ -1,4 +1,5 @@
 """
 """
 
-from can.interfaces.pcan.pcan import PcanBus, PcanError
+from can.interfaces.pcan.pcan import PcanBus as PcanBus
+from can.interfaces.pcan.pcan import PcanError as PcanError

--- a/can/interfaces/pcan/__init__.py
+++ b/can/interfaces/pcan/__init__.py
@@ -1,5 +1,9 @@
 """
 """
 
-from can.interfaces.pcan.pcan import PcanBus as PcanBus
-from can.interfaces.pcan.pcan import PcanError as PcanError
+__all__ = [
+    "PcanBus",
+    "PcanError",
+]
+
+from can.interfaces.pcan.pcan import PcanBus, PcanError

--- a/can/interfaces/pcan/basic.py
+++ b/can/interfaces/pcan/basic.py
@@ -15,11 +15,10 @@
 #  more Info at http://www.peak-system.com
 
 # Module Imports
+import logging
+import platform
 from ctypes import *
 from ctypes.util import find_library
-import platform
-
-import logging
 
 PLATFORM = platform.system()
 IS_WINDOWS = PLATFORM == "Windows"

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -2,73 +2,73 @@
 Enable basic CAN over a PCAN USB device.
 """
 import logging
+import platform
 import time
 from datetime import datetime
-import platform
-from typing import Optional, List, Tuple, Union, Any
+from typing import Any, List, Optional, Tuple, Union
 
 from packaging import version
 
 from can import (
-    BusABC,
-    BusState,
     BitTiming,
     BitTimingFd,
-    Message,
+    BusABC,
+    BusState,
     CanError,
-    CanOperationError,
     CanInitializationError,
+    CanOperationError,
+    Message,
 )
 from can.util import check_or_adjust_timing_clock, dlc2len, len2dlc
+
 from .basic import (
-    PCAN_BITRATES,
-    PCAN_FD_PARAMETER_LIST,
-    PCAN_CHANNEL_NAMES,
-    PCAN_NONEBUS,
-    PCAN_BAUD_500K,
-    PCAN_TYPE_ISA,
-    PCANBasic,
-    PCAN_ERROR_OK,
-    PCAN_ALLOW_ERROR_FRAMES,
-    PCAN_PARAMETER_ON,
-    PCAN_RECEIVE_EVENT,
-    PCAN_API_VERSION,
-    PCAN_DEVICE_NUMBER,
-    PCAN_ERROR_QRCVEMPTY,
-    PCAN_ERROR_BUSLIGHT,
-    PCAN_ERROR_BUSHEAVY,
-    PCAN_MESSAGE_EXTENDED,
-    PCAN_MESSAGE_RTR,
-    PCAN_MESSAGE_FD,
-    PCAN_MESSAGE_BRS,
-    PCAN_MESSAGE_ESI,
-    PCAN_MESSAGE_ERRFRAME,
-    PCAN_MESSAGE_STANDARD,
-    TPCANMsgFD,
-    TPCANMsg,
-    PCAN_CHANNEL_IDENTIFYING,
-    PCAN_LISTEN_ONLY,
-    PCAN_PARAMETER_OFF,
-    TPCANHandle,
+    FEATURE_FD_CAPABLE,
     IS_LINUX,
     IS_WINDOWS,
-    PCAN_PCIBUS1,
-    PCAN_USBBUS1,
-    PCAN_PCCBUS1,
-    PCAN_LANBUS1,
-    PCAN_CHANNEL_CONDITION,
-    PCAN_CHANNEL_AVAILABLE,
-    PCAN_CHANNEL_FEATURES,
-    FEATURE_FD_CAPABLE,
-    PCAN_DICT_STATUS,
-    PCAN_BUSOFF_AUTORESET,
-    TPCANBaudrate,
+    PCAN_ALLOW_ERROR_FRAMES,
+    PCAN_API_VERSION,
     PCAN_ATTACHED_CHANNELS,
-    TPCANChannelInformation,
-    VALID_PCAN_FD_CLOCKS,
+    PCAN_BAUD_500K,
+    PCAN_BITRATES,
+    PCAN_BUSOFF_AUTORESET,
+    PCAN_CHANNEL_AVAILABLE,
+    PCAN_CHANNEL_CONDITION,
+    PCAN_CHANNEL_FEATURES,
+    PCAN_CHANNEL_IDENTIFYING,
+    PCAN_CHANNEL_NAMES,
+    PCAN_DEVICE_NUMBER,
+    PCAN_DICT_STATUS,
+    PCAN_ERROR_BUSHEAVY,
+    PCAN_ERROR_BUSLIGHT,
+    PCAN_ERROR_OK,
+    PCAN_ERROR_QRCVEMPTY,
+    PCAN_FD_PARAMETER_LIST,
+    PCAN_LANBUS1,
+    PCAN_LISTEN_ONLY,
+    PCAN_MESSAGE_BRS,
+    PCAN_MESSAGE_ERRFRAME,
+    PCAN_MESSAGE_ESI,
+    PCAN_MESSAGE_EXTENDED,
+    PCAN_MESSAGE_FD,
+    PCAN_MESSAGE_RTR,
+    PCAN_MESSAGE_STANDARD,
+    PCAN_NONEBUS,
+    PCAN_PARAMETER_OFF,
+    PCAN_PARAMETER_ON,
+    PCAN_PCCBUS1,
+    PCAN_PCIBUS1,
+    PCAN_RECEIVE_EVENT,
+    PCAN_TYPE_ISA,
+    PCAN_USBBUS1,
     VALID_PCAN_CAN_CLOCKS,
+    VALID_PCAN_FD_CLOCKS,
+    PCANBasic,
+    TPCANBaudrate,
+    TPCANChannelInformation,
+    TPCANHandle,
+    TPCANMsg,
+    TPCANMsgFD,
 )
-
 
 # Set up logging
 log = logging.getLogger("can.pcan")
@@ -96,7 +96,7 @@ if IS_WINDOWS:
     try:
         # Try builtin Python 3 Windows API
         from _overlapped import CreateEvent
-        from _winapi import WaitForSingleObject, WAIT_OBJECT_0, INFINITE
+        from _winapi import INFINITE, WAIT_OBJECT_0, WaitForSingleObject
 
         HAS_EVENTS = True
     except ImportError:
@@ -104,8 +104,6 @@ if IS_WINDOWS:
 
 elif IS_LINUX:
     try:
-        import errno
-        import os
         import select
 
         HAS_EVENTS = True

--- a/can/interfaces/robotell.py
+++ b/can/interfaces/robotell.py
@@ -3,11 +3,12 @@ Interface for Chinese Robotell compatible interfaces (win32/linux).
 """
 
 import io
-import time
 import logging
+import time
 from typing import Optional
 
 from can import BusABC, Message
+
 from ..exceptions import CanInterfaceNotImplementedError, CanOperationError
 
 logger = logging.getLogger(__name__)

--- a/can/interfaces/seeedstudio/__init__.py
+++ b/can/interfaces/seeedstudio/__init__.py
@@ -1,4 +1,4 @@
 """
 """
 
-from can.interfaces.seeedstudio.seeedstudio import SeeedBus
+from can.interfaces.seeedstudio.seeedstudio import SeeedBus as SeeedBus

--- a/can/interfaces/seeedstudio/__init__.py
+++ b/can/interfaces/seeedstudio/__init__.py
@@ -1,4 +1,6 @@
 """
 """
 
-from can.interfaces.seeedstudio.seeedstudio import SeeedBus as SeeedBus
+__all__ = ["SeeedBus"]
+
+from can.interfaces.seeedstudio.seeedstudio import SeeedBus

--- a/can/interfaces/seeedstudio/seeedstudio.py
+++ b/can/interfaces/seeedstudio/seeedstudio.py
@@ -6,9 +6,9 @@ https://www.seeedstudio.com/USB-CAN-Analyzer-p-2888.html
 SKU 114991193
 """
 
+import io
 import logging
 import struct
-import io
 from time import time
 
 import can

--- a/can/interfaces/serial/__init__.py
+++ b/can/interfaces/serial/__init__.py
@@ -1,4 +1,4 @@
 """
 """
 
-from can.interfaces.serial.serial_can import SerialBus as Bus
+from can.interfaces.serial.serial_can import SerialBus as SerialBus

--- a/can/interfaces/serial/__init__.py
+++ b/can/interfaces/serial/__init__.py
@@ -1,4 +1,6 @@
 """
 """
 
-from can.interfaces.serial.serial_can import SerialBus as SerialBus
+__all__ = ["SerialBus"]
+
+from can.interfaces.serial.serial_can import SerialBus

--- a/can/interfaces/serial/serial_can.py
+++ b/can/interfaces/serial/serial_can.py
@@ -10,14 +10,15 @@ See the interface documentation for the format being used.
 import io
 import logging
 import struct
-from typing import Any, List, Tuple, Optional
+from typing import Any, List, Optional, Tuple
 
-from can import BusABC, Message
 from can import (
-    CanInterfaceNotImplementedError,
+    BusABC,
     CanInitializationError,
+    CanInterfaceNotImplementedError,
     CanOperationError,
     CanTimeoutError,
+    Message,
 )
 from can.typechecking import AutoDetectedConfig
 

--- a/can/interfaces/slcan.py
+++ b/can/interfaces/slcan.py
@@ -2,21 +2,19 @@
 Interface for slcan compatible interfaces (win32/linux).
 """
 
+import io
+import logging
+import time
 from typing import Any, Optional, Tuple
 
-import io
-import time
-import logging
+from can import BusABC, Message, typechecking
 
-from can import BusABC, Message
 from ..exceptions import (
-    CanInterfaceNotImplementedError,
     CanInitializationError,
+    CanInterfaceNotImplementedError,
     CanOperationError,
     error_check,
 )
-from can import typechecking
-
 
 logger = logging.getLogger(__name__)
 

--- a/can/interfaces/socketcan/__init__.py
+++ b/can/interfaces/socketcan/__init__.py
@@ -2,4 +2,6 @@
 See: https://www.kernel.org/doc/Documentation/networking/can.txt
 """
 
-from .socketcan import SocketcanBus, CyclicSendTask, MultiRateCyclicSendTask
+from .socketcan import CyclicSendTask as CyclicSendTask
+from .socketcan import MultiRateCyclicSendTask as MultiRateCyclicSendTask
+from .socketcan import SocketcanBus as SocketcanBus

--- a/can/interfaces/socketcan/__init__.py
+++ b/can/interfaces/socketcan/__init__.py
@@ -2,6 +2,10 @@
 See: https://www.kernel.org/doc/Documentation/networking/can.txt
 """
 
-from .socketcan import CyclicSendTask as CyclicSendTask
-from .socketcan import MultiRateCyclicSendTask as MultiRateCyclicSendTask
-from .socketcan import SocketcanBus as SocketcanBus
+__all__ = [
+    "CyclicSendTask",
+    "MultiRateCyclicSendTask",
+    "SocketcanBus",
+]
+
+from .socketcan import CyclicSendTask, MultiRateCyclicSendTask, SocketcanBus

--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -5,17 +5,16 @@ along some internal methods.
 At the end of the file the usage of the internal methods is shown.
 """
 
-from typing import Dict, List, Optional, Sequence, Tuple, Type, Union
-
-import logging
 import ctypes
 import ctypes.util
+import errno
+import logging
 import select
 import socket
 import struct
-import time
 import threading
-import errno
+import time
+from typing import Dict, List, Optional, Sequence, Tuple, Type, Union
 
 log = logging.getLogger(__name__)
 log_tx = log.getChild("tx")
@@ -31,15 +30,15 @@ except ImportError:
 
 
 import can
-from can import Message, BusABC
+from can import BusABC, Message
 from can.broadcastmanager import (
+    LimitedDurationCyclicSendTaskABC,
     ModifiableCyclicTaskABC,
     RestartableCyclicTaskABC,
-    LimitedDurationCyclicSendTaskABC,
 )
-from can.typechecking import CanFilters
 from can.interfaces.socketcan import constants
-from can.interfaces.socketcan.utils import pack_filters, find_available_interfaces
+from can.interfaces.socketcan.utils import find_available_interfaces, pack_filters
+from can.typechecking import CanFilters
 
 
 # Setup BCM struct

--- a/can/interfaces/socketcan/utils.py
+++ b/can/interfaces/socketcan/utils.py
@@ -8,7 +8,7 @@ import logging
 import os
 import struct
 import subprocess
-from typing import cast, Optional, List
+from typing import List, Optional, cast
 
 from can import typechecking
 from can.interfaces.socketcan.constants import CAN_EFF_FLAG

--- a/can/interfaces/socketcand/__init__.py
+++ b/can/interfaces/socketcand/__init__.py
@@ -6,4 +6,6 @@ Copyright (C) 2021  DOMOLOGIC GmbH
 http://www.domologic.de
 """
 
-from .socketcand import SocketCanDaemonBus as SocketCanDaemonBus
+__all__ = ["SocketCanDaemonBus"]
+
+from .socketcand import SocketCanDaemonBus

--- a/can/interfaces/socketcand/__init__.py
+++ b/can/interfaces/socketcand/__init__.py
@@ -6,4 +6,4 @@ Copyright (C) 2021  DOMOLOGIC GmbH
 http://www.domologic.de
 """
 
-from .socketcand import SocketCanDaemonBus
+from .socketcand import SocketCanDaemonBus as SocketCanDaemonBus

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -7,13 +7,14 @@ Authors: Marvin Seiler, Gerrit Telkamp
 Copyright (C) 2021  DOMOLOGIC GmbH
 http://www.domologic.de
 """
-import can
-import socket
-import select
 import logging
+import select
+import socket
 import time
 import traceback
 from collections import deque
+
+import can
 
 log = logging.getLogger(__name__)
 

--- a/can/interfaces/systec/__init__.py
+++ b/can/interfaces/systec/__init__.py
@@ -1,1 +1,3 @@
-from can.interfaces.systec.ucanbus import UcanBus as UcanBus
+__all__ = ["UcanBus"]
+
+from can.interfaces.systec.ucanbus import UcanBus

--- a/can/interfaces/systec/__init__.py
+++ b/can/interfaces/systec/__init__.py
@@ -1,1 +1,1 @@
-from can.interfaces.systec.ucanbus import UcanBus
+from can.interfaces.systec.ucanbus import UcanBus as UcanBus

--- a/can/interfaces/systec/constants.py
+++ b/can/interfaces/systec/constants.py
@@ -1,4 +1,6 @@
-from ctypes import c_ubyte as BYTE, c_ushort as WORD, c_ulong as DWORD
+from ctypes import c_ubyte as BYTE
+from ctypes import c_ulong as DWORD
+from ctypes import c_ushort as WORD
 
 #: Maximum number of modules that are supported.
 MAX_MODULES = 64

--- a/can/interfaces/systec/exceptions.py
+++ b/can/interfaces/systec/exceptions.py
@@ -1,9 +1,9 @@
+from abc import ABC, abstractmethod
 from typing import Dict
 
-from abc import ABC, abstractmethod
+from can import CanError
 
 from .constants import ReturnCode
-from can import CanError
 
 
 class UcanException(CanError, ABC):

--- a/can/interfaces/systec/structures.py
+++ b/can/interfaces/systec/structures.py
@@ -1,12 +1,20 @@
-from ctypes import Structure, POINTER, sizeof
+import os
+from ctypes import POINTER, Structure, sizeof
+from ctypes import (
+    c_long as BOOL,
+)
 from ctypes import (
     c_ubyte as BYTE,
-    c_ushort as WORD,
+)
+from ctypes import (
     c_ulong as DWORD,
-    c_long as BOOL,
+)
+from ctypes import (
+    c_ushort as WORD,
+)
+from ctypes import (
     c_void_p as LPVOID,
 )
-import os
 
 # Workaround for Unix based platforms to be able to load structures for testing, etc...
 if os.name == "nt":

--- a/can/interfaces/systec/ucan.py
+++ b/can/interfaces/systec/ucan.py
@@ -1,14 +1,12 @@
 import logging
 import sys
-
 from ctypes import byref
 from ctypes import c_wchar_p as LPWSTR
 
 from ...exceptions import CanInterfaceNotImplementedError
-
 from .constants import *
-from .structures import *
 from .exceptions import *
+from .structures import *
 
 log = logging.getLogger("can.systec")
 

--- a/can/interfaces/systec/ucanbus.py
+++ b/can/interfaces/systec/ucanbus.py
@@ -2,11 +2,11 @@ import logging
 from threading import Event
 
 from can import BusABC, BusState, Message
-from ...exceptions import CanError, CanInitializationError, CanOperationError
 
+from ...exceptions import CanError, CanInitializationError, CanOperationError
 from .constants import *
-from .structures import *
 from .exceptions import UcanException
+from .structures import *
 from .ucan import UcanServer
 
 log = logging.getLogger("can.systec")

--- a/can/interfaces/udp_multicast/__init__.py
+++ b/can/interfaces/udp_multicast/__init__.py
@@ -1,3 +1,3 @@
 """A module to allow CAN over UDP on IPv4/IPv6 multicast."""
 
-from .bus import UdpMulticastBus
+from .bus import UdpMulticastBus as UdpMulticastBus

--- a/can/interfaces/udp_multicast/__init__.py
+++ b/can/interfaces/udp_multicast/__init__.py
@@ -1,3 +1,5 @@
 """A module to allow CAN over UDP on IPv4/IPv6 multicast."""
 
-from .bus import UdpMulticastBus as UdpMulticastBus
+__all__ = ["UdpMulticastBus"]
+
+from .bus import UdpMulticastBus

--- a/can/interfaces/udp_multicast/bus.py
+++ b/can/interfaces/udp_multicast/bus.py
@@ -17,8 +17,7 @@ import can
 from can import BusABC
 from can.typechecking import AutoDetectedConfig
 
-from .utils import pack_message, unpack_message, check_msgpack_installed
-
+from .utils import check_msgpack_installed, pack_message, unpack_message
 
 # see socket.getaddrinfo()
 IPv4_ADDRESS_INFO = Tuple[str, int]  # address, port

--- a/can/interfaces/udp_multicast/utils.py
+++ b/can/interfaces/udp_multicast/utils.py
@@ -2,12 +2,9 @@
 Defines common functions.
 """
 
-from typing import Any
-from typing import Dict
-from typing import Optional
+from typing import Any, Dict, Optional
 
-from can import Message
-from can import CanInterfaceNotImplementedError
+from can import CanInterfaceNotImplementedError, Message
 from can.typechecking import ReadableBytesLike
 
 try:

--- a/can/interfaces/usb2can/__init__.py
+++ b/can/interfaces/usb2can/__init__.py
@@ -1,5 +1,10 @@
 """
 """
 
-from .usb2canabstractionlayer import Usb2CanAbstractionLayer as Usb2CanAbstractionLayer
-from .usb2canInterface import Usb2canBus as Usb2canBus
+__all__ = [
+    "Usb2CanAbstractionLayer",
+    "Usb2canBus",
+]
+
+from .usb2canabstractionlayer import Usb2CanAbstractionLayer
+from .usb2canInterface import Usb2canBus

--- a/can/interfaces/usb2can/__init__.py
+++ b/can/interfaces/usb2can/__init__.py
@@ -1,5 +1,5 @@
 """
 """
 
-from .usb2canInterface import Usb2canBus
-from .usb2canabstractionlayer import Usb2CanAbstractionLayer
+from .usb2canabstractionlayer import Usb2CanAbstractionLayer as Usb2CanAbstractionLayer
+from .usb2canInterface import Usb2canBus as Usb2canBus

--- a/can/interfaces/usb2can/usb2canInterface.py
+++ b/can/interfaces/usb2can/usb2canInterface.py
@@ -6,14 +6,17 @@ import logging
 from ctypes import byref
 from typing import Optional
 
-from can import BusABC, Message, CanInitializationError, CanOperationError
-from .usb2canabstractionlayer import Usb2CanAbstractionLayer, CanalMsg, CanalError
+from can import BusABC, CanInitializationError, CanOperationError, Message
+
+from .serial_selector import find_serial_devices
 from .usb2canabstractionlayer import (
     IS_ERROR_FRAME,
-    IS_REMOTE_FRAME,
     IS_ID_TYPE,
+    IS_REMOTE_FRAME,
+    CanalError,
+    CanalMsg,
+    Usb2CanAbstractionLayer,
 )
-from .serial_selector import find_serial_devices
 
 # Set up logging
 log = logging.getLogger("can.usb2can")

--- a/can/interfaces/usb2can/usb2canabstractionlayer.py
+++ b/can/interfaces/usb2can/usb2canabstractionlayer.py
@@ -3,11 +3,12 @@ This wrapper is for windows or direct access via CANAL API.
 Socket CAN is recommended under Unix/Linux systems.
 """
 
+import logging
 from ctypes import *
 from enum import IntEnum
-import logging
 
 import can
+
 from ...exceptions import error_check
 from ...typechecking import StringPathLike
 

--- a/can/interfaces/vector/__init__.py
+++ b/can/interfaces/vector/__init__.py
@@ -1,12 +1,24 @@
 """
 """
 
-from .canlib import VectorBus as VectorBus
-from .canlib import VectorBusParams as VectorBusParams
-from .canlib import VectorCanFdParams as VectorCanFdParams
-from .canlib import VectorCanParams as VectorCanParams
-from .canlib import VectorChannelConfig as VectorChannelConfig
-from .canlib import get_channel_configs as get_channel_configs
-from .exceptions import VectorError as VectorError
-from .exceptions import VectorInitializationError as VectorInitializationError
-from .exceptions import VectorOperationError as VectorOperationError
+__all__ = [
+    "get_channel_configs",
+    "VectorBus",
+    "VectorBusParams",
+    "VectorCanFdParams",
+    "VectorCanParams",
+    "VectorChannelConfig",
+    "VectorError",
+    "VectorInitializationError",
+    "VectorOperationError",
+]
+
+from .canlib import (
+    VectorBus,
+    VectorBusParams,
+    VectorCanFdParams,
+    VectorCanParams,
+    VectorChannelConfig,
+    get_channel_configs,
+)
+from .exceptions import VectorError, VectorInitializationError, VectorOperationError

--- a/can/interfaces/vector/__init__.py
+++ b/can/interfaces/vector/__init__.py
@@ -1,12 +1,12 @@
 """
 """
 
-from .canlib import (
-    VectorBus,
-    get_channel_configs,
-    VectorChannelConfig,
-    VectorBusParams,
-    VectorCanParams,
-    VectorCanFdParams,
-)
-from .exceptions import VectorError, VectorOperationError, VectorInitializationError
+from .canlib import VectorBus as VectorBus
+from .canlib import VectorBusParams as VectorBusParams
+from .canlib import VectorCanFdParams as VectorCanFdParams
+from .canlib import VectorCanParams as VectorCanParams
+from .canlib import VectorChannelConfig as VectorChannelConfig
+from .canlib import get_channel_configs as get_channel_configs
+from .exceptions import VectorError as VectorError
+from .exceptions import VectorInitializationError as VectorInitializationError
+from .exceptions import VectorOperationError as VectorOperationError

--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -8,19 +8,19 @@ Authors: Julien Grave <grave.jul@gmail.com>, Christian Sandberg
 # ==============================
 import ctypes
 import logging
-import time
 import os
+import time
 from types import ModuleType
 from typing import (
+    Any,
+    Callable,
+    Dict,
     List,
     NamedTuple,
     Optional,
-    Tuple,
     Sequence,
+    Tuple,
     Union,
-    Any,
-    Dict,
-    Callable,
     cast,
 )
 
@@ -28,7 +28,7 @@ WaitForSingleObject: Optional[Callable[[int, int], int]]
 INFINITE: Optional[int]
 try:
     # Try builtin Python 3 Windows API
-    from _winapi import WaitForSingleObject, INFINITE  # type: ignore
+    from _winapi import INFINITE, WaitForSingleObject  # type: ignore
 
     HAS_EVENTS = True
 except ImportError:
@@ -38,21 +38,21 @@ except ImportError:
 # Import Modules
 # ==============
 from can import (
-    BusABC,
-    Message,
-    CanInterfaceNotImplementedError,
-    CanInitializationError,
     BitTiming,
     BitTimingFd,
-)
-from can.util import (
-    len2dlc,
-    dlc2len,
-    deprecated_args_alias,
-    time_perfcounter_correlation,
-    check_or_adjust_timing_clock,
+    BusABC,
+    CanInitializationError,
+    CanInterfaceNotImplementedError,
+    Message,
 )
 from can.typechecking import AutoDetectedConfig, CanFilters
+from can.util import (
+    check_or_adjust_timing_clock,
+    deprecated_args_alias,
+    dlc2len,
+    len2dlc,
+    time_perfcounter_correlation,
+)
 
 # Define Module Logger
 # ====================
@@ -60,8 +60,8 @@ LOG = logging.getLogger(__name__)
 
 # Import Vector API modules
 # =========================
+from . import xlclass, xldefine
 from .exceptions import VectorError, VectorInitializationError, VectorOperationError
-from . import xldefine, xlclass
 
 # Import safely Vector API module for Travis tests
 xldriver: Optional[ModuleType] = None

--- a/can/interfaces/vector/xldefine.py
+++ b/can/interfaces/vector/xldefine.py
@@ -6,7 +6,6 @@ Definition of constants for vxlapi.
 # ==============================
 from enum import IntEnum, IntFlag
 
-
 MAX_MSG_LEN = 8
 XL_CAN_MAX_DATA_LEN = 64
 XL_INVALID_PORTHANDLE = -1

--- a/can/interfaces/vector/xldriver.py
+++ b/can/interfaces/vector/xldriver.py
@@ -10,7 +10,8 @@ Authors: Julien Grave <grave.jul@gmail.com>, Christian Sandberg
 import ctypes
 import logging
 import platform
-from .exceptions import VectorOperationError, VectorInitializationError
+
+from .exceptions import VectorInitializationError, VectorOperationError
 
 # Define Module Logger
 # ====================

--- a/can/interfaces/virtual.py
+++ b/can/interfaces/virtual.py
@@ -6,14 +6,13 @@ Any VirtualBus instances connecting to the same channel
 and reside in the same process will receive the same messages.
 """
 
-from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
-
-from copy import deepcopy
 import logging
-import time
 import queue
-from threading import RLock
+import time
+from copy import deepcopy
 from random import randint
+from threading import RLock
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from can import CanOperationError
 from can.bus import BusABC

--- a/can/io/__init__.py
+++ b/can/io/__init__.py
@@ -4,14 +4,26 @@ and Writers based off the file extension.
 """
 
 # Generic
-from .logger import Logger, BaseRotatingLogger, SizedRotatingLogger
-from .player import LogReader, MessageSync
+from .logger import BaseRotatingLogger as BaseRotatingLogger
+from .logger import Logger as Logger
+from .logger import SizedRotatingLogger as SizedRotatingLogger
+from .player import LogReader as LogReader
+from .player import MessageSync as MessageSync
+
+# isort: split
 
 # Format specific
-from .asc import ASCWriter, ASCReader
-from .blf import BLFReader, BLFWriter
-from .canutils import CanutilsLogReader, CanutilsLogWriter
-from .csv import CSVWriter, CSVReader
-from .sqlite import SqliteReader, SqliteWriter
-from .printer import Printer
-from .trc import TRCReader, TRCWriter, TRCFileVersion
+from .asc import ASCReader as ASCReader
+from .asc import ASCWriter as ASCWriter
+from .blf import BLFReader as BLFReader
+from .blf import BLFWriter as BLFWriter
+from .canutils import CanutilsLogReader as CanutilsLogReader
+from .canutils import CanutilsLogWriter as CanutilsLogWriter
+from .csv import CSVReader as CSVReader
+from .csv import CSVWriter as CSVWriter
+from .printer import Printer as Printer
+from .sqlite import SqliteReader as SqliteReader
+from .sqlite import SqliteWriter as SqliteWriter
+from .trc import TRCFileVersion as TRCFileVersion
+from .trc import TRCReader as TRCReader
+from .trc import TRCWriter as TRCWriter

--- a/can/io/__init__.py
+++ b/can/io/__init__.py
@@ -3,27 +3,39 @@ Read and write CAN bus messages using a range of Readers
 and Writers based off the file extension.
 """
 
+__all__ = [
+    "ASCReader",
+    "ASCWriter",
+    "BaseRotatingLogger",
+    "BLFReader",
+    "BLFWriter",
+    "CanutilsLogReader",
+    "CanutilsLogWriter",
+    "CSVReader",
+    "CSVWriter",
+    "Logger",
+    "LogReader",
+    "MessageSync",
+    "Printer",
+    "SizedRotatingLogger",
+    "SqliteReader",
+    "SqliteWriter",
+    "TRCFileVersion",
+    "TRCReader",
+    "TRCWriter",
+]
+
 # Generic
-from .logger import BaseRotatingLogger as BaseRotatingLogger
-from .logger import Logger as Logger
-from .logger import SizedRotatingLogger as SizedRotatingLogger
-from .player import LogReader as LogReader
-from .player import MessageSync as MessageSync
+from .logger import BaseRotatingLogger, Logger, SizedRotatingLogger
+from .player import LogReader, MessageSync
 
 # isort: split
 
 # Format specific
-from .asc import ASCReader as ASCReader
-from .asc import ASCWriter as ASCWriter
-from .blf import BLFReader as BLFReader
-from .blf import BLFWriter as BLFWriter
-from .canutils import CanutilsLogReader as CanutilsLogReader
-from .canutils import CanutilsLogWriter as CanutilsLogWriter
-from .csv import CSVReader as CSVReader
-from .csv import CSVWriter as CSVWriter
-from .printer import Printer as Printer
-from .sqlite import SqliteReader as SqliteReader
-from .sqlite import SqliteWriter as SqliteWriter
-from .trc import TRCFileVersion as TRCFileVersion
-from .trc import TRCReader as TRCReader
-from .trc import TRCWriter as TRCWriter
+from .asc import ASCReader, ASCWriter
+from .blf import BLFReader, BLFWriter
+from .canutils import CanutilsLogReader, CanutilsLogWriter
+from .csv import CSVReader, CSVWriter
+from .printer import Printer
+from .sqlite import SqliteReader, SqliteWriter
+from .trc import TRCFileVersion, TRCReader, TRCWriter

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -5,18 +5,16 @@ Example .asc files:
     - https://bitbucket.org/tobylorenz/vector_asc/src/master/src/Vector/ASC/tests/unittests/data/
     - under `test/data/logfile.asc`
 """
-import re
-from typing import Any, Generator, List, Optional, Dict, Union, TextIO
-
-from datetime import datetime
-import time
 import logging
+import re
+import time
+from datetime import datetime
+from typing import Any, Dict, Generator, List, Optional, TextIO, Union
 
 from ..message import Message
-from ..util import channel2int, len2dlc, dlc2len
-from .generic import FileIOMessageWriter, MessageReader
 from ..typechecking import StringPathLike
-
+from ..util import channel2int, dlc2len, len2dlc
+from .generic import FileIOMessageWriter, MessageReader
 
 CAN_MSG_EXT = 0x80000000
 CAN_ID_MASK = 0x1FFFFFFF

--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -12,18 +12,17 @@ of uncompressed data each. This data contains the actual CAN messages and other
 objects types.
 """
 
-import struct
-import zlib
 import datetime
-import time
 import logging
-from typing import List, BinaryIO, Generator, Union, Tuple, Optional, cast, Any
+import struct
+import time
+import zlib
+from typing import Any, BinaryIO, Generator, List, Optional, Tuple, Union, cast
 
 from ..message import Message
-from ..util import len2dlc, dlc2len, channel2int
 from ..typechecking import StringPathLike
+from ..util import channel2int, dlc2len, len2dlc
 from .generic import FileIOMessageWriter, MessageReader
-
 
 TSystemTime = Tuple[int, int, int, int, int, int, int, int]
 

--- a/can/io/canutils.py
+++ b/can/io/canutils.py
@@ -5,11 +5,12 @@ It is is compatible with "candump -L" from the canutils program
 """
 
 import logging
-from typing import Generator, TextIO, Union, Any
+from typing import Any, Generator, TextIO, Union
 
 from can.message import Message
-from .generic import FileIOMessageWriter, MessageReader
+
 from ..typechecking import StringPathLike
+from .generic import FileIOMessageWriter, MessageReader
 
 log = logging.getLogger("can.io.canutils")
 

--- a/can/io/csv.py
+++ b/can/io/csv.py
@@ -9,12 +9,13 @@ TODO: This module could use https://docs.python.org/2/library/csv.html#module-cs
       of a CSV file.
 """
 
-from base64 import b64encode, b64decode
-from typing import TextIO, Generator, Union, Any
+from base64 import b64decode, b64encode
+from typing import Any, Generator, TextIO, Union
 
 from can.message import Message
-from .generic import FileIOMessageWriter, MessageReader
+
 from ..typechecking import StringPathLike
+from .generic import FileIOMessageWriter, MessageReader
 
 
 class CSVReader(MessageReader):

--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -2,29 +2,28 @@
 See the :class:`Logger` class.
 """
 
+import gzip
 import os
 import pathlib
 from abc import ABC, abstractmethod
 from datetime import datetime
-import gzip
-from typing import Any, Optional, Callable, Type, Tuple, cast, Dict, Set
-
 from types import TracebackType
+from typing import Any, Callable, Dict, Optional, Set, Tuple, Type, cast
 
-from typing_extensions import Literal
 from pkg_resources import iter_entry_points
+from typing_extensions import Literal
 
-from ..message import Message
 from ..listener import Listener
-from .generic import BaseIOHandler, FileIOMessageWriter, MessageWriter
+from ..message import Message
+from ..typechecking import AcceptedIOType, FileLike, StringPathLike
 from .asc import ASCWriter
 from .blf import BLFWriter
 from .canutils import CanutilsLogWriter
 from .csv import CSVWriter
-from .sqlite import SqliteWriter
+from .generic import BaseIOHandler, FileIOMessageWriter, MessageWriter
 from .printer import Printer
+from .sqlite import SqliteWriter
 from .trc import TRCWriter
-from ..typechecking import StringPathLike, FileLike, AcceptedIOType
 
 
 class Logger(MessageWriter):

--- a/can/io/player.py
+++ b/can/io/player.py
@@ -10,15 +10,15 @@ import typing
 
 from pkg_resources import iter_entry_points
 
-from .generic import MessageReader
+from ..message import Message
+from ..typechecking import AcceptedIOType, FileLike, StringPathLike
 from .asc import ASCReader
 from .blf import BLFReader
 from .canutils import CanutilsLogReader
 from .csv import CSVReader
+from .generic import MessageReader
 from .sqlite import SqliteReader
 from .trc import TRCReader
-from ..typechecking import StringPathLike, FileLike, AcceptedIOType
-from ..message import Message
 
 
 class LogReader(MessageReader):

--- a/can/io/printer.py
+++ b/can/io/printer.py
@@ -3,12 +3,11 @@ This Listener simply prints to stdout / the terminal or a file.
 """
 
 import logging
-
-from typing import Optional, TextIO, Union, Any, cast
+from typing import Any, Optional, TextIO, Union, cast
 
 from ..message import Message
-from .generic import MessageWriter
 from ..typechecking import StringPathLike
+from .generic import MessageWriter
 
 log = logging.getLogger("can.io.printer")
 

--- a/can/io/sqlite.py
+++ b/can/io/sqlite.py
@@ -4,16 +4,17 @@ Implements an SQL database writer and reader for storing CAN messages.
 .. note:: The database schema is given in the documentation of the loggers.
 """
 
-import time
-import threading
 import logging
 import sqlite3
-from typing import Generator, Any
+import threading
+import time
+from typing import Any, Generator
 
 from can.listener import BufferedReader
 from can.message import Message
-from .generic import MessageWriter, MessageReader
+
 from ..typechecking import StringPathLike
+from .generic import MessageReader, MessageWriter
 
 log = logging.getLogger("can.io.sqlite")
 

--- a/can/io/trc.py
+++ b/can/io/trc.py
@@ -7,18 +7,17 @@ for file format description
 Version 1.1 will be implemented as it is most commonly used
 """  # noqa
 
+import io
+import logging
+import os
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-import io
-import os
-import logging
-from typing import Generator, Optional, Union, TextIO, Callable, List, Dict
+from typing import Callable, Dict, Generator, List, Optional, TextIO, Union
 
 from ..message import Message
-from ..util import channel2int, len2dlc, dlc2len
-from .generic import FileIOMessageWriter, MessageReader
 from ..typechecking import StringPathLike
-
+from ..util import channel2int, dlc2len, len2dlc
+from .generic import FileIOMessageWriter, MessageReader
 
 logger = logging.getLogger("can.io.trc")
 

--- a/can/listener.py
+++ b/can/listener.py
@@ -2,15 +2,15 @@
 This module contains the implementation of `can.Listener` and some readers.
 """
 
+import asyncio
 import sys
 import warnings
-import asyncio
 from abc import ABCMeta, abstractmethod
-from queue import SimpleQueue, Empty
+from queue import Empty, SimpleQueue
 from typing import Any, AsyncIterator, Optional
 
-from can.message import Message
 from can.bus import BusABC
+from can.message import Message
 
 
 class Listener(metaclass=ABCMeta):

--- a/can/logconvert.py
+++ b/can/logconvert.py
@@ -2,11 +2,11 @@
 Convert a log file from one format to another.
 """
 
-import sys
 import argparse
 import errno
+import sys
 
-from can import LogReader, Logger, SizedRotatingLogger
+from can import Logger, LogReader, SizedRotatingLogger
 
 
 class ArgumentParser(argparse.ArgumentParser):

--- a/can/logger.py
+++ b/can/logger.py
@@ -1,14 +1,15 @@
+import argparse
+import errno
 import re
 import sys
-import argparse
 from datetime import datetime
-import errno
-from typing import Any, Dict, List, Union, Sequence, Tuple
+from typing import Any, Dict, List, Sequence, Tuple, Union
 
 import can
 from can.io import BaseRotatingLogger
 from can.io.generic import MessageWriter
 from can.util import cast_from_string
+
 from . import Bus, BusState, Logger, SizedRotatingLogger
 from .typechecking import CanFilter, CanFilters
 

--- a/can/message.py
+++ b/can/message.py
@@ -6,12 +6,11 @@ This module contains the implementation of :class:`can.Message`.
     starting with Python 3.7.
 """
 
+from copy import deepcopy
+from math import isinf, isnan
 from typing import Optional
 
 from . import typechecking
-
-from copy import deepcopy
-from math import isinf, isnan
 
 
 class Message:  # pylint: disable=too-many-instance-attributes; OK for a dataclass

--- a/can/notifier.py
+++ b/can/notifier.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import threading
 import time
-from typing import Callable, Iterable, List, Optional, Union, Awaitable
+from typing import Awaitable, Callable, Iterable, List, Optional, Union
 
 from can.bus import BusABC
 from can.listener import Listener

--- a/can/player.py
+++ b/can/player.py
@@ -5,11 +5,11 @@ to a CAN bus.
 Similar to canplayer in the can-utils package.
 """
 
-import sys
 import argparse
-from datetime import datetime
 import errno
-from typing import cast, Iterable
+import sys
+from datetime import datetime
+from typing import Iterable, cast
 
 from can import LogReader, Message, MessageSync
 

--- a/can/thread_safe_bus.py
+++ b/can/thread_safe_bus.py
@@ -12,7 +12,6 @@ except ImportError as exc:
 
 from .interface import Bus
 
-
 try:
     from contextlib import nullcontext
 

--- a/can/util.py
+++ b/can/util.py
@@ -11,24 +11,24 @@ import platform
 import re
 import warnings
 from configparser import ConfigParser
-from time import time, perf_counter, get_clock_info
+from time import get_clock_info, perf_counter, time
 from typing import (
     Any,
     Callable,
-    cast,
     Dict,
     Iterable,
-    Tuple,
     Optional,
-    Union,
+    Tuple,
     TypeVar,
+    Union,
+    cast,
 )
 
 import can
+
 from . import typechecking
 from .bit_timing import BitTiming, BitTimingFd
-from .exceptions import CanInitializationError
-from .exceptions import CanInterfaceNotImplementedError
+from .exceptions import CanInitializationError, CanInterfaceNotImplementedError
 from .interfaces import VALID_INTERFACES
 
 log = logging.getLogger("can.util")

--- a/can/viewer.py
+++ b/can/viewer.py
@@ -30,20 +30,21 @@ import time
 from typing import Dict, List, Tuple, Union
 
 from can import __version__
+
 from .logger import (
-    _create_bus,
-    _parse_filters,
     _append_filter_argument,
     _create_base_argument_parser,
+    _create_bus,
     _parse_additional_config,
+    _parse_filters,
 )
-
 
 logger = logging.getLogger("can.viewer")
 
 try:
     import curses
-    from curses.ascii import ESC as KEY_ESC, SP as KEY_SPACE
+    from curses.ascii import ESC as KEY_ESC
+    from curses.ascii import SP as KEY_SPACE
 except ImportError:
     # Probably on Windows while windows-curses is not installed (e.g. in PyPy)
     logger.warning(

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -6,9 +6,9 @@ This file is execfile()d with the current directory set to its containing dir.
 
 # -- Imports -------------------------------------------------------------------
 
-import sys
-import os
 import ctypes
+import os
+import sys
 from unittest.mock import MagicMock
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,16 @@ requires = [
     "wheel",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+select = [
+    "F401",  # unused-imports
+    "UP",  # pyupgrade
+    "I",  # isort
+]
+
+# Assume Python 3.7.
+target-version = "py37"
+
+[tool.ruff.isort]
+known-first-party = ["can"]

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,4 +1,5 @@
 pylint==2.16.4
+ruff==0.0.260
 black~=23.1.0
 mypy==1.0.1
 mypy-extensions==0.4.3

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,12 @@ Setup script for the `can` package.
 Learn more at https://github.com/hardbyte/python-can/
 """
 
+import logging
+import re
 from os import listdir
 from os.path import isfile, join
-import re
-import logging
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 logging.basicConfig(level=logging.WARNING)
 

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -4,10 +4,10 @@
 This module tests two buses attached to each other.
 """
 
-import unittest
-from time import sleep, time
-from multiprocessing.dummy import Pool as ThreadPool
 import random
+import unittest
+from multiprocessing.dummy import Pool as ThreadPool
+from time import sleep, time
 
 import pytest
 
@@ -17,12 +17,12 @@ from can.interfaces.udp_multicast import UdpMulticastBus
 
 from .config import (
     IS_CI,
-    IS_UNIX,
     IS_OSX,
-    IS_TRAVIS,
-    TEST_INTERFACE_SOCKETCAN,
-    TEST_CAN_FD,
     IS_PYPY,
+    IS_TRAVIS,
+    IS_UNIX,
+    TEST_CAN_FD,
+    TEST_INTERFACE_SOCKETCAN,
 )
 
 

--- a/test/contextmanager_test.py
+++ b/test/contextmanager_test.py
@@ -5,6 +5,7 @@ This module tests the context manager of Bus and Notifier classes
 """
 
 import unittest
+
 import can
 
 

--- a/test/listener_test.py
+++ b/test/listener_test.py
@@ -3,13 +3,13 @@
 """
 """
 import asyncio
-import unittest
-import random
 import logging
-import tempfile
 import os
+import random
+import tempfile
+import unittest
 import warnings
-from os.path import join, dirname
+from os.path import dirname, join
 
 import can
 

--- a/test/logformats_test.py
+++ b/test/logformats_test.py
@@ -12,23 +12,24 @@ comments.
 TODO: correctly set preserves_channel and adds_default_channel
 """
 import logging
-import unittest
-from parameterized import parameterized
-import tempfile
 import os
-from abc import abstractmethod, ABCMeta
-from itertools import zip_longest
+import tempfile
+import unittest
+from abc import ABCMeta, abstractmethod
 from datetime import datetime
+from itertools import zip_longest
+
+from parameterized import parameterized
 
 import can
 from can.io import blf
 
 from .data.example_data import (
-    TEST_MESSAGES_BASE,
-    TEST_MESSAGES_REMOTE_FRAMES,
-    TEST_MESSAGES_ERROR_FRAMES,
-    TEST_MESSAGES_CAN_FD,
     TEST_COMMENTS,
+    TEST_MESSAGES_BASE,
+    TEST_MESSAGES_CAN_FD,
+    TEST_MESSAGES_ERROR_FRAMES,
+    TEST_MESSAGES_REMOTE_FRAMES,
     sort_messages,
 )
 from .message_helper import ComparingMessagesTestCase

--- a/test/network_test.py
+++ b/test/network_test.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
 
-import unittest
-import threading
-import random
 import logging
+import random
+import threading
+import unittest
 
 logging.getLogger(__file__).setLevel(logging.WARNING)
 

--- a/test/notifier_test.py
+++ b/test/notifier_test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-import unittest
-import time
 import asyncio
+import time
+import unittest
 
 import can
 

--- a/test/serial_test.py
+++ b/test/serial_test.py
@@ -12,9 +12,8 @@ from unittest.mock import patch
 import can
 from can.interfaces.serial.serial_can import SerialBus
 
-from .message_helper import ComparingMessagesTestCase
 from .config import IS_PYPY
-
+from .message_helper import ComparingMessagesTestCase
 
 # Mentioned in #1010
 TIMEOUT = 0.5 if IS_PYPY else 0.1  # 0.1 is the default set in SerialBus

--- a/test/simplecyclic_test.py
+++ b/test/simplecyclic_test.py
@@ -4,10 +4,10 @@
 This module tests cyclic send tasks.
 """
 
-from time import sleep
-import unittest
-from unittest.mock import MagicMock
 import gc
+import unittest
+from time import sleep
+from unittest.mock import MagicMock
 
 import can
 

--- a/test/test_cyclic_socketcan.py
+++ b/test/test_cyclic_socketcan.py
@@ -3,9 +3,9 @@
 """
 This module tests multiple message cyclic send tasks.
 """
+import time
 import unittest
 
-import time
 import can
 
 from .config import TEST_INTERFACE_SOCKETCAN

--- a/test/test_interface_canalystii.py
+++ b/test/test_interface_canalystii.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python
 
+"""
+"""
+
 import unittest
-from unittest.mock import patch, call
 from ctypes import c_ubyte
+from unittest.mock import call, patch
 
 import canalystii as driver  # low-level driver module, mock out this layer
+
 import can
 from can.interfaces.canalystii import CANalystIIBus
 

--- a/test/test_interface_ixxat.py
+++ b/test/test_interface_ixxat.py
@@ -8,6 +8,7 @@ python setup.py test --addopts "--verbose -s test/test_interface_ixxat.py"
 """
 
 import unittest
+
 import can
 
 

--- a/test/test_interface_ixxat_fd.py
+++ b/test/test_interface_ixxat_fd.py
@@ -8,6 +8,7 @@ python setup.py test --addopts "--verbose -s test/test_interface_ixxat_fd.py"
 """
 
 import unittest
+
 import can
 
 

--- a/test/test_kvaser.py
+++ b/test/test_kvaser.py
@@ -10,8 +10,7 @@ from unittest.mock import Mock
 import pytest
 
 import can
-from can.interfaces.kvaser import canlib
-from can.interfaces.kvaser import constants
+from can.interfaces.kvaser import canlib, constants
 
 
 class KvaserTest(unittest.TestCase):

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -4,12 +4,12 @@
 This module tests the functions inside of logger.py
 """
 
-import unittest
-from unittest import mock
-from unittest.mock import Mock
 import gzip
 import os
 import sys
+import unittest
+from unittest import mock
+from unittest.mock import Mock
 
 import pytest
 

--- a/test/test_message_class.py
+++ b/test/test_message_class.py
@@ -1,22 +1,21 @@
 #!/usr/bin/env python
 
-import unittest
-import sys
-from math import isinf, isnan
-from copy import copy, deepcopy
 import pickle
+import sys
+import unittest
+from copy import copy, deepcopy
 from datetime import timedelta
+from math import isinf, isnan
 
-from hypothesis import HealthCheck, given, settings
 import hypothesis.errors
 import hypothesis.strategies as st
+import pytest
+from hypothesis import HealthCheck, given, settings
 
 from can import Message
 
+from .config import IS_GITHUB_ACTIONS, IS_PYPY, IS_WINDOWS
 from .message_helper import ComparingMessagesTestCase
-from .config import IS_GITHUB_ACTIONS, IS_WINDOWS, IS_PYPY
-
-import pytest
 
 
 class TestMessageClass(unittest.TestCase):

--- a/test/test_message_filtering.py
+++ b/test/test_message_filtering.py
@@ -10,7 +10,6 @@ from can import Bus, Message
 
 from .data.example_data import TEST_ALL_MESSAGES
 
-
 EXAMPLE_MSG = Message(arbitration_id=0x123, is_extended_id=True)
 HIGHEST_MSG = Message(arbitration_id=0x1FFFFFFF, is_extended_id=True)
 

--- a/test/test_message_sync.py
+++ b/test/test_message_sync.py
@@ -4,19 +4,18 @@
 This module tests :class:`can.MessageSync`.
 """
 
-from copy import copy
-import time
 import gc
-
+import time
 import unittest
+from copy import copy
+
 import pytest
 
-from can import MessageSync, Message
+from can import Message, MessageSync
 
-from .config import IS_CI, IS_TRAVIS, IS_OSX, IS_GITHUB_ACTIONS, IS_LINUX
-from .message_helper import ComparingMessagesTestCase
+from .config import IS_CI, IS_GITHUB_ACTIONS, IS_LINUX, IS_OSX, IS_TRAVIS
 from .data.example_data import TEST_MESSAGES_BASE
-
+from .message_helper import ComparingMessagesTestCase
 
 TEST_FEWER_MESSAGES = TEST_MESSAGES_BASE[::2]
 

--- a/test/test_neousys.py
+++ b/test/test_neousys.py
@@ -1,20 +1,14 @@
 #!/usr/bin/env python
 
-import ctypes
-import os
-import pickle
 import unittest
-from unittest.mock import Mock
-
 from ctypes import (
-    byref,
-    cast,
     POINTER,
-    sizeof,
+    byref,
     c_ubyte,
+    cast,
+    sizeof,
 )
-
-import pytest
+from unittest.mock import Mock
 
 import can
 from can.interfaces.neousys import neousys

--- a/test/test_neovi.py
+++ b/test/test_neovi.py
@@ -4,6 +4,7 @@
 """
 import pickle
 import unittest
+
 from can.interfaces.ics_neovi import ICSApiError
 
 

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -4,12 +4,13 @@
 This module tests the functions inside of player.py
 """
 
+import io
+import os
+import sys
 import unittest
 from unittest import mock
 from unittest.mock import Mock
-import os
-import sys
-import io
+
 import can
 import can.player
 

--- a/test/test_robotell.py
+++ b/test/test_robotell.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import unittest
+
 import can
 
 

--- a/test/test_rotating_loggers.py
+++ b/test/test_rotating_loggers.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import can
+
 from .data.example_data import generate_message
 
 

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -4,10 +4,10 @@
 This module tests that the scripts are all callable.
 """
 
-import subprocess
-import unittest
-import sys
 import errno
+import subprocess
+import sys
+import unittest
 from abc import ABCMeta, abstractmethod
 
 from .config import *

--- a/test/test_slcan.py
+++ b/test/test_slcan.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
 import unittest
-import can
-from .config import IS_PYPY
 
+import can
+
+from .config import IS_PYPY
 
 """
 Mentioned in #1010 & #1490

--- a/test/test_socketcan.py
+++ b/test/test_socketcan.py
@@ -8,8 +8,8 @@ import struct
 import unittest
 import warnings
 from unittest.mock import patch
-import can
 
+import can
 from can.interfaces.socketcan.constants import (
     CAN_BCM_TX_DELETE,
     CAN_BCM_TX_SETUP,
@@ -18,13 +18,14 @@ from can.interfaces.socketcan.constants import (
     TX_COUNTEVT,
 )
 from can.interfaces.socketcan.socketcan import (
+    BcmMsgHead,
     bcm_header_factory,
     build_bcm_header,
-    build_bcm_tx_delete_header,
     build_bcm_transmit_header,
+    build_bcm_tx_delete_header,
     build_bcm_update_header,
-    BcmMsgHead,
 )
+
 from .config import IS_LINUX, IS_PYPY
 
 

--- a/test/test_socketcan_helpers.py
+++ b/test/test_socketcan_helpers.py
@@ -5,13 +5,11 @@ Tests helpers in `can.interfaces.socketcan.socketcan_common`.
 """
 
 import gzip
-from base64 import b64decode
 import unittest
+from base64 import b64decode
 from unittest import mock
 
-from subprocess import CalledProcessError
-
-from can.interfaces.socketcan.utils import find_available_interfaces, error_code_to_str
+from can.interfaces.socketcan.utils import error_code_to_str, find_available_interfaces
 
 from .config import IS_LINUX, TEST_INTERFACE_SOCKETCAN
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -10,10 +10,10 @@ from can.exceptions import CanInitializationError
 from can.util import (
     _create_bus_config,
     _rename_kwargs,
-    channel2int,
-    deprecated_args_alias,
-    check_or_adjust_timing_clock,
     cast_from_string,
+    channel2int,
+    check_or_adjust_timing_clock,
+    deprecated_args_alias,
 )
 
 

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -9,22 +9,24 @@ import functools
 import pickle
 import sys
 import time
+from test.config import IS_WINDOWS
 from unittest.mock import Mock
 
 import pytest
 
 import can
 from can.interfaces.vector import (
-    canlib,
-    xldefine,
-    xlclass,
+    VectorBusParams,
+    VectorCanFdParams,
+    VectorCanParams,
+    VectorChannelConfig,
     VectorError,
     VectorInitializationError,
     VectorOperationError,
-    VectorChannelConfig,
+    canlib,
+    xlclass,
+    xldefine,
 )
-from can.interfaces.vector import VectorBusParams, VectorCanParams, VectorCanFdParams
-from test.config import IS_WINDOWS
 
 XLDRIVER_FOUND = canlib.xldriver is not None
 

--- a/test/test_viewer.py
+++ b/test/test_viewer.py
@@ -30,14 +30,13 @@ import struct
 import time
 import unittest
 from collections import defaultdict
-from typing import Dict, Tuple, Union
+from test.config import IS_CI
 from unittest.mock import patch
 
 import pytest
 
 import can
 from can.viewer import CanViewer, parse_args
-from test.config import IS_CI
 
 # Allow the curses module to be missing (e.g. on PyPy on Windows)
 try:

--- a/test/zero_dlc_test.py
+++ b/test/zero_dlc_test.py
@@ -3,9 +3,8 @@
 """
 """
 
-from time import sleep
-import unittest
 import logging
+import unittest
 
 import can
 


### PR DESCRIPTION
Closes #1547 

This also introduces ruff with isort, pyupgrade and the unused-imports check.

@felixdivo The version with the `import x as x` reexport can be seen [here](https://github.com/zariiii9003/python-can/blob/81a610820fa34c71461e6027334193b55c50043e/can/__init__.py). I think that one is less ugly, but i don't care too much.

