### PR TITLE
Improve can.Bus typing

### DIFF
--- a/can/logger.py
+++ b/can/logger.py
@@ -85,7 +85,7 @@ def _append_filter_argument(
     )
 
 
-def _create_bus(parsed_args: Any, **kwargs: Any) -> can.Bus:
+def _create_bus(parsed_args: Any, **kwargs: Any) -> can.BusABC:
     logging_level_names = ["critical", "error", "warning", "info", "debug", "subdebug"]
     can.set_logging_level(logging_level_names[min(5, parsed_args.verbosity)])
 
@@ -99,7 +99,7 @@ def _create_bus(parsed_args: Any, **kwargs: Any) -> can.Bus:
     if parsed_args.data_bitrate:
         config["data_bitrate"] = parsed_args.data_bitrate
 
-    return Bus(parsed_args.channel, **config)  # type: ignore
+    return Bus(parsed_args.channel, **config)
 
 
 def _parse_filters(parsed_args: Any) -> CanFilters:

--- a/doc/bus.rst
+++ b/doc/bus.rst
@@ -3,10 +3,10 @@
 Bus
 ---
 
-The :class:`~can.Bus` provides a wrapper around a physical or virtual CAN Bus.
+The :class:`~can.BusABC` class provides a wrapper around a physical or virtual CAN Bus.
 
-An interface specific instance is created by instantiating the :class:`~can.Bus`
-class with a particular ``interface``, for example::
+An interface specific instance is created by calling the :func:`~can.Bus`
+function with a particular ``interface``, for example::
 
     vector_bus = can.Bus(interface='vector', ...)
 
@@ -77,13 +77,14 @@ See :meth:`~can.BusABC.set_filters` for the implementation.
 Bus API
 '''''''
 
-.. autoclass:: can.Bus
+.. autofunction:: can.Bus
+
+.. autoclass:: can.BusABC
     :class-doc-from: class
-    :show-inheritance:
     :members:
     :inherited-members:
 
-.. autoclass:: can.bus.BusState
+.. autoclass:: can.BusState
     :members:
     :undoc-members:
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -126,7 +126,9 @@ nitpick_ignore = [
     ("py:class", "can.typechecking.CanFilter"),
     ("py:class", "can.typechecking.CanFilterExtended"),
     ("py:class", "can.typechecking.AutoDetectedConfig"),
-    ("py:class", "can.util.T"),
+    ("py:class", "can.util.T1"),
+    ("py:class", "can.util.T2"),
+    ("py:class", "~P1"),
     # intersphinx fails to reference some builtins
     ("py:class", "asyncio.events.AbstractEventLoop"),
     ("py:class", "_thread.allocate_lock"),

--- a/doc/internal-api.rst
+++ b/doc/internal-api.rst
@@ -57,23 +57,32 @@ They **might** implement the following:
     and thus might not provide message filtering:
 
 
-Concrete instances are usually created by :class:`can.Bus` which takes the users
+Concrete instances are usually created by :func:`can.Bus` which takes the users
 configuration into account.
 
 
 Bus Internals
 ~~~~~~~~~~~~~
 
-Several methods are not documented in the main :class:`can.Bus`
+Several methods are not documented in the main :class:`can.BusABC`
 as they are primarily useful for library developers as opposed to
-library users. This is the entire ABC bus class with all internal
-methods:
+library users.
 
-.. autoclass:: can.BusABC
-    :members:
-    :private-members:
-    :special-members:
+.. automethod:: can.BusABC.__init__
 
+.. automethod:: can.BusABC.__iter__
+
+.. automethod:: can.BusABC.__str__
+
+.. autoattribute:: can.BusABC.__weakref__
+
+.. automethod:: can.BusABC._recv_internal
+
+.. automethod:: can.BusABC._apply_filters
+
+.. automethod:: can.BusABC._send_periodic_internal
+
+.. automethod:: can.BusABC._detect_available_configs
 
 
 About the IO module


### PR DESCRIPTION
Convert `can.Bus` into a function to clean up a lot of the messy typing. This should fix the [pyright abstract class complaints](https://github.com/hardbyte/python-can/pull/1551#issuecomment-1495974163).

I had to move the `can.BusABC` documentation from `internal-api.rst` to `bus.rst`, the private methods of `can.BusABC` are still documented in `internal-api.rst`.