### PR TITLE
With Windows event the first two periodic frames are sent without delay

### DIFF
--- a/can/broadcastmanager.py
+++ b/can/broadcastmanager.py
@@ -293,6 +293,10 @@ class ThreadBasedCyclicSendTask(
         msg_index = 0
         msg_due_time_ns = time.perf_counter_ns()
 
+        if USE_WINDOWS_EVENTS:
+            # Make sure the timer is non-signaled before entering the loop
+            win32event.WaitForSingleObject(self.event.handle, 0)
+
         while not self.stopped:
             # Prevent calling bus.send from multiple threads
             with self.send_lock:


### PR DESCRIPTION
With Windows event the first two periodic frames are sent without delay

When the `ThreadBasedCyclicSendTask` thread starts, the timer event was already set before entering the first loop. This resulted in the first timer wait to not wait.

Sample code to show the issue:
```python
import time

import can
from can import Message, Notifier, BufferedReader, broadcastmanager


class MyListener(BufferedReader):
    def __init__(self, msg, period):
        super().__init__()
        self.msg = msg
        self.period = period

    def on_message_received(self, msg: Message) -> None:
        if msg.arbitration_id == self.msg.arbitration_id:
            super().on_message_received(msg)


def main():
    # Set False to test without Windows events
    # broadcastmanager.USE_WINDOWS_EVENTS = False

    msg = Message(
        arbitration_id=0x100,
        is_extended_id=False,
        data=(0, ) * 8
    )
    period = 5
    duration = 10

    with can.Bus() as bus:
        listener = MyListener(msg, period)
        notifier = Notifier(bus, (listener,))
        bus.send_periodic(msg, period=period, duration=duration)
        time.sleep(duration)
        notifier.stop()

        frames = []
        while not listener.buffer.empty():
            frames.append(listener.buffer.get())

        print(f"Found {len(frames)} frame(s)")
        for i in range(len(frames)):
            if i > 0:
                print(f"Delta: {frames[i].timestamp - frames[i-1].timestamp}")
            print(frames[i])

        assert abs(frames[1].timestamp - frames[0].timestamp) > period/2.0


if __name__ == "__main__":
    main()

```