### PR TITLE
Implement _detect_available_configs for the Ixxat bus.

### DIFF
--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -156,9 +156,7 @@ class IXXATBus(BusABC):
         duration: Optional[float] = None,
         modifier_callback: Optional[Callable[[Message], None]] = None,
     ) -> CyclicSendTaskABC:
-        return self.bus._send_periodic_internal(
-            msgs, period, duration, modifier_callback
-        )
+        return self.bus._send_periodic_internal(msgs, period, duration, modifier_callback)
 
     def shutdown(self) -> None:
         super().shutdown()
@@ -170,3 +168,7 @@ class IXXATBus(BusABC):
         Return the current state of the hardware
         """
         return self.bus.state
+
+    @staticmethod
+    def _detect_available_configs():
+        return vcinpl._detect_available_configs()

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Sequence, Union
+from typing import Callable, Optional, Sequence, Union, List
 
 import can.interfaces.ixxat.canlib_vcinpl as vcinpl
 import can.interfaces.ixxat.canlib_vcinpl2 as vcinpl2
@@ -8,6 +8,7 @@ from can import (
     CyclicSendTaskABC,
     Message,
 )
+from can.typechecking import AutoDetectedConfig
 
 
 class IXXATBus(BusABC):
@@ -170,5 +171,5 @@ class IXXATBus(BusABC):
         return self.bus.state
 
     @staticmethod
-    def _detect_available_configs():
+    def _detect_available_configs() -> List[AutoDetectedConfig]:
         return vcinpl._detect_available_configs()

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -157,7 +157,9 @@ class IXXATBus(BusABC):
         duration: Optional[float] = None,
         modifier_callback: Optional[Callable[[Message], None]] = None,
     ) -> CyclicSendTaskABC:
-        return self.bus._send_periodic_internal(msgs, period, duration, modifier_callback)
+        return self.bus._send_periodic_internal(
+            msgs, period, duration, modifier_callback
+        )
 
     def shutdown(self) -> None:
         super().shutdown()

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Sequence, Union, List
+from typing import Callable, List, Optional, Sequence, Union
 
 import can.interfaces.ixxat.canlib_vcinpl as vcinpl
 import can.interfaces.ixxat.canlib_vcinpl2 as vcinpl2

--- a/can/interfaces/ixxat/canlib_vcinpl.py
+++ b/can/interfaces/ixxat/canlib_vcinpl.py
@@ -14,7 +14,7 @@ import functools
 import logging
 import sys
 import warnings
-from typing import Callable, Optional, Sequence, Tuple, Union
+from typing import Callable, Optional, Sequence, Tuple, Union, List
 
 from can import (
     BusABC,
@@ -29,6 +29,7 @@ from can.ctypesutil import HANDLE, PHANDLE, CLibrary
 from can.ctypesutil import HRESULT as ctypes_HRESULT
 from can.exceptions import CanInitializationError, CanInterfaceNotImplementedError
 from can.util import deprecated_args_alias
+from can.typechecking import AutoDetectedConfig
 
 from . import constants, structures
 from .exceptions import *
@@ -945,7 +946,7 @@ def get_ixxat_hwids():
     return hwids
 
 
-def _detect_available_configs():
+def _detect_available_configs() -> List[AutoDetectedConfig]:
 
     config_list = []  # list in wich to store the resulting bus kwargs
 
@@ -957,33 +958,36 @@ def _detect_available_configs():
     channel_handle = HANDLE()
     device_handle2 = HANDLE()
 
-    _canlib.vciEnumDeviceOpen(ctypes.byref(device_handle))
-    while True:
-        try:
-            _canlib.vciEnumDeviceNext(device_handle, ctypes.byref(device_info))
-        except StopIteration:
-            break
-        else:
-            hwid = device_info.UniqueHardwareId.AsChar.decode("ascii")
-            _canlib.vciDeviceOpen(
-                ctypes.byref(device_info.VciObjectId),
-                ctypes.byref(device_handle2),
-            )
-            for channel in range(4):
-                try:
-                    _canlib.canChannelOpen(
-                        device_handle2,
-                        channel,
-                        constants.FALSE,
-                        ctypes.byref(channel_handle),
-                    )
-                except Exception:
-                    # Array outside of bounds error == accessing a channel not in the hardware
-                    break
-                else:
-                    _canlib.canChannelClose(channel_handle)
-                    config_list.append({"interface": "ixxat", "channel": channel, "unique_hardware_id": hwid})
-            _canlib.vciDeviceClose(device_handle2)
-    _canlib.vciEnumDeviceClose(device_handle)
+    try:
+        _canlib.vciEnumDeviceOpen(ctypes.byref(device_handle))
+        while True:
+            try:
+                _canlib.vciEnumDeviceNext(device_handle, ctypes.byref(device_info))
+            except StopIteration:
+                break
+            else:
+                hwid = device_info.UniqueHardwareId.AsChar.decode("ascii")
+                _canlib.vciDeviceOpen(
+                    ctypes.byref(device_info.VciObjectId),
+                    ctypes.byref(device_handle2),
+                )
+                for channel in range(4):
+                    try:
+                        _canlib.canChannelOpen(
+                            device_handle2,
+                            channel,
+                            constants.FALSE,
+                            ctypes.byref(channel_handle),
+                        )
+                    except Exception:
+                        # Array outside of bounds error == accessing a channel not in the hardware
+                        break
+                    else:
+                        _canlib.canChannelClose(channel_handle)
+                        config_list.append({"interface": "ixxat", "channel": channel, "unique_hardware_id": hwid})
+                _canlib.vciDeviceClose(device_handle2)
+        _canlib.vciEnumDeviceClose(device_handle)
+    except AttributeError:
+        pass  # _canlib is None in the CI tests -> return a blank list
 
     return config_list

--- a/can/interfaces/ixxat/canlib_vcinpl.py
+++ b/can/interfaces/ixxat/canlib_vcinpl.py
@@ -14,7 +14,7 @@ import functools
 import logging
 import sys
 import warnings
-from typing import Callable, Optional, Sequence, Tuple, Union, List
+from typing import Callable, List, Optional, Sequence, Tuple, Union
 
 from can import (
     BusABC,
@@ -28,8 +28,8 @@ from can import (
 from can.ctypesutil import HANDLE, PHANDLE, CLibrary
 from can.ctypesutil import HRESULT as ctypes_HRESULT
 from can.exceptions import CanInitializationError, CanInterfaceNotImplementedError
-from can.util import deprecated_args_alias
 from can.typechecking import AutoDetectedConfig
+from can.util import deprecated_args_alias
 
 from . import constants, structures
 from .exceptions import *

--- a/can/interfaces/ixxat/canlib_vcinpl.py
+++ b/can/interfaces/ixxat/canlib_vcinpl.py
@@ -984,12 +984,12 @@ def _detect_available_configs() -> List[AutoDetectedConfig]:
                     else:
                         _canlib.canChannelClose(channel_handle)
                         config_list.append(
-                        {
-                            "interface": "ixxat",
-                            "channel": channel,
-                            "unique_hardware_id": hwid,
-                        }
-                    )
+                            {
+                                "interface": "ixxat",
+                                "channel": channel,
+                                "unique_hardware_id": hwid,
+                            }
+                        )
                 _canlib.vciDeviceClose(device_handle2)
         _canlib.vciEnumDeviceClose(device_handle)
     except AttributeError:

--- a/can/interfaces/ixxat/canlib_vcinpl.py
+++ b/can/interfaces/ixxat/canlib_vcinpl.py
@@ -943,3 +943,47 @@ def get_ixxat_hwids():
     _canlib.vciEnumDeviceClose(device_handle)
 
     return hwids
+
+
+def _detect_available_configs():
+
+    config_list = []  # list in wich to store the resulting bus kwargs
+
+    # used to detect HWID
+    device_handle = HANDLE()
+    device_info = structures.VCIDEVICEINFO()
+
+    # used to attempt to open channels
+    channel_handle = HANDLE()
+    device_handle2 = HANDLE()
+
+    _canlib.vciEnumDeviceOpen(ctypes.byref(device_handle))
+    while True:
+        try:
+            _canlib.vciEnumDeviceNext(device_handle, ctypes.byref(device_info))
+        except StopIteration:
+            break
+        else:
+            hwid = device_info.UniqueHardwareId.AsChar.decode("ascii")
+            _canlib.vciDeviceOpen(
+                ctypes.byref(device_info.VciObjectId),
+                ctypes.byref(device_handle2),
+            )
+            for channel in range(4):
+                try:
+                    _canlib.canChannelOpen(
+                        device_handle2,
+                        channel,
+                        constants.FALSE,
+                        ctypes.byref(channel_handle),
+                    )
+                except Exception:
+                    # Array outside of bounds error == accessing a channel not in the hardware
+                    break
+                else:
+                    _canlib.canChannelClose(channel_handle)
+                    config_list.append({"interface": "ixxat", "channel": channel, "unique_hardware_id": hwid})
+            _canlib.vciDeviceClose(device_handle2)
+    _canlib.vciEnumDeviceClose(device_handle)
+
+    return config_list

--- a/can/interfaces/ixxat/canlib_vcinpl.py
+++ b/can/interfaces/ixxat/canlib_vcinpl.py
@@ -947,7 +947,6 @@ def get_ixxat_hwids():
 
 
 def _detect_available_configs() -> List[AutoDetectedConfig]:
-
     config_list = []  # list in wich to store the resulting bus kwargs
 
     # used to detect HWID
@@ -984,7 +983,13 @@ def _detect_available_configs() -> List[AutoDetectedConfig]:
                         break
                     else:
                         _canlib.canChannelClose(channel_handle)
-                        config_list.append({"interface": "ixxat", "channel": channel, "unique_hardware_id": hwid})
+                        config_list.append(
+                        {
+                            "interface": "ixxat",
+                            "channel": channel,
+                            "unique_hardware_id": hwid,
+                        }
+                    )
                 _canlib.vciDeviceClose(device_handle2)
         _canlib.vciEnumDeviceClose(device_handle)
     except AttributeError:

--- a/can/interfaces/ixxat/canlib_vcinpl2.py
+++ b/can/interfaces/ixxat/canlib_vcinpl2.py
@@ -509,17 +509,15 @@ class IXXATBus(BusABC):
             tseg1_abr is None or tseg2_abr is None or sjw_abr is None
         ):
             raise ValueError(
-                "To use bitrate {} (that has not predefined preset) is mandatory to use also parameters tseg1_abr, tseg2_abr and swj_abr".format(
-                    bitrate
-                )
+                f"To use bitrate {bitrate} (that has not predefined preset) is mandatory "
+                f"to use also parameters tseg1_abr, tseg2_abr and swj_abr"
             )
         if data_bitrate not in constants.CAN_DATABITRATE_PRESETS and (
             tseg1_dbr is None or tseg2_dbr is None or sjw_dbr is None
         ):
             raise ValueError(
-                "To use data_bitrate {} (that has not predefined preset) is mandatory to use also parameters tseg1_dbr, tseg2_dbr and swj_dbr".format(
-                    data_bitrate
-                )
+                f"To use data_bitrate {data_bitrate} (that has not predefined preset) is mandatory "
+                f"to use also parameters tseg1_dbr, tseg2_dbr and swj_dbr"
             )
 
         if rx_fifo_size <= 0:

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -396,9 +396,7 @@ class PcanBus(BusABC):
             for b in bits(error):
                 stsReturn = self.m_objPCANBasic.GetErrorText(b, 0x9)
                 if stsReturn[0] != PCAN_ERROR_OK:
-                    text = "An error occurred. Error-code's text ({:X}h) couldn't be retrieved".format(
-                        error
-                    )
+                    text = f"An error occurred. Error-code's text ({error:X}h) couldn't be retrieved"
                 else:
                     text = stsReturn[1].decode("utf-8", errors="replace")
 

--- a/doc/interfaces/ixxat.rst
+++ b/doc/interfaces/ixxat.rst
@@ -64,15 +64,22 @@ The function :meth:`~can.detect_available_configs` can be used to generate a lis
     .. testsetup:: ixxat
 
         from unittest.mock import Mock
-        can.detect_available_configs = Mock(side_effect=lambda: [{'interface': 'ixxat', 'channel': 0, 'unique_hardware_id': 'HW441489'}, {'interface': 'ixxat', 'channel': 0, 'unique_hardware_id': 'HW107422'}, {'interface': 'ixxat', 'channel': 1, 'unique_hardware_id': 'HW107422'}])
+        import can
+        assert hasattr(can, "detect_available_configs")
+        can.detect_available_configs = Mock(
+            "interface",
+            return_value=[{'interface': 'ixxat', 'channel': 0, 'unique_hardware_id': 'HW441489'}, {'interface': 'ixxat', 'channel': 0, 'unique_hardware_id': 'HW107422'}, {'interface': 'ixxat', 'channel': 1, 'unique_hardware_id': 'HW107422'}],
+        )
 
     .. doctest:: ixxat
 
         >>> import can 
-        >>> print(can.detect_available_configs("ixxat"))
-        [{'interface': 'ixxat', 'channel': 0, 'unique_hardware_id': 'HW509182'},
-        {'interface': 'ixxat', 'channel': 0, 'unique_hardware_id': 'HW107422'},
-        {'interface': 'ixxat', 'channel': 1, 'unique_hardware_id': 'HW107422'}]
+        >>> configs = can.detect_available_configs("ixxat")
+        >>> for config in configs:
+        ...     print(config)
+        {'interface': 'ixxat', 'channel': 0, 'unique_hardware_id': 'HW441489'}
+        {'interface': 'ixxat', 'channel': 0, 'unique_hardware_id': 'HW107422'}
+        {'interface': 'ixxat', 'channel': 1, 'unique_hardware_id': 'HW107422'}
 
 
 You may also get a list of all connected IXXAT devices using the function ``get_ixxat_hwids()`` as demonstrated below:

--- a/doc/interfaces/ixxat.rst
+++ b/doc/interfaces/ixxat.rst
@@ -56,17 +56,35 @@ VCI documentation, section "Message filters" for more info.
 
 List available devices
 ----------------------
-In case you have connected multiple IXXAT devices, you have to select them by using their unique hardware id.
-To get a list of all connected IXXAT you can use the function ``get_ixxat_hwids()`` as demonstrated below:
+
+In case you have connected multiple IXXAT devices, you have to select them by using their unique hardware id. 
+The function :meth:`~can.detect_available_configs` can be used to generate a list of :class:`~can.BusABC` constructors
+(including the channel number and unique hardware ID number for the connected devices).
 
     .. testsetup:: ixxat
+
+        from unittest.mock import Mock
+        can.detect_available_configs = Mock(side_effect=lambda: [{'interface': 'ixxat', 'channel': 0, 'unique_hardware_id': 'HW441489'}, {'interface': 'ixxat', 'channel': 0, 'unique_hardware_id': 'HW107422'}, {'interface': 'ixxat', 'channel': 1, 'unique_hardware_id': 'HW107422'}])
+
+    .. doctest:: ixxat
+
+        >>> import can 
+        >>> print(can.detect_available_configs("ixxat"))
+        [{'interface': 'ixxat', 'channel': 0, 'unique_hardware_id': 'HW509182'},
+        {'interface': 'ixxat', 'channel': 0, 'unique_hardware_id': 'HW107422'},
+        {'interface': 'ixxat', 'channel': 1, 'unique_hardware_id': 'HW107422'}]
+
+
+You may also get a list of all connected IXXAT devices using the function ``get_ixxat_hwids()`` as demonstrated below:
+
+    .. testsetup:: ixxat2
 
         from unittest.mock import Mock
         import can.interfaces.ixxat
         assert hasattr(can.interfaces.ixxat, "get_ixxat_hwids")
         can.interfaces.ixxat.get_ixxat_hwids = Mock(side_effect=lambda: ['HW441489', 'HW107422'])
 
-    .. doctest:: ixxat
+    .. doctest:: ixxat2
 
         >>> from can.interfaces.ixxat import get_ixxat_hwids
         >>> for hwid in get_ixxat_hwids():

--- a/test/test_interface_ixxat.py
+++ b/test/test_interface_ixxat.py
@@ -51,6 +51,18 @@ class HardwareTestCase(unittest.TestCase):
             raise unittest.SkipTest("not available on this platform")
 
     def test_bus_creation(self):
+        try:
+            configs = can.detect_available_configs("ixxat")
+            if configs:
+                for interface_kwargs in configs:
+                    bus = can.Bus(**interface_kwargs)
+                    bus.shutdown()
+            else:
+                raise unittest.SkipTest("No adapters were detected")
+        except can.CanInterfaceNotImplementedError:
+            raise unittest.SkipTest("not available on this platform")
+
+    def test_bus_creation_incorrect_channel(self):
         # non-existent channel -> use arbitrary high value
         with self.assertRaises(can.CanInitializationError):
             can.Bus(interface="ixxat", channel=0xFFFF)


### PR DESCRIPTION
Tested on local hardware, although I only have single channel devices so have not been able to validate that the multichannel detection works correctly.

I only realised once writing the pull request that there is some overlap with #1180 in the changes I have made. I have submitted a seperate PR anyway as I believe that the solution in these commits is much more in line with the behaviour of the rest of the library, but please feel free to close if you wish to progress the other PR.