### PR TITLE
Can Player compatibility with interfaces that use additional configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,9 +103,7 @@ jobs:
         pylint --rcfile=.pylintrc \
         can/**.py \
         can/io \
-        setup.py \
         doc/conf.py \
-        scripts/**.py \
         examples/**.py \
         can/interfaces/socketcan
 

--- a/can/io/mf4.py
+++ b/can/io/mf4.py
@@ -113,8 +113,7 @@ class MF4Writer(BinaryIOMessageWriter):
 
         if kwargs.get("append", False):
             raise ValueError(
-                f"{self.__class__.__name__} is currently not equipped to "
-                f"append messages to an existing file."
+                f"{self.__class__.__name__} is currently not equipped to " f"append messages to an existing file."
             )
 
         super().__init__(file, mode="w+b")
@@ -135,9 +134,7 @@ class MF4Writer(BinaryIOMessageWriter):
         else:
             attachment = None
 
-        acquisition_source = SourceInformation(
-            source_type=SOURCE_BUS, bus_type=BUS_TYPE_CAN
-        )
+        acquisition_source = SourceInformation(source_type=SOURCE_BUS, bus_type=BUS_TYPE_CAN)
 
         # standard frames group
         self._mdf.append(
@@ -272,7 +269,11 @@ class MF4Reader(BinaryIOMessageReader):
     The MF4Reader only supports MF4 files that were recorded with python-can.
     """
 
-    def __init__(self, file: Union[StringPathLike, BinaryIO]) -> None:
+    def __init__(
+        self,
+        file: Union[StringPathLike, BinaryIO],
+        **kwargs: Any,
+    ) -> None:
         """
         :param file: a path-like object or as file-like object to read from
                         If this is a file-like object, is has to be opened in
@@ -296,10 +297,7 @@ class MF4Reader(BinaryIOMessageReader):
 
         masters = [self._mdf.get_master(i) for i in range(3)]
 
-        masters = [
-            np.core.records.fromarrays((master, np.ones(len(master)) * i))
-            for i, master in enumerate(masters)
-        ]
+        masters = [np.core.records.fromarrays((master, np.ones(len(master)) * i)) for i, master in enumerate(masters)]
 
         self.masters = np.sort(np.concatenate(masters))
 

--- a/can/io/trc.py
+++ b/can/io/trc.py
@@ -87,9 +87,9 @@ class TRCReader(TextIOMessageReader):
             elif line.startswith(";$STARTTIME"):
                 logger.debug("TRCReader: Found start time '%s'", line)
                 try:
-                    self.start_time = datetime(1899, 12, 30, tzinfo=timezone.utc) + timedelta(
-                        days=float(line.split("=")[1])
-                    )
+                    self.start_time = datetime(
+                        1899, 12, 30, tzinfo=timezone.utc
+                    ) + timedelta(days=float(line.split("=")[1]))
                 except IndexError:
                     logger.debug("TRCReader: Failed to parse start time")
             elif line.startswith(";$COLUMNS"):
@@ -113,7 +113,9 @@ class TRCReader(TextIOMessageReader):
                 raise ValueError("File has no column information")
 
         if self.file_version == TRCFileVersion.UNKNOWN:
-            logger.info("TRCReader: No file version was found, so version 1.0 is assumed")
+            logger.info(
+                "TRCReader: No file version was found, so version 1.0 is assumed"
+            )
             self._parse_cols = self._parse_msg_V1_0
         elif self.file_version == TRCFileVersion.V1_0:
             self._parse_cols = self._parse_msg_V1_0
@@ -146,7 +148,9 @@ class TRCReader(TextIOMessageReader):
 
         msg = Message()
         if isinstance(self.start_time, datetime):
-            msg.timestamp = (self.start_time + timedelta(milliseconds=float(cols[1]))).timestamp()
+            msg.timestamp = (
+                self.start_time + timedelta(milliseconds=float(cols[1]))
+            ).timestamp()
         else:
             msg.timestamp = float(cols[1]) / 1000
         msg.arbitration_id = int(arbit_id, 16)
@@ -172,14 +176,18 @@ class TRCReader(TextIOMessageReader):
 
         msg = Message()
         if isinstance(self.start_time, datetime):
-            msg.timestamp = (self.start_time + timedelta(milliseconds=float(cols[self.columns["O"]]))).timestamp()
+            msg.timestamp = (
+                self.start_time + timedelta(milliseconds=float(cols[self.columns["O"]]))
+            ).timestamp()
         else:
             msg.timestamp = float(cols[1]) / 1000
         msg.arbitration_id = int(cols[self.columns["I"]], 16)
         msg.is_extended_id = len(cols[self.columns["I"]]) > 4
         msg.channel = int(cols[bus]) if bus is not None else 1
         msg.dlc = dlc
-        msg.data = bytearray([int(cols[i + self.columns["D"]], 16) for i in range(length)])
+        msg.data = bytearray(
+            [int(cols[i + self.columns["D"]], 16) for i in range(length)]
+        )
         msg.is_rx = cols[self.columns["d"]] == "Rx"
         msg.is_fd = type_ in ["FD", "FB", "FE", "BI"]
         msg.bitrate_switch = type_ in ["FB", " FE"]
@@ -249,7 +257,9 @@ class TRCWriter(TextIOMessageWriter):
     file: TextIO
     first_timestamp: Optional[float]
 
-    FORMAT_MESSAGE = "{msgnr:>7} {time:13.3f} DT {channel:>2} {id:>8} {dir:>2} -  {dlc:<4} {data}"
+    FORMAT_MESSAGE = (
+        "{msgnr:>7} {time:13.3f} DT {channel:>2} {id:>8} {dir:>2} -  {dlc:<4} {data}"
+    )
     FORMAT_MESSAGE_V1_0 = "{msgnr:>6}) {time:7.0f} {id:>8} {dlc:<1} {data}"
 
     def __init__(

--- a/can/io/trc.py
+++ b/can/io/trc.py
@@ -11,7 +11,7 @@ import logging
 import os
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import Callable, Dict, Generator, List, Optional, TextIO, Union
+from typing import Any, Callable, Dict, Generator, List, Optional, TextIO, Union
 
 from ..message import Message
 from ..typechecking import StringPathLike
@@ -49,6 +49,7 @@ class TRCReader(TextIOMessageReader):
     def __init__(
         self,
         file: Union[StringPathLike, TextIO],
+        **kwargs: Any,
     ) -> None:
         """
         :param file: a path-like object or as file-like object to read from
@@ -86,9 +87,9 @@ class TRCReader(TextIOMessageReader):
             elif line.startswith(";$STARTTIME"):
                 logger.debug("TRCReader: Found start time '%s'", line)
                 try:
-                    self.start_time = datetime(
-                        1899, 12, 30, tzinfo=timezone.utc
-                    ) + timedelta(days=float(line.split("=")[1]))
+                    self.start_time = datetime(1899, 12, 30, tzinfo=timezone.utc) + timedelta(
+                        days=float(line.split("=")[1])
+                    )
                 except IndexError:
                     logger.debug("TRCReader: Failed to parse start time")
             elif line.startswith(";$COLUMNS"):
@@ -112,9 +113,7 @@ class TRCReader(TextIOMessageReader):
                 raise ValueError("File has no column information")
 
         if self.file_version == TRCFileVersion.UNKNOWN:
-            logger.info(
-                "TRCReader: No file version was found, so version 1.0 is assumed"
-            )
+            logger.info("TRCReader: No file version was found, so version 1.0 is assumed")
             self._parse_cols = self._parse_msg_V1_0
         elif self.file_version == TRCFileVersion.V1_0:
             self._parse_cols = self._parse_msg_V1_0
@@ -147,9 +146,7 @@ class TRCReader(TextIOMessageReader):
 
         msg = Message()
         if isinstance(self.start_time, datetime):
-            msg.timestamp = (
-                self.start_time + timedelta(milliseconds=float(cols[1]))
-            ).timestamp()
+            msg.timestamp = (self.start_time + timedelta(milliseconds=float(cols[1]))).timestamp()
         else:
             msg.timestamp = float(cols[1]) / 1000
         msg.arbitration_id = int(arbit_id, 16)
@@ -175,18 +172,14 @@ class TRCReader(TextIOMessageReader):
 
         msg = Message()
         if isinstance(self.start_time, datetime):
-            msg.timestamp = (
-                self.start_time + timedelta(milliseconds=float(cols[self.columns["O"]]))
-            ).timestamp()
+            msg.timestamp = (self.start_time + timedelta(milliseconds=float(cols[self.columns["O"]]))).timestamp()
         else:
             msg.timestamp = float(cols[1]) / 1000
         msg.arbitration_id = int(cols[self.columns["I"]], 16)
         msg.is_extended_id = len(cols[self.columns["I"]]) > 4
         msg.channel = int(cols[bus]) if bus is not None else 1
         msg.dlc = dlc
-        msg.data = bytearray(
-            [int(cols[i + self.columns["D"]], 16) for i in range(length)]
-        )
+        msg.data = bytearray([int(cols[i + self.columns["D"]], 16) for i in range(length)])
         msg.is_rx = cols[self.columns["d"]] == "Rx"
         msg.is_fd = type_ in ["FD", "FB", "FE", "BI"]
         msg.bitrate_switch = type_ in ["FB", " FE"]
@@ -256,15 +249,14 @@ class TRCWriter(TextIOMessageWriter):
     file: TextIO
     first_timestamp: Optional[float]
 
-    FORMAT_MESSAGE = (
-        "{msgnr:>7} {time:13.3f} DT {channel:>2} {id:>8} {dir:>2} -  {dlc:<4} {data}"
-    )
+    FORMAT_MESSAGE = "{msgnr:>7} {time:13.3f} DT {channel:>2} {id:>8} {dir:>2} -  {dlc:<4} {data}"
     FORMAT_MESSAGE_V1_0 = "{msgnr:>6}) {time:7.0f} {id:>8} {dlc:<1} {data}"
 
     def __init__(
         self,
         file: Union[StringPathLike, TextIO],
         channel: int = 1,
+        **kwargs: Any,
     ) -> None:
         """
         :param file: a path-like object or as file-like object to write to


### PR DESCRIPTION
Fix readers for filetypes that did not implement **kwargs in their __init__ methods (#1609)

I have also updated the CI.yml file to remove the pylint specs for checking the now removed `/scripts` directory and `setup.py` file.