### PR TITLE
Fix decoding error in Kvaser constructor for non-ASCII product name

### DIFF
--- a/can/interfaces/kvaser/canlib.py
+++ b/can/interfaces/kvaser/canlib.py
@@ -727,7 +727,8 @@ def get_channel_info(channel):
         ctypes.sizeof(number),
     )
 
-    return f"{name.value.decode('ascii')}, S/N {serial.value} (#{number.value + 1})"
+    name_decoded = name.value.decode("ascii", errors="replace")
+    return f"{name_decoded}, S/N {serial.value} (#{number.value + 1})"
 
 
 init_kvaser_library()

--- a/test/test_kvaser.py
+++ b/test/test_kvaser.py
@@ -54,14 +54,14 @@ class KvaserTest(unittest.TestCase):
         # Test if the bus constructor is able to deal with non-ASCII characters
         def canGetChannelDataMock(
             channel: ctypes.c_int,
-            dtype: ctypes.c_int,
+            param: ctypes.c_int,
             buf: ctypes.c_void_p,
             bufsize: ctypes.c_size_t,
         ):
-            if dtype == constants.canCHANNELDATA_DEVDESCR_ASCII:
-                obj = ctypes.cast(buf, ctypes.POINTER(ctypes.c_char))
+            if param == constants.canCHANNELDATA_DEVDESCR_ASCII:
+                buf_char_ptr = ctypes.cast(buf, ctypes.POINTER(ctypes.c_char))
                 for i, char in enumerate(b"hello\x7a\xcb"):
-                    obj[i] = char
+                    buf_char_ptr[i] = char
 
         canlib.canGetChannelData = canGetChannelDataMock
         bus = can.Bus(channel=0, interface="kvaser")

--- a/test/test_kvaser.py
+++ b/test/test_kvaser.py
@@ -3,6 +3,7 @@
 """
 """
 
+import ctypes
 import time
 import unittest
 from unittest.mock import Mock
@@ -48,6 +49,26 @@ class KvaserTest(unittest.TestCase):
         self.assertEqual(self.bus.protocol, can.CanProtocol.CAN_20)
         self.assertTrue(canlib.canOpenChannel.called)
         self.assertTrue(canlib.canBusOn.called)
+
+    def test_bus_creation_illegal_channel_name(self):
+        # Test if the bus constructor is able to deal with non-ASCII characters
+        def canGetChannelDataMock(
+            channel: ctypes.c_int,
+            dtype: ctypes.c_int,
+            buf: ctypes.c_void_p,
+            bufsize: ctypes.c_size_t,
+        ):
+            if dtype == constants.canCHANNELDATA_DEVDESCR_ASCII:
+                obj = ctypes.cast(buf, ctypes.POINTER(ctypes.c_char))
+                for i, char in enumerate(b"hello\x7a\xcb"):
+                    obj[i] = char
+
+        canlib.canGetChannelData = canGetChannelDataMock
+        bus = can.Bus(channel=0, interface="kvaser")
+
+        self.assertTrue(bus.channel_info.startswith("hello"))
+
+        bus.shutdown()
 
     def test_bus_shutdown(self):
         self.bus.shutdown()


### PR DESCRIPTION
The PR will change the constructor to be less susceptible to non-ASCII characters in the device description.