### PR TITLE
Update CHANGELOG.md for 4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+Version 4.2.2
+=============
+
+Bug Fixes
+---------
+* Fix socketcan KeyError (#1598, #1599).
+* Fix IXXAT not properly shutdown message (#1606).
+* Fix Mf4Reader and TRCReader incompatibility with extra CLI args (#1610).
+* Fix decoding error in Kvaser constructor for non-ASCII product name (#1613). 
+
+
 Version 4.2.1
 =============
 

--- a/can/__init__.py
+++ b/can/__init__.py
@@ -8,7 +8,7 @@ messages on a can bus.
 import logging
 from typing import Any, Dict
 
-__version__ = "4.2.1"
+__version__ = "4.2.2"
 __all__ = [
     "ASCReader",
     "ASCWriter",


### PR DESCRIPTION
Cherry-pick CHANGELOG.md update from the `release-4.2` branch.