### PR TITLE
BigEndian test fixes

### DIFF
--- a/test/test_bit_timing.py
+++ b/test/test_bit_timing.py
@@ -175,7 +175,7 @@ def test_from_btr():
 def test_btr_persistence():
     f_clock = 8_000_000
     for btr0btr1 in PCAN_BITRATES.values():
-        btr1, btr0 = struct.unpack("BB", btr0btr1)
+        btr0, btr1 = struct.pack(">H", btr0btr1.value)
 
         t = can.BitTiming.from_registers(f_clock, btr0, btr1)
         assert t.btr0 == btr0

--- a/test/test_pcan.py
+++ b/test/test_pcan.py
@@ -3,6 +3,7 @@ Test for PCAN Interface
 """
 
 import ctypes
+import struct
 import unittest
 from unittest import mock
 from unittest.mock import Mock, patch
@@ -379,9 +380,7 @@ class TestPCANBus(unittest.TestCase):
             self.assertEqual(len(configs), 50)
         else:
             value = (TPCANChannelInformation * 1).from_buffer_copy(
-                b"Q\x00\x05\x00\x01\x00\x00\x00PCAN-USB FD\x00\x00\x00\x00"
-                b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
-                b'\x00\x00\x00\x00\x00\x00\x003"\x11\x00\x01\x00\x00\x00'
+                struct.pack("HBBI33sII", 81, 5, 0, 1, b"PCAN-USB FD", 1122867, 1)
             )
             self.mock_pcan.GetValue = Mock(return_value=(PCAN_ERROR_OK, value))
             configs = PcanBus._detect_available_configs()


### PR DESCRIPTION
- PCAN_BITRATES are stored in BIGendian, no use to byteswap on littleendian.
- Also the TPCANChannelInformation expects data in the native byte order

Closes: https://github.com/hardbyte/python-can/issues/1624