### PR TITLE
Fix IXXAT periodic messages not working

### DIFF
--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -131,6 +131,8 @@ class IXXATBus(BusABC):
                 **kwargs
             )
 
+        super().__init__(channel=channel, **kwargs)
+
     def flush_tx_buffer(self):
         """Flushes the transmit buffer on the IXXAT"""
         return self.bus.flush_tx_buffer()


### PR DESCRIPTION
Hey,

As reported in a few instances, the periodic messages don't work on IXXAT. The `IXXATBus` appears to be just missing the call to the super-classes constructor. This call is present in the `develop` branch but is missing in the current release v4.2.2

References: #1285 #1605 