### PR TITLE
Refactor flush_tx_queue for VectorBus

### DIFF
--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -888,15 +888,24 @@ class VectorBus(BusABC):
         if self._can_protocol is CanProtocol.CAN_FD:
             xl_can_tx_event = xlclass.XLcanTxEvent()
             xl_can_tx_event.tag = xldefine.XL_CANFD_TX_EventTags.XL_CAN_EV_TAG_TX_MSG
-            xl_can_tx_event.tagData.canMsg.msgFlags |= xldefine.XL_CANFD_TX_MessageFlags.XL_CAN_TXMSG_FLAG_HIGHPRIO
+            xl_can_tx_event.tagData.canMsg.msgFlags |= (
+                xldefine.XL_CANFD_TX_MessageFlags.XL_CAN_TXMSG_FLAG_HIGHPRIO
+            )
 
             self.xldriver.xlCanTransmitEx(
-                self.port_handle, self.mask, ctypes.c_uint(1), ctypes.c_uint(0), xl_can_tx_event
+                self.port_handle,
+                self.mask,
+                ctypes.c_uint(1),
+                ctypes.c_uint(0),
+                xl_can_tx_event,
             )
         else:
             xl_event = xlclass.XLevent()
             xl_event.tag = xldefine.XL_EventTags.XL_TRANSMIT_MSG
-            xl_event.tagData.msg.flags |= xldefine.XL_MessageFlags.XL_CAN_MSG_FLAG_OVERRUN
+            xl_event.tagData.msg.flags |= (
+                xldefine.XL_MessageFlags.XL_CAN_MSG_FLAG_OVERRUN
+                | xldefine.XL_MessageFlags.XL_CAN_MSG_FLAG_WAKEUP
+            )
 
             self.xldriver.xlCanTransmit(
                 self.port_handle, self.mask, ctypes.c_uint(1), xl_event

--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -881,9 +881,11 @@ class VectorBus(BusABC):
         """
         Flush the TX buffer of the bus.
 
-        According to XL Driver Library Manual, function xlCanFlushTransmitQueue performs a no-op for
-        Vector devices other than XL family. As a workaround, dummy TX frame with overrun/highprio flag is sent, which
-        clears the TX queue.
+        Implementation does not use function ``xlCanFlushTransmitQueue`` of the XL driver, as it works only
+        for XL family devices.
+
+        .. warning::
+            Using this function will flush the queue and send a high voltage message (ID = 0, DLC = 0, no data).
         """
         if self._can_protocol is CanProtocol.CAN_FD:
             xl_can_tx_event = xlclass.XLcanTxEvent()

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -610,6 +610,43 @@ def test_receive_fd_non_msg_event() -> None:
     bus.shutdown()
 
 
+def test_flush_tx_buffer_mocked(mock_xldriver) -> None:
+    bus = can.Bus(channel=0, interface="vector", _testing=True)
+    bus.flush_tx_buffer()
+    transmit_args = can.interfaces.vector.canlib.xldriver.xlCanTransmit.call_args[0]
+
+    num_msg = transmit_args[2]
+    assert num_msg.value == ctypes.c_uint(1).value
+
+    event = transmit_args[3]
+    assert isinstance(event, xlclass.XLevent)
+    assert event.tag & xldefine.XL_EventTags.XL_TRANSMIT_MSG
+    assert event.tagData.msg.flags & (
+        xldefine.XL_MessageFlags.XL_CAN_MSG_FLAG_OVERRUN
+        | xldefine.XL_MessageFlags.XL_CAN_MSG_FLAG_WAKEUP
+    )
+
+
+def test_flush_tx_buffer_fd_mocked(mock_xldriver) -> None:
+    bus = can.Bus(channel=0, interface="vector", fd=True, _testing=True)
+    bus.flush_tx_buffer()
+    transmit_args = can.interfaces.vector.canlib.xldriver.xlCanTransmitEx.call_args[0]
+
+    num_msg = transmit_args[2]
+    assert num_msg.value == ctypes.c_uint(1).value
+
+    num_msg_sent = transmit_args[3]
+    assert num_msg_sent.value == ctypes.c_uint(0).value
+
+    event = transmit_args[4]
+    assert isinstance(event, xlclass.XLcanTxEvent)
+    assert event.tag & xldefine.XL_CANFD_TX_EventTags.XL_CAN_EV_TAG_TX_MSG
+    assert (
+        event.tagData.canMsg.msgFlags
+        & xldefine.XL_CANFD_TX_MessageFlags.XL_CAN_TXMSG_FLAG_HIGHPRIO
+    )
+
+
 @pytest.mark.skipif(not XLDRIVER_FOUND, reason="Vector XL API is unavailable")
 def test_flush_tx_buffer() -> None:
     bus = can.Bus(channel=0, serial=_find_virtual_can_serial(), interface="vector")

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -610,12 +610,6 @@ def test_receive_fd_non_msg_event() -> None:
     bus.shutdown()
 
 
-def test_flush_tx_buffer_mocked(mock_xldriver) -> None:
-    bus = can.Bus(channel=0, interface="vector", _testing=True)
-    bus.flush_tx_buffer()
-    can.interfaces.vector.canlib.xldriver.xlCanFlushTransmitQueue.assert_called()
-
-
 @pytest.mark.skipif(not XLDRIVER_FOUND, reason="Vector XL API is unavailable")
 def test_flush_tx_buffer() -> None:
     bus = can.Bus(channel=0, serial=_find_virtual_can_serial(), interface="vector")


### PR DESCRIPTION
In `VectorBus` class, there's an implementation of `flush_tx_buffer` relying on `xlCanFlushTransmitQueue` function of the XL driver. However, this function is a no-op for devices other than XL family, which are discontinued. This means that the library does not support flushing the TX buffer for any Vector devices currently available on the market.
(https://cdn.vector.com/cms/content/products/XL_Driver_Library/Docs/XL_Driver_Library_Manual_EN.pdf)

My implementation of flush_tx_buffer consists of “sending” a dummy message with overrun/highprio flag set. The Vector interface will flush the TX queue after receiving a request to send this message.

Tested on VN5610A, for both FD and non-FD bus. I think it's a good idea to check this on other Vector devices, especially on XL family, to make sure that the implementation works for them all. In our use case, the flush is called after `XL_ERR_QUEUE_IS_FULL` is raised (e.g. when sending a ton of messages on a dead bus). In previous implementation, any next send request will raise this error if the bus is still dead, because the flush was a no-op. In my implementation, next send requests will not raise an error (until it fills up again).