### PR TITLE
Change python implementation to increase speed in pcan send

### DIFF
--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -608,8 +608,7 @@ class PcanBus(BusABC):
             CANMsg.MSGTYPE = msgType
 
             # copy data
-            for i in range(msg.dlc):
-                CANMsg.DATA[i] = msg.data[i]
+            CANMsg.DATA[: msg.dlc] = msg.data[: msg.dlc]
 
             log.debug("Data: %s", msg.data)
             log.debug("Type: %s", type(msg.data))
@@ -628,8 +627,7 @@ class PcanBus(BusABC):
             # if a remote frame will be sent, data bytes are not important.
             if not msg.is_remote_frame:
                 # copy data
-                for i in range(CANMsg.LEN):
-                    CANMsg.DATA[i] = msg.data[i]
+                CANMsg.DATA[: CANMsg.LEN] = msg.data[: CANMsg.LEN]
 
             log.debug("Data: %s", msg.data)
             log.debug("Type: %s", type(msg.data))


### PR DESCRIPTION
During test with a python implementation using python-can to send uds message, the analysis of the speed show that using a list slicing instead of a for loop increase the speed of our test from 131Kbytes/s to 142kBytes/s.

