### PR TITLE
bugfix issue #1661 

### DIFF
--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -182,12 +182,13 @@ class BLFReader(BinaryIOMessageReader):
             self.file.read(obj_size % 4)
 
             if obj_type == LOG_CONTAINER:
-                method, uncompressed_size = LOG_CONTAINER_STRUCT.unpack_from(obj_data)
+                method, _ = LOG_CONTAINER_STRUCT.unpack_from(obj_data)
                 container_data = obj_data[LOG_CONTAINER_STRUCT.size :]
                 if method == NO_COMPRESSION:
                     data = container_data
                 elif method == ZLIB_DEFLATE:
-                    zobj = zlib.decompressobj()  # obj for decompressing data streams that won’t fit into memory at once.
+                    # obj for decompressing data streams that won’t fit into memory at once.
+                    zobj = zlib.decompressobj()  
                     data = zobj.decompress(container_data)
                 else:
                     # Unknown compression method

--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -187,8 +187,7 @@ class BLFReader(BinaryIOMessageReader):
                 if method == NO_COMPRESSION:
                     data = container_data
                 elif method == ZLIB_DEFLATE:
-                    # obj for decompressing data streams that won’t fit into memory at once.
-                    zobj = zlib.decompressobj()  
+                    zobj = zlib.decompressobj()
                     data = zobj.decompress(container_data)
                 else:
                     # Unknown compression method

--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -187,7 +187,9 @@ class BLFReader(BinaryIOMessageReader):
                 if method == NO_COMPRESSION:
                     data = container_data
                 elif method == ZLIB_DEFLATE:
-                    data = zlib.decompress(container_data, 15, uncompressed_size)
+                    elif method == ZLIB_DEFLATE:
+                    zobj = zlib.decompressobj()  # obj for decompressing data streams that won’t fit into memory at once.
+                    data = zobj.decompress(container_data)
                 else:
                     # Unknown compression method
                     LOG.warning("Unknown compression method (%d)", method)

--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -187,7 +187,6 @@ class BLFReader(BinaryIOMessageReader):
                 if method == NO_COMPRESSION:
                     data = container_data
                 elif method == ZLIB_DEFLATE:
-                    elif method == ZLIB_DEFLATE:
                     zobj = zlib.decompressobj()  # obj for decompressing data streams that won’t fit into memory at once.
                     data = zobj.decompress(container_data)
                 else:


### PR DESCRIPTION
 BLFReader zlib.error: Error -5 while decompressing data: incomplete or truncated stream in Python #1661 

https://github.com/hardbyte/python-can/issues/1661