### PR TITLE
We do not need to account for drift when we USE_WINDOWS_EVENTS

### DIFF
--- a/can/broadcastmanager.py
+++ b/can/broadcastmanager.py
@@ -324,7 +324,7 @@ class ThreadBasedCyclicSendTask(
             if USE_WINDOWS_EVENTS:
                 win32event.WaitForSingleObject(
                     self.event.handle,
-                    -1,
+                    win32event.INFINITE,
                 )
             else:
                 # Compensate for the time it takes to send the message

--- a/can/broadcastmanager.py
+++ b/can/broadcastmanager.py
@@ -289,12 +289,11 @@ class ThreadBasedCyclicSendTask(
 
     def _run(self) -> None:
         msg_index = 0
+        msg_due_time_ns = time.perf_counter_ns()
 
         if USE_WINDOWS_EVENTS:
             # Make sure the timer is non-signaled before entering the loop
             win32event.WaitForSingleObject(self.event.handle, 0)
-        else:
-            msg_due_time_ns = time.perf_counter_ns()
 
         while not self.stopped:
             # Prevent calling bus.send from multiple threads

--- a/can/broadcastmanager.py
+++ b/can/broadcastmanager.py
@@ -35,7 +35,6 @@ except ImportError:
 log = logging.getLogger("can.bcm")
 
 NANOSECONDS_IN_SECOND: Final[int] = 1_000_000_000
-NANOSECONDS_IN_MILLISECOND: Final[int] = 1_000_000
 
 
 class CyclicTask(abc.ABC):
@@ -316,19 +315,19 @@ class ThreadBasedCyclicSendTask(
                         self.stop()
                         break
 
-            msg_due_time_ns += self.period_ns
+            if not USE_WINDOWS_EVENTS:
+                msg_due_time_ns += self.period_ns
             if self.end_time is not None and time.perf_counter() >= self.end_time:
                 break
             msg_index = (msg_index + 1) % len(self.messages)
 
-            # Compensate for the time it takes to send the message
-            delay_ns = msg_due_time_ns - time.perf_counter_ns()
-
-            if delay_ns > 0:
-                if USE_WINDOWS_EVENTS:
-                    win32event.WaitForSingleObject(
-                        self.event.handle,
-                        int(round(delay_ns / NANOSECONDS_IN_MILLISECOND)),
-                    )
-                else:
+            if USE_WINDOWS_EVENTS:
+                win32event.WaitForSingleObject(
+                    self.event.handle,
+                    -1,
+                )
+            else:
+                # Compensate for the time it takes to send the message
+                delay_ns = msg_due_time_ns - time.perf_counter_ns()
+                if delay_ns > 0:
                     time.sleep(delay_ns / NANOSECONDS_IN_SECOND)

--- a/can/broadcastmanager.py
+++ b/can/broadcastmanager.py
@@ -289,11 +289,12 @@ class ThreadBasedCyclicSendTask(
 
     def _run(self) -> None:
         msg_index = 0
-        msg_due_time_ns = time.perf_counter_ns()
 
         if USE_WINDOWS_EVENTS:
             # Make sure the timer is non-signaled before entering the loop
             win32event.WaitForSingleObject(self.event.handle, 0)
+        else:
+            msg_due_time_ns = time.perf_counter_ns()
 
         while not self.stopped:
             # Prevent calling bus.send from multiple threads


### PR DESCRIPTION
When using USE_WINDOWS_EVENTS the waitable timer will be fired at fixed rate, we do not need to account for the drift.
The change makes it wait for the timer to be in signaled state only.
Previous code was causing multiple frames to be send back to back without delay.