### PR TITLE
skip the can_op_mode check if the device reports can_op_mode=0

### DIFF
--- a/can/interfaces/vector/canlib.py
+++ b/can/interfaces/vector/canlib.py
@@ -538,16 +538,19 @@ class VectorBus(BusABC):
         )
 
         # check CAN operation mode
-        if fd:
-            settings_acceptable &= bool(
-                bus_params_data.can_op_mode
-                & xldefine.XL_CANFD_BusParams_CanOpMode.XL_BUS_PARAMS_CANOPMODE_CANFD
-            )
-        elif bus_params_data.can_op_mode != 0:  # can_op_mode is always 0 for cancaseXL
-            settings_acceptable &= bool(
-                bus_params_data.can_op_mode
-                & xldefine.XL_CANFD_BusParams_CanOpMode.XL_BUS_PARAMS_CANOPMODE_CAN20
-            )
+        # skip the check if can_op_mode is 0
+        # as it happens for cancaseXL, VN7600 and sometimes on other hardware (VN1640)
+        if bus_params_data.can_op_mode:
+            if fd:
+                settings_acceptable &= bool(
+                    bus_params_data.can_op_mode
+                    & xldefine.XL_CANFD_BusParams_CanOpMode.XL_BUS_PARAMS_CANOPMODE_CANFD
+                )
+            else:
+                settings_acceptable &= bool(
+                    bus_params_data.can_op_mode
+                    & xldefine.XL_CANFD_BusParams_CanOpMode.XL_BUS_PARAMS_CANOPMODE_CAN20
+                )
 
         # check bitrates
         if bitrate:


### PR DESCRIPTION
Some device report can_op_mode=0 so the check will always fail.

For example this happened on a VN1640

```python
can.detect_available_configs(interfaces=["vector"])
```

```
[{'interface': 'vector', 'channel': 0, 'serial': 23347, 'hw_type': <XL_HardwareType.XL_HWTYPE_VN1640: 59>, 'hw_index': 0, 'hw_channel': 0, 'supports_fd': True, 'vector_channel_config': VectorChannelConfig(name='VN1640A Channel 1', hw_type=<XL_HardwareType.XL_HWTYPE_VN1640: 59>, hw_index=0, hw_channel=0, channel_index=0, channel_mask=1, channel_capabilities=<XL_ChannelCapabilities.XL_CHANNEL_FLAG_CANFD_ISO_SUPPORT|33554432|32768|16|4|2|XL_CHANNEL_FLAG_TIME_SYNC_RUNNING: 2181070871>, channel_bus_capabilities=<XL_BusCapabilities.XL_BUS_ACTIVE_CAP_CAN|XL_BUS_COMPATIBLE_KLINE|XL_BUS_COMPATIBLE_J1708|XL_BUS_COMPATIBLE_LIN|XL_BUS_COMPATIBLE_CAN: 67843>, is_on_bus=False, connected_bus_type=<XL_BusTypes.XL_BUS_TYPE_NONE: 0>, bus_params=VectorBusParams(bus_type=<XL_BusTypes.XL_BUS_TYPE_CAN: 1>, can=VectorCanParams(bitrate=500000, sjw=1, tseg1=4, tseg2=3, sam=1, output_mode=<XL_OutputMode.XL_OUTPUT_MODE_NORMAL: 1>, can_op_mode=<XL_CANFD_BusParams_CanOpMode.0: 0>), canfd=VectorCanFdParams(bitrate=500000, data_bitrate=0, sjw_abr=1, tseg1_abr=4, tseg2_abr=3, sam_abr=1, sjw_dbr=0, tseg1_dbr=0, tseg2_dbr=0, output_mode=<XL_OutputMode.XL_OUTPUT_MODE_NORMAL: 1>, can_op_mode=<XL_CANFD_BusParams_CanOpMode.0: 0>)), serial_number=23347, article_number=7114, transceiver_name='CANpiggy 1051cap (Highspeed)')}, 

{'interface': 'vector', 'channel': 1, 'serial': 23347, 'hw_type': <XL_HardwareType.XL_HWTYPE_VN1640: 59>, 'hw_index': 0, 'hw_channel': 1, 'supports_fd': True, 'vector_channel_config': VectorChannelConfig(name='VN1640A Channel 2', hw_type=<XL_HardwareType.XL_HWTYPE_VN1640: 59>, hw_index=0, hw_channel=1, channel_index=1, channel_mask=2, channel_capabilities=<XL_ChannelCapabilities.XL_CHANNEL_FLAG_CANFD_ISO_SUPPORT|33554432|32768|16|4|2|XL_CHANNEL_FLAG_TIME_SYNC_RUNNING: 2181070871>, channel_bus_capabilities=<XL_BusCapabilities.XL_BUS_ACTIVE_CAP_CAN|XL_BUS_COMPATIBLE_KLINE|XL_BUS_COMPATIBLE_J1708|XL_BUS_COMPATIBLE_LIN|XL_BUS_COMPATIBLE_CAN: 67843>, 
is_on_bus=False, connected_bus_type=<XL_BusTypes.XL_BUS_TYPE_NONE: 0>, bus_params=VectorBusParams(bus_type=<XL_BusTypes.XL_BUS_TYPE_CAN: 1>, can=VectorCanParams(bitrate=500000, sjw=1, tseg1=4, tseg2=3, sam=1, output_mode=<XL_OutputMode.XL_OUTPUT_MODE_NORMAL: 1>, can_op_mode=<XL_CANFD_BusParams_CanOpMode.0: 0>), canfd=VectorCanFdParams(bitrate=500000, data_bitrate=0, sjw_abr=1, tseg1_abr=4, tseg2_abr=3, sam_abr=1, sjw_dbr=0, tseg1_dbr=0, tseg2_dbr=0, output_mode=<XL_OutputMode.XL_OUTPUT_MODE_NORMAL: 1>, can_op_mode=<XL_CANFD_BusParams_CanOpMode.0: 0>)), serial_number=23347, article_number=7114, transceiver_name='CANpiggy 1051cap (Highspeed)')}, 

{'interface': 'vector', 'channel': 2, 'serial': 23347, 'hw_type': <XL_HardwareType.XL_HWTYPE_VN1640: 59>, 'hw_index': 0, 'hw_channel': 2, 'supports_fd': True, 'vector_channel_config': VectorChannelConfig(name='VN1640A Channel 3', hw_type=<XL_HardwareType.XL_HWTYPE_VN1640: 59>, hw_index=0, hw_channel=2, channel_index=2, channel_mask=4, channel_capabilities=<XL_ChannelCapabilities.XL_CHANNEL_FLAG_CANFD_ISO_SUPPORT|33554432|32768|16|4|2|XL_CHANNEL_FLAG_TIME_SYNC_RUNNING: 2181070871>, channel_bus_capabilities=<XL_BusCapabilities.XL_BUS_ACTIVE_CAP_CAN|XL_BUS_COMPATIBLE_J1708|XL_BUS_COMPATIBLE_LIN|XL_BUS_COMPATIBLE_CAN: 65795>, 
is_on_bus=True, connected_bus_type=<XL_BusTypes.XL_BUS_TYPE_CAN: 1>, bus_params=VectorBusParams(bus_type=<XL_BusTypes.XL_BUS_TYPE_CAN: 1>, can=VectorCanParams(bitrate=500000, sjw=16, tseg1=63, tseg2=16, sam=0, output_mode=<XL_OutputMode.XL_OUTPUT_MODE_NORMAL: 1>, can_op_mode=<XL_CANFD_BusParams_CanOpMode.0: 0>), canfd=VectorCanFdParams(bitrate=500000, data_bitrate=2000000, sjw_abr=16, tseg1_abr=63, tseg2_abr=16, sam_abr=0, sjw_dbr=4, tseg1_dbr=15, tseg2_dbr=4, output_mode=<XL_OutputMode.XL_OUTPUT_MODE_NORMAL: 1>, can_op_mode=<XL_CANFD_BusParams_CanOpMode.0: 0>)), serial_number=23347, article_number=7114, transceiver_name='CANpiggy 1051cap (Highspeed)')}, 

{'interface': 'vector', 'channel': 3, 'serial': 23347, 'hw_type': <XL_HardwareType.XL_HWTYPE_VN1640: 59>, 'hw_index': 0, 'hw_channel': 3, 'supports_fd': True, 'vector_channel_config': VectorChannelConfig(name='VN1640A Channel 4', hw_type=<XL_HardwareType.XL_HWTYPE_VN1640: 59>, hw_index=0, hw_channel=3, channel_index=3, channel_mask=8, channel_capabilities=<XL_ChannelCapabilities.XL_CHANNEL_FLAG_CANFD_ISO_SUPPORT|33554432|32768|16|4|2|XL_CHANNEL_FLAG_TIME_SYNC_RUNNING: 2181070871>, channel_bus_capabilities=<XL_BusCapabilities.XL_BUS_ACTIVE_CAP_CAN|XL_BUS_COMPATIBLE_J1708|XL_BUS_COMPATIBLE_LIN|XL_BUS_COMPATIBLE_CAN: 65795>, is_on_bus=False, connected_bus_type=<XL_BusTypes.XL_BUS_TYPE_NONE: 0>, bus_params=VectorBusParams(bus_type=<XL_BusTypes.XL_BUS_TYPE_CAN: 1>, can=VectorCanParams(bitrate=500000, sjw=1, tseg1=4, tseg2=3, sam=1, output_mode=<XL_OutputMode.XL_OUTPUT_MODE_NORMAL: 1>, can_op_mode=<XL_CANFD_BusParams_CanOpMode.0: 0>), canfd=VectorCanFdParams(bitrate=500000, data_bitrate=0, sjw_abr=1, tseg1_abr=4, tseg2_abr=3, sam_abr=1, sjw_dbr=0, tseg1_dbr=0, tseg2_dbr=0, output_mode=<XL_OutputMode.XL_OUTPUT_MODE_NORMAL: 1>, can_op_mode=<XL_CANFD_BusParams_CanOpMode.0: 0>)), serial_number=23347, article_number=7114, transceiver_name='CANpiggy 1051cap (Highspeed)')}, ]
```