### PR TITLE
Add feature to detect socketcand beacon

### DIFF
--- a/can/interfaces/socketcand/__init__.py
+++ b/can/interfaces/socketcand/__init__.py
@@ -8,7 +8,8 @@ http://www.domologic.de
 
 __all__ = [
     "SocketCanDaemonBus",
+    "detect_beacon",
     "socketcand",
 ]
 
-from .socketcand import SocketCanDaemonBus
+from .socketcand import SocketCanDaemonBus, detect_beacon

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -26,7 +26,7 @@ DEFAULT_SOCKETCAND_DISCOVERY_ADDRESS = ""
 DEFAULT_SOCKETCAND_DISCOVERY_PORT = 42000
 
 
-def detect_beacon():
+def detect_beacon(timeout_ms):
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
         sock.bind(
             (DEFAULT_SOCKETCAND_DISCOVERY_ADDRESS, DEFAULT_SOCKETCAND_DISCOVERY_PORT)
@@ -37,8 +37,6 @@ def detect_beacon():
             DEFAULT_SOCKETCAND_DISCOVERY_PORT,
         )
 
-        # Time between beacons no more than 3 seconds. Allow for at least 3
-        timeout_ms = 12000
         now = time.time() * 1000
         end_time = now + timeout_ms
         while (time.time() * 1000) < end_time:
@@ -328,7 +326,9 @@ class SocketCanDaemonBus(can.BusABC):
     @staticmethod
     def _detect_available_configs() -> List[can.typechecking.AutoDetectedConfig]:
         try:
-            return detect_beacon()
+            # Time between beacons no more than 3 seconds. Allow for a little
+            # more than 3s
+            return detect_beacon(3.1)
         except Exception as e:
             log.warning(f"Could not detect socketcand beacon: {e}")
             return []

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -321,4 +321,8 @@ class SocketCanDaemonBus(can.BusABC):
 
     @staticmethod
     def _detect_available_configs() -> List[can.typechecking.AutoDetectedConfig]:
-        return detect_beacon()
+        try:
+            return detect_beacon()
+        except Exception as e:
+            log.warning(f"Could not detect socketcand beacon: {e}")
+            return []

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -30,9 +30,9 @@ def detect_beacon(timeout_ms: int = 3100) -> List[can.typechecking.AutoDetectedC
     """
     Detects socketcand servers
 
-    This is what :meth:`can.detect_available_configs` ends up calling
-    search for available socketcand servers with fixed timeout of 3.1
-    seconds (socketcand sends out a beacon packet every 3 seconds).
+    This is what :meth:`can.detect_available_configs` ends up calling to search
+    for available socketcand servers with a default timeout of 3100ms
+    (socketcand sends a beacon packet every 3000ms).
 
     Using this method directly allows for adjusting the timeout. Extending
     the timeout beyond the default time period could be useful if UDP
@@ -341,8 +341,6 @@ class SocketCanDaemonBus(can.BusABC):
     @staticmethod
     def _detect_available_configs() -> List[can.typechecking.AutoDetectedConfig]:
         try:
-            # Time between beacons no more than 3 seconds. Allow for a little
-            # more than 3s
             return detect_beacon()
         except Exception as e:
             log.warning(f"Could not detect socketcand beacon: {e}")

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -30,19 +30,19 @@ def detect_beacon(timeout_ms: int = 3100) -> List[can.typechecking.AutoDetectedC
     """
     Detects socketcand servers
 
-        This is what :meth:`can.detect_available_configs` ends up calling
-        search for available socketcand servers with fixed timeout of 3.1
-        seconds (socketcand sends out a beacon packet every 3 seconds).
+    This is what :meth:`can.detect_available_configs` ends up calling
+    search for available socketcand servers with fixed timeout of 3.1
+    seconds (socketcand sends out a beacon packet every 3 seconds).
 
-        Using this method directly allows for adjusting the timeout. Extending
-        the timeout beyond the default time period could be useful if UDP
-        packet loss is a concern.
+    Using this method directly allows for adjusting the timeout. Extending
+    the timeout beyond the default time period could be useful if UDP
+    packet loss is a concern.
 
-        :param timeout_ms:
-            Timeout in milliseconds to wait for socketcand beacon packets
+    :param timeout_ms:
+        Timeout in milliseconds to wait for socketcand beacon packets
 
-        :return:
-            See :meth:`~can.detect_available_configs`
+    :return:
+        See :meth:`~can.detect_available_configs`
     """
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
         sock.bind(

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -120,9 +120,7 @@ def detect_beacon(timeout_ms) -> List[can.typechecking.AutoDetectedConfig]:
                     f"Failed to detect beacon: {exc} {traceback.format_exc()}"
                 )
 
-        raise TimeoutError(
-            f"detect_beacon: Failed to detect udp beacon for {timeout_ms} ms"
-        )
+        return []
 
 
 def convert_ascii_message_to_can_message(ascii_msg: str) -> can.Message:

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -13,7 +13,10 @@ import select
 import socket
 import time
 import traceback
+import urllib.parse as urlparselib
+import xml.etree.ElementTree as ET
 from collections import deque
+from typing import List
 
 import can
 

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -26,7 +26,24 @@ DEFAULT_SOCKETCAND_DISCOVERY_ADDRESS = ""
 DEFAULT_SOCKETCAND_DISCOVERY_PORT = 42000
 
 
-def detect_beacon(timeout_ms):
+def detect_beacon(timeout_ms) -> List[can.typechecking.AutoDetectedConfig]:
+    """
+    Detects socketcand servers
+
+        This is what :meth:`can.SocketCanDaemonBus._detect_available_configs`
+        uses to search for available socketcand servers with fixed timeout of
+        3.1 seconds (socketcand sends out a beacon packet every 3 seconds).
+
+        Using this method directly allows for adjusting the timeout. Extending
+        the timeout beyond the default time period could be useful if UDP
+        packet loss is a concern.
+
+        :param timeout_ms:
+            Timeout in milliseconds to wait for socketcand beacon packets
+
+        :return:
+            See :meth:`can.SocketCanDaemonBus._detect_available_configs`
+    """
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
         sock.bind(
             (DEFAULT_SOCKETCAND_DISCOVERY_ADDRESS, DEFAULT_SOCKETCAND_DISCOVERY_PORT)

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -30,7 +30,9 @@ def detect_beacon():
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.bind((DEFAULT_SOCKETCAND_DISCOVERY_ADDRESS, DEFAULT_SOCKETCAND_DISCOVERY_PORT))
     log.info(
-        f"Listening on for socketcand UDP advertisement on {DEFAULT_SOCKETCAND_DISCOVERY_ADDRESS}:{DEFAULT_SOCKETCAND_DISCOVERY_PORT}"
+        "Listening on for socketcand UDP advertisement on %s:%s",
+        DEFAULT_SOCKETCAND_DISCOVERY_ADDRESS,
+        DEFAULT_SOCKETCAND_DISCOVERY_PORT
     )
 
     # Time between beacons no more than 3 seconds. Allow for at least 3

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -30,9 +30,9 @@ def detect_beacon(timeout_ms) -> List[can.typechecking.AutoDetectedConfig]:
     """
     Detects socketcand servers
 
-        This is what :meth:`can.SocketCanDaemonBus._detect_available_configs`
-        uses to search for available socketcand servers with fixed timeout of
-        3.1 seconds (socketcand sends out a beacon packet every 3 seconds).
+        This is what :meth:`can.detect_available_configs` ends up calling
+        search for available socketcand servers with fixed timeout of 3.1
+        seconds (socketcand sends out a beacon packet every 3 seconds).
 
         Using this method directly allows for adjusting the timeout. Extending
         the timeout beyond the default time period could be useful if UDP
@@ -42,7 +42,7 @@ def detect_beacon(timeout_ms) -> List[can.typechecking.AutoDetectedConfig]:
             Timeout in milliseconds to wait for socketcand beacon packets
 
         :return:
-            See :meth:`can.BusABC._detect_available_configs`
+            See :meth:`~can.detect_available_configs`
     """
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
         sock.bind(

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -32,7 +32,7 @@ def detect_beacon():
     log.info(
         "Listening on for socketcand UDP advertisement on %s:%s",
         DEFAULT_SOCKETCAND_DISCOVERY_ADDRESS,
-        DEFAULT_SOCKETCAND_DISCOVERY_PORT
+        DEFAULT_SOCKETCAND_DISCOVERY_PORT,
     )
 
     # Time between beacons no more than 3 seconds. Allow for at least 3

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -343,7 +343,7 @@ class SocketCanDaemonBus(can.BusABC):
         try:
             # Time between beacons no more than 3 seconds. Allow for a little
             # more than 3s
-            return detect_beacon(3.1)
+            return detect_beacon()
         except Exception as e:
             log.warning(f"Could not detect socketcand beacon: {e}")
             return []

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -26,7 +26,7 @@ DEFAULT_SOCKETCAND_DISCOVERY_ADDRESS = ""
 DEFAULT_SOCKETCAND_DISCOVERY_PORT = 42000
 
 
-def detect_beacon(timeout_ms) -> List[can.typechecking.AutoDetectedConfig]:
+def detect_beacon(timeout_ms: int = 3100) -> List[can.typechecking.AutoDetectedConfig]:
     """
     Detects socketcand servers
 

--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -42,7 +42,7 @@ def detect_beacon(timeout_ms) -> List[can.typechecking.AutoDetectedConfig]:
             Timeout in milliseconds to wait for socketcand beacon packets
 
         :return:
-            See :meth:`can.SocketCanDaemonBus._detect_available_configs`
+            See :meth:`can.BusABC._detect_available_configs`
     """
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
         sock.bind(

--- a/doc/interfaces/socketcand.rst
+++ b/doc/interfaces/socketcand.rst
@@ -2,8 +2,8 @@
 
 socketcand Interface
 ====================
-`Socketcand <https://github.com/linux-can/socketcand>`__ is part of the 
-`Linux-CAN <https://github.com/linux-can>`__ project, providing a 
+`Socketcand <https://github.com/linux-can/socketcand>`__ is part of the
+`Linux-CAN <https://github.com/linux-can>`__ project, providing a
 Network-to-CAN bridge as a Linux damon. It implements a specific
 `TCP/IP based communication protocol <https://github.com/linux-can/socketcand/blob/master/doc/protocol.md>`__
 to transfer CAN frames and control commands.
@@ -11,7 +11,7 @@ to transfer CAN frames and control commands.
 The main advantage compared to UDP-based protocols (e.g. virtual interface)
 is, that TCP guarantees delivery and that the message order is kept.
 
-Here is a small example dumping all can messages received by a socketcand 
+Here is a small example dumping all can messages received by a socketcand
 daemon running on a remote Raspberry Pi:
 
 .. code-block:: python
@@ -36,6 +36,33 @@ The output may look like this::
     Timestamp: 1637791111.434377    ID: 00000665    X Rx                DLC:  8    97 96 51 0f 23 25 fc 28
     Timestamp: 1637791111.609763    ID: 0000031d    X Rx                DLC:  8    16 27 d8 3d fe d8 31 24
     Timestamp: 1637791111.634630    ID: 00000587    X Rx                DLC:  8    4e 06 85 23 6f 81 2b 65
+
+
+This interface also supports :meth:`can.BusABC._detect_available_configs`.
+
+.. code-block:: python
+
+    import can
+    import can.interfaces.socketcand
+
+    cfg = can.interfaces.socketcand._detect_available_configs()
+    if cfg:
+        bus = can.Bus(**cfg[0])
+
+The socketcand daemon broadcasts UDP beacons every 3 seconds. The default
+detection method waits for slightly more than 3 seconds to receive the beacon
+packet. If you want to increase the timeout, you can use
+:meth:`can.interfaces.socketcand.detect_beacon` directly. Below is an example
+which detects the beacon and uses the configuration to create a socketcand bus.
+
+.. code-block:: python
+
+    import can
+    import can.interfaces.socketcand
+
+    cfg = can.interfaces.socketcand.detect_beacon(6000)
+    if cfg:
+        bus = can.Bus(**cfg[0])
 
 Bus
 ---

--- a/doc/interfaces/socketcand.rst
+++ b/doc/interfaces/socketcand.rst
@@ -38,7 +38,7 @@ The output may look like this::
     Timestamp: 1637791111.634630    ID: 00000587    X Rx                DLC:  8    4e 06 85 23 6f 81 2b 65
 
 
-This interface also supports :meth:`can.BusABC._detect_available_configs`.
+This interface also supports :meth:`~can.detect_available_configs`.
 
 .. code-block:: python
 
@@ -71,6 +71,8 @@ Bus
    :show-inheritance:
    :member-order: bysource
    :members:
+
+.. autofunction:: can.interfaces.socketcand.detect_beacon
 
 Socketcand Quickstart
 ---------------------


### PR DESCRIPTION
This implements the client side service discovery for socketcand:
https://github.com/dschanoeh/socketcand/blob/master/doc/protocol.md#service-discovery

Need some feedback on how to enable this option. In the PR, I've proposed a way that makes the happy path as easy as possible ... though it is a breaking change for the SocketCanDaemonBus class.

Happy path:
```
bus = SocketCanDaemonBus(None) # Auto detect socketcand server, and connect to first available CAN bus
```

1. If a host address (hostname,port) is provided, it works the same way as before.

2. If a host address (hostname,port) is *not* provided, it activates detect_beacon(). The user can optionally provide an address to listen for the beacon on a specific interface and port. If not provided, it listens on all interfaces at the default port 42000. If channel is None, it selects the first channel in the channel list provided in the beacon.