### PR TITLE
Fix socketcand erroneously discarding frames

### DIFF
--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -191,9 +191,7 @@ class SocketCanDaemonBus(can.BusABC):
                     self.__message_buffer.append(parsed_can_message)
                 buffer_view = buffer_view[end + 1 :]
 
-            self.__receive_buffer = self.__receive_buffer[
-                chars_processed_successfully + 1 :
-            ]
+            self.__receive_buffer = self.__receive_buffer[chars_processed_successfully:]
             can_message = (
                 None
                 if len(self.__message_buffer) == 0


### PR DESCRIPTION
The __receive_buffer is always truncated by [chars_processed_successfully + 1:].  When a partial socketcand frame is received, chars_processed_successfully is 0, and this results in 1 character being discarded. This will be the '<' character, and thus when the rest of the frame is received, it will be treated as a bad frame, and discarded.

I double checked wireshark to make sure the bytestream wasn't corrupted, or there wasn't some weird latency related issue (which shouldn't make a difference anyways..). It was all good.

I also instrumented the code a bit to catch it in the act in the while loop progressively processing the `buffer_view` buffer. Below is a log which shows it happening (scroll to the bottom):

```
DEBUG:can.interfaces.socketcand.socketcand:Received Ascii Message: < frame 0B0B0003 1701324984.734563 0000000000000000 >< frame 0B0B0004 1701324984.734655 0000000000000000 >< frame 0B0B0009 1701324984.734657 0000000000000000 >< frame 0B0B0066 1701324984.734661 0000000000000000 >< frame 0B0B0067 1701324984.734664 0000000000000000 >< frame 0B0B0072 1701324984.734665 0000000000000000 >< frame 0B0B0073 1701324984.734666 0000000000000000 >< frame 0B0B00C8 1701324984.734669 0000000000000000 >< frame 0B0B00C9 1701324984.734672 0000000000000000 >< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B0003 1701324984.734563 0000000000000000 >< frame 0B0B0004 1701324984.734655 0000000000000000 >< frame 0B0B0009 1701324984.734657 0000000000000000 >< frame 0B0B0066 1701324984.734661 0000000000000000 >< frame 0B0B0067 1701324984.734664 0000000000000000 >< frame 0B0B0072 1701324984.734665 0000000000000000 >< frame 0B0B0073 1701324984.734666 0000000000000000 >< frame 0B0B00C8 1701324984.734669 0000000000000000 >< frame 0B0B00C9 1701324984.734672 0000000000000000 >< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B0003 1701324984.734563 0000000000000000 >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B0004 1701324984.734655 0000000000000000 >< frame 0B0B0009 1701324984.734657 0000000000000000 >< frame 0B0B0066 1701324984.734661 0000000000000000 >< frame 0B0B0067 1701324984.734664 0000000000000000 >< frame 0B0B0072 1701324984.734665 0000000000000000 >< frame 0B0B0073 1701324984.734666 0000000000000000 >< frame 0B0B00C8 1701324984.734669 0000000000000000 >< frame 0B0B00C9 1701324984.734672 0000000000000000 >< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B0004 1701324984.734655 0000000000000000 >< frame 0B0B0009 1701324984.734657 0000000000000000 >< frame 0B0B0066 1701324984.734661 0000000000000000 >< frame 0B0B0067 1701324984.734664 0000000000000000 >< frame 0B0B0072 1701324984.734665 0000000000000000 >< frame 0B0B0073 1701324984.734666 0000000000000000 >< frame 0B0B00C8 1701324984.734669 0000000000000000 >< frame 0B0B00C9 1701324984.734672 0000000000000000 >< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B0004 1701324984.734655 0000000000000000 >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B0009 1701324984.734657 0000000000000000 >< frame 0B0B0066 1701324984.734661 0000000000000000 >< frame 0B0B0067 1701324984.734664 0000000000000000 >< frame 0B0B0072 1701324984.734665 0000000000000000 >< frame 0B0B0073 1701324984.734666 0000000000000000 >< frame 0B0B00C8 1701324984.734669 0000000000000000 >< frame 0B0B00C9 1701324984.734672 0000000000000000 >< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B0009 1701324984.734657 0000000000000000 >< frame 0B0B0066 1701324984.734661 0000000000000000 >< frame 0B0B0067 1701324984.734664 0000000000000000 >< frame 0B0B0072 1701324984.734665 0000000000000000 >< frame 0B0B0073 1701324984.734666 0000000000000000 >< frame 0B0B00C8 1701324984.734669 0000000000000000 >< frame 0B0B00C9 1701324984.734672 0000000000000000 >< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B0009 1701324984.734657 0000000000000000 >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B0066 1701324984.734661 0000000000000000 >< frame 0B0B0067 1701324984.734664 0000000000000000 >< frame 0B0B0072 1701324984.734665 0000000000000000 >< frame 0B0B0073 1701324984.734666 0000000000000000 >< frame 0B0B00C8 1701324984.734669 0000000000000000 >< frame 0B0B00C9 1701324984.734672 0000000000000000 >< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B0066 1701324984.734661 0000000000000000 >< frame 0B0B0067 1701324984.734664 0000000000000000 >< frame 0B0B0072 1701324984.734665 0000000000000000 >< frame 0B0B0073 1701324984.734666 0000000000000000 >< frame 0B0B00C8 1701324984.734669 0000000000000000 >< frame 0B0B00C9 1701324984.734672 0000000000000000 >< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B0066 1701324984.734661 0000000000000000 >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B0067 1701324984.734664 0000000000000000 >< frame 0B0B0072 1701324984.734665 0000000000000000 >< frame 0B0B0073 1701324984.734666 0000000000000000 >< frame 0B0B00C8 1701324984.734669 0000000000000000 >< frame 0B0B00C9 1701324984.734672 0000000000000000 >< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B0067 1701324984.734664 0000000000000000 >< frame 0B0B0072 1701324984.734665 0000000000000000 >< frame 0B0B0073 1701324984.734666 0000000000000000 >< frame 0B0B00C8 1701324984.734669 0000000000000000 >< frame 0B0B00C9 1701324984.734672 0000000000000000 >< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B0067 1701324984.734664 0000000000000000 >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B0072 1701324984.734665 0000000000000000 >< frame 0B0B0073 1701324984.734666 0000000000000000 >< frame 0B0B00C8 1701324984.734669 0000000000000000 >< frame 0B0B00C9 1701324984.734672 0000000000000000 >< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B0072 1701324984.734665 0000000000000000 >< frame 0B0B0073 1701324984.734666 0000000000000000 >< frame 0B0B00C8 1701324984.734669 0000000000000000 >< frame 0B0B00C9 1701324984.734672 0000000000000000 >< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B0072 1701324984.734665 0000000000000000 >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B0073 1701324984.734666 0000000000000000 >< frame 0B0B00C8 1701324984.734669 0000000000000000 >< frame 0B0B00C9 1701324984.734672 0000000000000000 >< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B0073 1701324984.734666 0000000000000000 >< frame 0B0B00C8 1701324984.734669 0000000000000000 >< frame 0B0B00C9 1701324984.734672 0000000000000000 >< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B0073 1701324984.734666 0000000000000000 >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B00C8 1701324984.734669 0000000000000000 >< frame 0B0B00C9 1701324984.734672 0000000000000000 >< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B00C8 1701324984.734669 0000000000000000 >< frame 0B0B00C9 1701324984.734672 0000000000000000 >< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B00C8 1701324984.734669 0000000000000000 >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B00C9 1701324984.734672 0000000000000000 >< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B00C9 1701324984.734672 0000000000000000 >< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B00C9 1701324984.734672 0000000000000000 >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B00CA 1701324984.734674 0000000002330000 >< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B00CA 1701324984.734674 0000000002330000 >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B00CB 1701324984.734676 0000000000000000 >< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B00CB 1701324984.734676 0000000000000000 >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B00CC 1701324984.734677 0333044400000000 >< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B00CC 1701324984.734677 0333044400000000 >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B00CD 1701324984.734678 024402350135022B >< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B00CD 1701324984.734678 024402350135022B >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B00CE 1701324984.734681 0000000000000000 >< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B00CE 1701324984.734681 0000000000000000 >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B00CF 1701324984.734683 0000000000000000 >< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B00CF 1701324984.734683 0000000000000000 >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B00D0 1701324984.734685 0000000000000000 >< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B00D0 1701324984.734685 0000000000000000 >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B00D1 1701324984.734688 0000000000000000 >< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B00D1 1701324984.734688 0000000000000000 >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B00D2 1701324984.734690 0000000000000000 >< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B00D2 1701324984.734690 0000000000000000 >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B00D3 1701324984.734694 0000000000000000 >< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:single_message=< frame 0B0B00D3 1701324984.734694 0000000000000000 >
DEBUG:can.interfaces.socketcand.socketcand:after trunc buffer_view=< frame 0B0B00D4
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view=< frame 0B0B00D4
WARNING:can.interfaces.socketcand.socketcand:Got incomplete message => waiting for more data
DEBUG:can.interfaces.socketcand.socketcand:Received Ascii Message: 1701324984.734696 0000000000000000 >
DEBUG:can.interfaces.socketcand.socketcand:start buffer_view= frame 0B0B00D4 1701324984.734696 0000000000000000 >
WARNING:can.interfaces.socketcand.socketcand:Bad data: No opening < found => discarding entire buffer ' frame 0B0B00D4 1701324984.734696 0000000000000000 >'
```