### PR TITLE
improve the "ASCReader"  read performance.

### DIFF
--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -9,7 +9,7 @@ import logging
 import re
 import time
 from datetime import datetime
-from typing import Any, Dict, Generator, List, Optional, TextIO, Union
+from typing import Any, Dict, Final, Generator, List, Optional, TextIO, Union
 
 from ..message import Message
 from ..typechecking import StringPathLike
@@ -20,6 +20,14 @@ CAN_MSG_EXT = 0x80000000
 CAN_ID_MASK = 0x1FFFFFFF
 BASE_HEX = 16
 BASE_DEC = 10
+ASC_TRIGGER_REGEX: Final = re.compile(
+    r"begin\s+triggerblock\s+\w+\s+(?P<datetime_string>.+)", re.IGNORECASE
+)
+ASC_MESSAGE_REGEX: Final = re.compile(
+    r"\d+\.\d+\s+(\d+\s+(\w+\s+(Tx|Rx)|ErrorFrame)|CANFD)",
+    re.ASCII | re.IGNORECASE,
+)
+
 
 logger = logging.getLogger("can.io.asc")
 
@@ -254,18 +262,11 @@ class ASCReader(TextIOMessageReader):
 
     def __iter__(self) -> Generator[Message, None, None]:
         self._extract_header()
-        trigger_match_re = re.compile(
-            r"begin\s+triggerblock\s+\w+\s+(?P<datetime_string>.+)", re.IGNORECASE
-        )
-        can_message_match = re.compile(
-            r"\d+\.\d+\s+(\d+\s+(\w+\s+(Tx|Rx)|ErrorFrame)|CANFD)",
-            re.ASCII | re.IGNORECASE,
-        )
+
         for _line in self.file:
             line = _line.strip()
 
-            trigger_match = trigger_match_re.match(line)
-            if trigger_match:
+            if trigger_match := ASC_TRIGGER_REGEX.match(line):
                 datetime_str = trigger_match.group("datetime_string")
                 self.start_time = (
                     0.0
@@ -274,7 +275,7 @@ class ASCReader(TextIOMessageReader):
                 )
                 continue
 
-            if not can_message_match.match(line):
+            if not ASC_MESSAGE_REGEX.match(line):
                 # line might be a comment, chip status,
                 # J1939 message or some other unsupported event
                 continue

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -254,13 +254,14 @@ class ASCReader(TextIOMessageReader):
 
     def __iter__(self) -> Generator[Message, None, None]:
         self._extract_header()
-        trigger_match = re.compile(r"begin\s+triggerblock\s+\w+\s+(?P<datetime_string>.+)",re.IGNORECASE)
+        trigger_match_re = re.compile(r"begin\s+triggerblock\s+\w+\s+(?P<datetime_string>.+)",re.IGNORECASE)
         can_message_match = re.compile(r"\d+\.\d+\s+(\d+\s+(\w+\s+(Tx|Rx)|ErrorFrame)|CANFD)", re.ASCII | re.IGNORECASE)
         for _line in self.file:
             line = _line.strip()
 
-            if trigger_match.match(line):
-                datetime_str = trigger_match.match(line).group("datetime_string")
+            trigger_match = trigger_match_re.match(line)
+            if trigger_match:
+                datetime_str = trigger_match.group("datetime_string")
                 self.start_time = (
                     0.0
                     if self.relative_timestamp

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -254,8 +254,13 @@ class ASCReader(TextIOMessageReader):
 
     def __iter__(self) -> Generator[Message, None, None]:
         self._extract_header()
-        trigger_match_re = re.compile(r"begin\s+triggerblock\s+\w+\s+(?P<datetime_string>.+)",re.IGNORECASE)
-        can_message_match = re.compile(r"\d+\.\d+\s+(\d+\s+(\w+\s+(Tx|Rx)|ErrorFrame)|CANFD)", re.ASCII | re.IGNORECASE)
+        trigger_match_re = re.compile(
+            r"begin\s+triggerblock\s+\w+\s+(?P<datetime_string>.+)", re.IGNORECASE
+        )
+        can_message_match = re.compile(
+            r"\d+\.\d+\s+(\d+\s+(\w+\s+(Tx|Rx)|ErrorFrame)|CANFD)",
+            re.ASCII | re.IGNORECASE,
+        )
         for _line in self.file:
             line = _line.strip()
 
@@ -268,7 +273,7 @@ class ASCReader(TextIOMessageReader):
                     else self._datetime_to_timestamp(datetime_str)
                 )
                 continue
-                
+
             if not can_message_match.match(line):
                 # line might be a comment, chip status,
                 # J1939 message or some other unsupported event


### PR DESCRIPTION
Improve the `ASCReader`  read performance.
Use `re.compile` to compile the regular expression,then `match` the message will faster than direct `match` the message .

The read speed is about 30% faster than before.