### PR TITLE
Fix send periodic

### DIFF
--- a/can/broadcastmanager.py
+++ b/can/broadcastmanager.py
@@ -297,11 +297,8 @@ class ThreadBasedCyclicSendTask(
             win32event.WaitForSingleObject(self.event.handle, 0)
 
         while not self.stopped:
-            if not USE_WINDOWS_EVENTS:
-                msg_due_time_ns += self.period_ns
             if self.end_time is not None and time.perf_counter() >= self.end_time:
                 break
-            msg_index = (msg_index + 1) % len(self.messages)
 
             # Prevent calling bus.send from multiple threads
             with self.send_lock:
@@ -321,6 +318,11 @@ class ThreadBasedCyclicSendTask(
                     if not self.on_error(exc):
                         self.stop()
                         break
+
+            if not USE_WINDOWS_EVENTS:
+                msg_due_time_ns += self.period_ns
+
+            msg_index = (msg_index + 1) % len(self.messages)
 
             if USE_WINDOWS_EVENTS:
                 win32event.WaitForSingleObject(

--- a/can/broadcastmanager.py
+++ b/can/broadcastmanager.py
@@ -297,6 +297,12 @@ class ThreadBasedCyclicSendTask(
             win32event.WaitForSingleObject(self.event.handle, 0)
 
         while not self.stopped:
+            if not USE_WINDOWS_EVENTS:
+                msg_due_time_ns += self.period_ns
+            if self.end_time is not None and time.perf_counter() >= self.end_time:
+                break
+            msg_index = (msg_index + 1) % len(self.messages)
+
             # Prevent calling bus.send from multiple threads
             with self.send_lock:
                 try:
@@ -315,12 +321,6 @@ class ThreadBasedCyclicSendTask(
                     if not self.on_error(exc):
                         self.stop()
                         break
-
-            if not USE_WINDOWS_EVENTS:
-                msg_due_time_ns += self.period_ns
-            if self.end_time is not None and time.perf_counter() >= self.end_time:
-                break
-            msg_index = (msg_index + 1) % len(self.messages)
 
             if USE_WINDOWS_EVENTS:
                 win32event.WaitForSingleObject(

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -273,19 +273,22 @@ class Back2BackTestCase(unittest.TestCase):
         self.bus2.recv(0)
         self.bus2.recv(0)
 
-    def test_perodic_tasks_do_not_exceed_duration(self):
-        duration, period = 2.0, 0.6
-        messages = []
+    def test_send_periodic_duration(self):
+        """
+        Verify that send_periodic only transmits for the specified duration.
 
-        self.bus2.send_periodic(can.Message(), period, duration)
-        while True:
-            msg = self.bus1.recv(period + 0.1)
-            if msg is None:
-                break
-            messages.append(msg)
+        Regression test for #1713.
+        """
+        for params in [(0.01, 0.003), (0.1, 0.011), (1, 0.4)]:
+            duration, period = params
+            messages = []
 
-        delta_t = messages[-1].timestamp - messages[0].timestamp
-        assert delta_t <= duration
+            self.bus2.send_periodic(can.Message(), period, duration)
+            while (msg := self.bus1.recv(period * 1.25)) is not None:
+                messages.append(msg)
+
+            delta_t = round(messages[-1].timestamp - messages[0].timestamp, 2)
+            assert delta_t <= duration
 
 
 @unittest.skipUnless(TEST_INTERFACE_SOCKETCAN, "skip testing of socketcan")

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -273,6 +273,20 @@ class Back2BackTestCase(unittest.TestCase):
         self.bus2.recv(0)
         self.bus2.recv(0)
 
+    def test_perodic_tasks_do_not_exceed_duration(self):
+        duration, period = 2.0, 0.6
+        messages = []
+
+        self.bus2.send_periodic(can.Message(), period, duration)
+        while True:
+            msg = self.bus1.recv(period + 0.1)
+            if msg is None:
+                break
+            messages.append(msg)
+
+        delta_t = messages[-1].timestamp - messages[0].timestamp
+        assert delta_t <= duration
+
 
 @unittest.skipUnless(TEST_INTERFACE_SOCKETCAN, "skip testing of socketcan")
 class BasicTestSocketCan(Back2BackTestCase):


### PR DESCRIPTION
Closes #1710 

The proposed fix is to check whether `duration` is exceeded before the transmit of the next message.