### PR TITLE
Fix Typo in Error Handling Logic of _check Method on message.py file

### DIFF
--- a/can/message.py
+++ b/can/message.py
@@ -245,7 +245,7 @@ class Message:  # pylint: disable=too-many-instance-attributes; OK for a datacla
         if self.is_remote_frame:
             if self.is_error_frame:
                 raise ValueError(
-                    "a message cannot be a remote and an error frame at the sane time"
+                    "a message cannot be a remote and an error frame at the same time"
                 )
             if self.is_fd:
                 raise ValueError("CAN FD does not support remote frames")


### PR DESCRIPTION
resolves #1714

### Summary
This pull request addresses a small but impactful typo found in the `_check` method of the message.py file. The word "sane" is used mistakenly instead of "same".

### Changes Made
- Corrected the typo in the following line:
  ```python
  raise ValueError("a message cannot be a remote and an error frame at the sane time")
  ```
  Changed to:
  ```python
  raise ValueError("a message cannot be a remote and an error frame at the same time")
  ```

### Impact
This correction enhances the readability and clarity of the error handling logic. Such typos, while seemingly minor, can cause confusion for developers who are trying to understand or contribute to the codebase. Ensuring that the documentation and comments are clear and error-free is essential for maintaining the overall quality of the code.

### Additional Information
This fix does not alter any functional aspect of the code. It is purely a correction for the sake of clarity and correctness in the code documentation.
