### PR TITLE
add parser for TRC 1.3 format

### DIFF
--- a/can/io/trc.py
+++ b/can/io/trc.py
@@ -121,6 +121,8 @@ class TRCReader(TextIOMessageReader):
             self._parse_cols = self._parse_msg_v1_0
         elif self.file_version == TRCFileVersion.V1_1:
             self._parse_cols = self._parse_cols_v1_1
+        elif self.file_version == TRCFileVersion.V1_3:
+            self._parse_cols = self._parse_msg_v1_3
         elif self.file_version in [TRCFileVersion.V2_0, TRCFileVersion.V2_1]:
             self._parse_cols = self._parse_cols_v2_x
         else:
@@ -159,6 +161,25 @@ class TRCReader(TextIOMessageReader):
         msg.dlc = int(cols[4])
         msg.data = bytearray([int(cols[i + 5], 16) for i in range(msg.dlc)])
         msg.is_rx = cols[2] == "Rx"
+        return msg
+
+    def _parse_msg_v1_3(self, cols: List[str]) -> Optional[Message]:
+        arbit_id = cols[4]
+
+        msg = Message()
+        if isinstance(self.start_time, datetime):
+            msg.timestamp = (
+                self.start_time + timedelta(milliseconds=float(cols[1]))
+            ).timestamp()
+        else:
+            msg.timestamp = float(cols[1]) / 1000
+        msg.arbitration_id = int(arbit_id, 16)
+        msg.is_extended_id = len(arbit_id) > 4
+        msg.channel = 1
+        msg.dlc = int(cols[6])
+        msg.data = bytearray([int(cols[i + 7], 16) for i in range(msg.dlc)])
+        msg.is_rx = cols[3] == "Rx"
+        msg.bus = int(cols[2])
         return msg
 
     def _parse_msg_v2_x(self, cols: List[str]) -> Optional[Message]:

--- a/can/io/trc.py
+++ b/can/io/trc.py
@@ -76,6 +76,8 @@ class TRCReader(TextIOMessageReader):
                     file_version = line.split("=")[1]
                     if file_version == "1.1":
                         self.file_version = TRCFileVersion.V1_1
+                    if file_version == "1.3":
+                        self.file_version = TRCFileVersion.V1_3
                     elif file_version == "2.0":
                         self.file_version = TRCFileVersion.V2_0
                     elif file_version == "2.1":

--- a/can/message.py
+++ b/can/message.py
@@ -38,6 +38,7 @@ class Message:  # pylint: disable=too-many-instance-attributes; OK for a datacla
         "is_remote_frame",
         "is_error_frame",
         "channel",
+        "bus",
         "dlc",
         "data",
         "is_fd",
@@ -55,6 +56,7 @@ class Message:  # pylint: disable=too-many-instance-attributes; OK for a datacla
         is_remote_frame: bool = False,
         is_error_frame: bool = False,
         channel: Optional[typechecking.Channel] = None,
+        bus: Optional[int] = None,
         dlc: Optional[int] = None,
         data: Optional[typechecking.CanData] = None,
         is_fd: bool = False,
@@ -83,6 +85,7 @@ class Message:  # pylint: disable=too-many-instance-attributes; OK for a datacla
         self.is_remote_frame = is_remote_frame
         self.is_error_frame = is_error_frame
         self.channel = channel
+        self.bus = bus
         self.is_fd = is_fd
         self.is_rx = is_rx
         self.bitrate_switch = bitrate_switch


### PR DESCRIPTION
added columns "bus" and reserverd. bus is the number of the CAN Bus as an integer, reserved is not parsed.

Reference: https://www.peak-system.com/produktcd/Pdf/English/PEAK_CAN_TRC_File_Format.pdf