### PR TITLE
Fix ASCWriter millisecond handling

### DIFF
--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -7,14 +7,13 @@ Example .asc files:
 """
 import logging
 import re
-import time
 from datetime import datetime
 from typing import Any, Dict, Final, Generator, List, Optional, TextIO, Union
 
+from .generic import TextIOMessageReader, TextIOMessageWriter
 from ..message import Message
 from ..typechecking import StringPathLike
 from ..util import channel2int, dlc2len, len2dlc
-from .generic import TextIOMessageReader, TextIOMessageWriter
 
 CAN_MSG_EXT = 0x80000000
 CAN_ID_MASK = 0x1FFFFFFF
@@ -340,7 +339,6 @@ class ASCWriter(TextIOMessageWriter):
             "{bit_timing_conf_ext_data:>8}",
         ]
     )
-    FORMAT_START_OF_FILE_DATE = "%a %b %d %H:%M:%S.%f %Y"
     FORMAT_DATE = "%a %b %d %H:%M:%S.{} %Y"
     FORMAT_EVENT = "{timestamp: 9.6f} {message}\n"
 
@@ -367,12 +365,8 @@ class ASCWriter(TextIOMessageWriter):
         self.channel = channel
 
         # write start of file header
-        now = datetime.now().strftime(self.FORMAT_START_OF_FILE_DATE)
-        # Note: CANoe requires that the microsecond field only have 3 digits
-        idx = now.index(".")  # Find the index in the string of the decimal
-        # Keep decimal and first three ms digits (4), remove remaining digits
-        now = now.replace(now[idx + 4 : now[idx:].index(" ") + idx], "")
-        self.file.write(f"date {now}\n")
+        start_time = self._format_header_datetime(datetime.now())
+        self.file.write(f"date {start_time}\n")
         self.file.write("base hex  timestamps absolute\n")
         self.file.write("internal events logged\n")
 
@@ -380,6 +374,15 @@ class ASCWriter(TextIOMessageWriter):
         self.header_written = False
         self.last_timestamp = 0.0
         self.started = 0.0
+
+    def _format_header_datetime(self, dt: datetime) -> str:
+        # Note: CANoe requires that the microsecond field only have 3 digits
+        # Since Python strftime only supports microsecond formatters, we must
+        # manually include the millisecond portion before passing the format
+        # to strftime
+        msec = dt.microsecond // 1000 % 1000
+        format_w_msec = self.FORMAT_DATE.format(msec)
+        return dt.strftime(format_w_msec)
 
     def stop(self) -> None:
         # This is guaranteed to not be None since we raise ValueError in __init__
@@ -400,12 +403,11 @@ class ASCWriter(TextIOMessageWriter):
 
         # this is the case for the very first message:
         if not self.header_written:
-            self.last_timestamp = timestamp or 0.0
-            self.started = self.last_timestamp
-            mlsec = repr(self.last_timestamp).split(".")[1][:3]
-            formatted_date = time.strftime(
-                self.FORMAT_DATE.format(mlsec), time.localtime(self.last_timestamp)
-            )
+            self.started = self.last_timestamp = timestamp or 0.0
+
+            start_time = datetime.fromtimestamp(self.last_timestamp)
+            formatted_date = self._format_header_datetime(start_time)
+
             self.file.write(f"Begin Triggerblock {formatted_date}\n")
             self.header_written = True
             self.log_event("Start of measurement")  # caution: this is a recursive call!

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -340,8 +340,8 @@ class ASCWriter(TextIOMessageWriter):
             "{bit_timing_conf_ext_data:>8}",
         ]
     )
-    FORMAT_START_OF_FILE_DATE = "%a %b %d %I:%M:%S.%f %p %Y"
-    FORMAT_DATE = "%a %b %d %I:%M:%S.{} %p %Y"
+    FORMAT_START_OF_FILE_DATE = "%a %b %d %H:%M:%S.%f %Y"
+    FORMAT_DATE = "%a %b %d %H:%M:%S.{} %Y"
     FORMAT_EVENT = "{timestamp: 9.6f} {message}\n"
 
     def __init__(

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -10,10 +10,10 @@ import re
 from datetime import datetime
 from typing import Any, Dict, Final, Generator, List, Optional, TextIO, Union
 
-from .generic import TextIOMessageReader, TextIOMessageWriter
 from ..message import Message
 from ..typechecking import StringPathLike
 from ..util import channel2int, dlc2len, len2dlc
+from .generic import TextIOMessageReader, TextIOMessageWriter
 
 CAN_MSG_EXT = 0x80000000
 CAN_ID_MASK = 0x1FFFFFFF

--- a/test/data/single_frame_us_locale.asc
+++ b/test/data/single_frame_us_locale.asc
@@ -1,0 +1,7 @@
+date Sat Sep 30 15:06:13.191 2017
+base hex  timestamps absolute
+internal events logged
+Begin Triggerblock Sat Sep 30 15:06:13.191 2017
+ 0.000000 Start of measurement
+ 0.000000 1  123x            Rx   d 1 68
+End TriggerBlock

--- a/test/logformats_test.py
+++ b/test/logformats_test.py
@@ -408,7 +408,7 @@ class TestAscFileFormat(ReaderWriterTest):
         with can.ASCReader(logfile, **kwargs) as reader:
             return list(reader)
 
-    def test_absolute_time(self):
+    def test_read_absolute_time(self):
         time_from_file = "Sat Sep 30 10:06:13.191 PM 2017"
         start_time = datetime.strptime(
             time_from_file, self.FORMAT_START_OF_FILE_DATE
@@ -436,7 +436,7 @@ class TestAscFileFormat(ReaderWriterTest):
         actual = self._read_log_file("test_CanMessage.asc", relative_timestamp=False)
         self.assertMessagesEqual(actual, expected_messages)
 
-    def test_can_message(self):
+    def test_read_can_message(self):
         expected_messages = [
             can.Message(
                 timestamp=2.5010,
@@ -459,7 +459,7 @@ class TestAscFileFormat(ReaderWriterTest):
         actual = self._read_log_file("test_CanMessage.asc")
         self.assertMessagesEqual(actual, expected_messages)
 
-    def test_can_remote_message(self):
+    def test_read_can_remote_message(self):
         expected_messages = [
             can.Message(
                 timestamp=2.510001,
@@ -488,7 +488,7 @@ class TestAscFileFormat(ReaderWriterTest):
         actual = self._read_log_file("test_CanRemoteMessage.asc")
         self.assertMessagesEqual(actual, expected_messages)
 
-    def test_can_fd_remote_message(self):
+    def test_read_can_fd_remote_message(self):
         expected_messages = [
             can.Message(
                 timestamp=30.300981,
@@ -504,7 +504,7 @@ class TestAscFileFormat(ReaderWriterTest):
         actual = self._read_log_file("test_CanFdRemoteMessage.asc")
         self.assertMessagesEqual(actual, expected_messages)
 
-    def test_can_fd_message(self):
+    def test_read_can_fd_message(self):
         expected_messages = [
             can.Message(
                 timestamp=30.005021,
@@ -541,7 +541,7 @@ class TestAscFileFormat(ReaderWriterTest):
         actual = self._read_log_file("test_CanFdMessage.asc")
         self.assertMessagesEqual(actual, expected_messages)
 
-    def test_can_fd_message_64(self):
+    def test_read_can_fd_message_64(self):
         expected_messages = [
             can.Message(
                 timestamp=30.506898,
@@ -566,7 +566,7 @@ class TestAscFileFormat(ReaderWriterTest):
         actual = self._read_log_file("test_CanFdMessage64.asc")
         self.assertMessagesEqual(actual, expected_messages)
 
-    def test_can_and_canfd_error_frames(self):
+    def test_read_can_and_canfd_error_frames(self):
         expected_messages = [
             can.Message(timestamp=2.501000, channel=0, is_error_frame=True),
             can.Message(timestamp=3.501000, channel=0, is_error_frame=True),
@@ -582,16 +582,16 @@ class TestAscFileFormat(ReaderWriterTest):
         actual = self._read_log_file("test_CanErrorFrames.asc")
         self.assertMessagesEqual(actual, expected_messages)
 
-    def test_ignore_comments(self):
+    def test_read_ignore_comments(self):
         _msg_list = self._read_log_file("logfile.asc")
 
-    def test_no_triggerblock(self):
+    def test_read_no_triggerblock(self):
         _msg_list = self._read_log_file("issue_1256.asc")
 
-    def test_can_dlc_greater_than_8(self):
+    def test_read_can_dlc_greater_than_8(self):
         _msg_list = self._read_log_file("issue_1299.asc")
 
-    def test_error_frame_channel(self):
+    def test_read_error_frame_channel(self):
         # gh-issue 1578
         err_frame = can.Message(is_error_frame=True, channel=4)
 

--- a/test/logformats_test.py
+++ b/test/logformats_test.py
@@ -20,6 +20,7 @@ from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from datetime import datetime
 from itertools import zip_longest
+from pathlib import Path
 from unittest.mock import patch
 
 from parameterized import parameterized
@@ -413,8 +414,9 @@ class TestAscFileFormat(ReaderWriterTest):
             adds_default_channel=0,
         )
 
-    def _get_logfile_location(self, filename: str) -> str:
-        return os.path.join(os.path.dirname(__file__), "data", filename)
+    def _get_logfile_location(self, filename: str) -> Path:
+        my_dir = Path(__file__).parent
+        return my_dir / "data" / filename
 
     def _read_log_file(self, filename, **kwargs):
         logfile = self._get_logfile_location(filename)
@@ -644,14 +646,10 @@ class TestAscFileFormat(ReaderWriterTest):
 
             writer.stop()
 
-        with open(self.test_file_name, "r") as f:
-            actual = f.read()
-
+        actual_file = Path(self.test_file_name)
         expected_file = self._get_logfile_location("single_frame_us_locale.asc")
-        with open(expected_file, "r") as f:
-            expected = f.read()
 
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected_file.read_text(), actual_file.read_text())
 
 
 class TestBlfFileFormat(ReaderWriterTest):


### PR DESCRIPTION
With this PR, I would like to improve the string formatting of milliseconds in the `ASCWriter` class.
Unfortunately, the format seems to rely on localized datetimes. I added a commit to change the date time format to 24h instead of 12h. Let me know what you think.