### PR TITLE
Update Neousys available configs detection

### DIFF
--- a/can/interfaces/neousys/neousys.py
+++ b/can/interfaces/neousys/neousys.py
@@ -239,5 +239,8 @@ class NeousysBus(BusABC):
 
     @staticmethod
     def _detect_available_configs():
-        # There is only one channel
-        return [{"interface": "neousys", "channel": 0}]
+        if NEOUSYS_CANLIB is None:
+            return []
+        else:
+            # There is only one channel
+            return [{"interface": "neousys", "channel": 0}]


### PR DESCRIPTION
The modification ensures that the Neousys interface's method '_detect_available_configs' function checks if NEOUSYS_CANLIB is None. If it's None, no configuration is returned, and if it's not, the usual configuration with the interface as 'neousys' and channel as 0 is returned. This provides an additional layer of error handling.

closes #1738