### PR TITLE
Add notes/kvaser support for non-iso support

### DIFF
--- a/can/bus.py
+++ b/can/bus.py
@@ -44,7 +44,8 @@ class CanProtocol(Enum):
     """The CAN protocol type supported by a :class:`can.BusABC` instance"""
 
     CAN_20 = auto()
-    CAN_FD = auto()
+    CAN_FD = auto() # ISO Mode
+    CAN_FD_NON_ISO = auto()
     CAN_XL = auto()
 
 

--- a/can/bus.py
+++ b/can/bus.py
@@ -44,7 +44,7 @@ class CanProtocol(Enum):
     """The CAN protocol type supported by a :class:`can.BusABC` instance"""
 
     CAN_20 = auto()
-    CAN_FD = auto() # ISO Mode
+    CAN_FD = auto()  # ISO Mode
     CAN_FD_NON_ISO = auto()
     CAN_XL = auto()
 

--- a/can/interfaces/kvaser/canlib.py
+++ b/can/interfaces/kvaser/canlib.py
@@ -415,6 +415,10 @@ class KvaserBus(BusABC):
             In this case, the bit will be sampled three quanta in a row,
             with the last sample being taken in the edge between TSEG1 and TSEG2.
             Three samples should only be used for relatively slow baudrates.
+        :param bool fd_non_iso:
+            Open the channel in Non-ISO (Bosch) FD mode. Only applies for FD buses.
+            This changes the handling of the stuff-bit counter and the CRC. Defaults
+            to False (ISO mode)
 
         :param bool driver_mode:
             Silent or normal.
@@ -454,6 +458,7 @@ class KvaserBus(BusABC):
         accept_virtual = kwargs.get("accept_virtual", True)
         fd = isinstance(timing, BitTimingFd) if timing else kwargs.get("fd", False)
         data_bitrate = kwargs.get("data_bitrate", None)
+        fd_non_iso = kwargs.get("fd_non_iso", False)
 
         try:
             channel = int(channel)
@@ -483,7 +488,10 @@ class KvaserBus(BusABC):
         if accept_virtual:
             flags |= canstat.canOPEN_ACCEPT_VIRTUAL
         if fd:
-            flags |= canstat.canOPEN_CAN_FD
+            if fd_non_iso:
+                flags |= canstat.canOPEN_CAN_FD_NONISO
+            else:
+                flags |= canstat.canOPEN_CAN_FD
 
         log.debug("Creating read handle to bus channel: %s", channel)
         self._read_handle = canOpenChannel(channel, flags)

--- a/can/interfaces/kvaser/canlib.py
+++ b/can/interfaces/kvaser/canlib.py
@@ -415,10 +415,6 @@ class KvaserBus(BusABC):
             In this case, the bit will be sampled three quanta in a row,
             with the last sample being taken in the edge between TSEG1 and TSEG2.
             Three samples should only be used for relatively slow baudrates.
-        :param bool fd_non_iso:
-            Open the channel in Non-ISO (Bosch) FD mode. Only applies for FD buses.
-            This changes the handling of the stuff-bit counter and the CRC. Defaults
-            to False (ISO mode)
 
         :param bool driver_mode:
             Silent or normal.
@@ -433,6 +429,10 @@ class KvaserBus(BusABC):
             computer, set this to True or set single_handle to True.
         :param bool fd:
             If CAN-FD frames should be supported.
+        :param bool fd_non_iso:
+            Open the channel in Non-ISO (Bosch) FD mode. Only applies for FD buses.
+            This changes the handling of the stuff-bit counter and the CRC. Defaults
+            to False (ISO mode)
         :param bool exclusive:
             Don't allow sharing of this CANlib channel.
         :param bool override_exclusive:
@@ -467,7 +467,11 @@ class KvaserBus(BusABC):
 
         self.channel = channel
         self.single_handle = single_handle
-        self._can_protocol = CanProtocol.CAN_FD if fd else CanProtocol.CAN_20
+        self._can_protocol = CanProtocol.CAN_20
+        if fd_non_iso:
+            self._can_protocol = CanProtocol.CAN_FD_NON_ISO
+        elif fd:
+            self._can_protocol = CanProtocol.CAN_FD
 
         log.debug("Initialising bus instance")
         num_channels = ctypes.c_int(0)

--- a/doc/interfaces/kvaser.rst
+++ b/doc/interfaces/kvaser.rst
@@ -39,6 +39,11 @@ in the ``recv`` method. If a message does not match any of the filters,
 ``recv()`` will return None.
 
 
+ISO/Non-ISO CAN FD Mode
+-----------------------
+
+Kvaser devices in FD mode can be configured for either ISO or Non-ISO mode in the bus initialization with the ``fd_non_iso`` option.
+
 Custom methods
 ~~~~~~~~~~~~~~
 

--- a/doc/interfaces/kvaser.rst
+++ b/doc/interfaces/kvaser.rst
@@ -39,11 +39,6 @@ in the ``recv`` method. If a message does not match any of the filters,
 ``recv()`` will return None.
 
 
-ISO/Non-ISO CAN FD Mode
------------------------
-
-Kvaser devices in FD mode can be configured for either ISO or Non-ISO mode in the bus initialization with the ``fd_non_iso`` option.
-
 Custom methods
 ~~~~~~~~~~~~~~
 

--- a/doc/interfaces/pcan.rst
+++ b/doc/interfaces/pcan.rst
@@ -38,9 +38,9 @@ Here is an example configuration file for using `PCAN-USB <https://www.peak-syst
  Channel bitrate
 
 ISO/Non-ISO CAN FD Mode
------------------------
+~~~~~~~~~~~~~~~~~~~~~~~
 
-The PCAN basic driver doesn't presently allow toggling the ISO/Non-ISO FD modes.
+The PCAN basic driver doesn't presently allow toggling the ISO/Non-ISO FD modes directly.
 The default mode is stored on the device and can be controlled using the PCANView Windows application.
 See: https://forum.peak-system.com/viewtopic.php?t=6496
 

--- a/doc/interfaces/pcan.rst
+++ b/doc/interfaces/pcan.rst
@@ -37,7 +37,14 @@ Here is an example configuration file for using `PCAN-USB <https://www.peak-syst
 ``bitrate`` (default ``500000``)
  Channel bitrate
 
+ISO/Non-ISO CAN FD Mode
+-----------------------
 
+The PCAN basic driver doesn't presently allow toggling the ISO/Non-ISO FD modes.
+The default mode is stored on the device and can be controlled using the PCANView Windows application.
+See: https://forum.peak-system.com/viewtopic.php?t=6496
+
+This restriction does not apply to the socket-can driver.
 
 .. _pcandoc linux installation:
 

--- a/doc/interfaces/socketcan.rst
+++ b/doc/interfaces/socketcan.rst
@@ -284,6 +284,11 @@ to ensure usage of SocketCAN Linux API. The most important differences are:
     :members:
     :inherited-members:
 
+ISO/Non-ISO CAN FD Mode
+-----------------------
+
+Socket CAN devices can (for supported hardware) control ISO vs Non-ISO FD during creation with the ``ip`` command using the ``fd-non-iso`` flag.
+
 .. External references
 
 .. _Linux kernel docs: https://www.kernel.org/doc/Documentation/networking/can.txt

--- a/test/test_kvaser.py
+++ b/test/test_kvaser.py
@@ -211,7 +211,9 @@ class KvaserTest(unittest.TestCase):
         can.Bus(channel=0, interface="kvaser", timing=timing)
         canlib.canSetBusParams.assert_called_once_with(0, 500_000, 68, 11, 10, 1, 0)
         canlib.canSetBusParamsFd.assert_called_once_with(0, 2_000_000, 10, 9, 8)
-        canlib.canOpenChannel.assert_called_with(0, constants.canOPEN_CAN_FD | constants.canOPEN_ACCEPT_VIRTUAL)
+        canlib.canOpenChannel.assert_called_with(
+            0, constants.canOPEN_CAN_FD | constants.canOPEN_ACCEPT_VIRTUAL
+        )
 
     def test_canfd_non_iso(self):
         canlib.canSetBusParams.reset_mock()
@@ -231,7 +233,9 @@ class KvaserTest(unittest.TestCase):
         can.Bus(channel=0, interface="kvaser", timing=timing, fd_non_iso=True)
         canlib.canSetBusParams.assert_called_once_with(0, 500_000, 68, 11, 10, 1, 0)
         canlib.canSetBusParamsFd.assert_called_once_with(0, 2_000_000, 10, 9, 8)
-        canlib.canOpenChannel.assert_called_with(0, constants.canOPEN_CAN_FD_NONISO | constants.canOPEN_ACCEPT_VIRTUAL)
+        canlib.canOpenChannel.assert_called_with(
+            0, constants.canOPEN_CAN_FD_NONISO | constants.canOPEN_ACCEPT_VIRTUAL
+        )
 
     def test_canfd_nondefault_data_bitrate(self):
         canlib.canSetBusParams.reset_mock()

--- a/test/test_kvaser.py
+++ b/test/test_kvaser.py
@@ -230,7 +230,8 @@ class KvaserTest(unittest.TestCase):
             data_tseg2=9,
             data_sjw=8,
         )
-        can.Bus(channel=0, interface="kvaser", timing=timing, fd_non_iso=True)
+        bus = can.Bus(channel=0, interface="kvaser", timing=timing, fd_non_iso=True)
+        self.assertEqual(bus.protocol, can.CanProtocol.CAN_FD_NON_ISO)
         canlib.canSetBusParams.assert_called_once_with(0, 500_000, 68, 11, 10, 1, 0)
         canlib.canSetBusParamsFd.assert_called_once_with(0, 2_000_000, 10, 9, 8)
         canlib.canOpenChannel.assert_called_with(

--- a/test/test_kvaser.py
+++ b/test/test_kvaser.py
@@ -196,6 +196,7 @@ class KvaserTest(unittest.TestCase):
     def test_canfd_timing(self):
         canlib.canSetBusParams.reset_mock()
         canlib.canSetBusParamsFd.reset_mock()
+        canlib.canOpenChannel.reset_mock()
         timing = can.BitTimingFd.from_bitrate_and_segments(
             f_clock=80_000_000,
             nom_bitrate=500_000,
@@ -210,6 +211,27 @@ class KvaserTest(unittest.TestCase):
         can.Bus(channel=0, interface="kvaser", timing=timing)
         canlib.canSetBusParams.assert_called_once_with(0, 500_000, 68, 11, 10, 1, 0)
         canlib.canSetBusParamsFd.assert_called_once_with(0, 2_000_000, 10, 9, 8)
+        canlib.canOpenChannel.assert_called_with(0, constants.canOPEN_CAN_FD | constants.canOPEN_ACCEPT_VIRTUAL)
+
+    def test_canfd_non_iso(self):
+        canlib.canSetBusParams.reset_mock()
+        canlib.canSetBusParamsFd.reset_mock()
+        canlib.canOpenChannel.reset_mock()
+        timing = can.BitTimingFd.from_bitrate_and_segments(
+            f_clock=80_000_000,
+            nom_bitrate=500_000,
+            nom_tseg1=68,
+            nom_tseg2=11,
+            nom_sjw=10,
+            data_bitrate=2_000_000,
+            data_tseg1=10,
+            data_tseg2=9,
+            data_sjw=8,
+        )
+        can.Bus(channel=0, interface="kvaser", timing=timing, fd_non_iso=True)
+        canlib.canSetBusParams.assert_called_once_with(0, 500_000, 68, 11, 10, 1, 0)
+        canlib.canSetBusParamsFd.assert_called_once_with(0, 2_000_000, 10, 9, 8)
+        canlib.canOpenChannel.assert_called_with(0, constants.canOPEN_CAN_FD_NONISO | constants.canOPEN_ACCEPT_VIRTUAL)
 
     def test_canfd_nondefault_data_bitrate(self):
         canlib.canSetBusParams.reset_mock()


### PR DESCRIPTION
Some older devices in the wild use non-iso CAN FD (Bosch). Some hardware supports choosing the mode in the driver, others are configurable during install or with a separate application. Kvaser is in the canlib API. PCAN requires either socket-can driver or the Windows GUI. Socket-CAN is an initialization flag.

Add documentation and hooks for kvaser. Relatively unintrusive. It didn't fit nicely with the bit-timings concept as it's purely associated with CRC calculation and stuffing.