### PR TITLE
Add ability to pass explicit dlc value to send() using the SYSTEC interface

### DIFF
--- a/can/interfaces/systec/structures.py
+++ b/can/interfaces/systec/structures.py
@@ -52,9 +52,10 @@ class CanMsg(Structure):
         ),  # Receive time stamp in ms (for transmit messages no meaning)
     ]
 
-    def __init__(self, id_=0, frame_format=MsgFrameFormat.MSG_FF_STD, data=None):
+    def __init__(self, id_=0, frame_format=MsgFrameFormat.MSG_FF_STD, data=None, dlc=None):
         data = [] if data is None else data
-        super().__init__(id_, frame_format, len(data), (BYTE * 8)(*data), 0)
+        dlc = len(data) if dlc is None else dlc
+        super().__init__(id_, frame_format, dlc, (BYTE * 8)(*data), 0)
 
     def __eq__(self, other):
         if not isinstance(other, CanMsg):

--- a/can/interfaces/systec/structures.py
+++ b/can/interfaces/systec/structures.py
@@ -52,7 +52,9 @@ class CanMsg(Structure):
         ),  # Receive time stamp in ms (for transmit messages no meaning)
     ]
 
-    def __init__(self, id_=0, frame_format=MsgFrameFormat.MSG_FF_STD, data=None, dlc=None):
+    def __init__(
+        self, id_=0, frame_format=MsgFrameFormat.MSG_FF_STD, data=None, dlc=None
+    ):
         data = [] if data is None else data
         dlc = len(data) if dlc is None else dlc
         super().__init__(id_, frame_format, dlc, (BYTE * 8)(*data), 0)

--- a/can/interfaces/systec/ucanbus.py
+++ b/can/interfaces/systec/ucanbus.py
@@ -207,7 +207,7 @@ class UcanBus(BusABC):
                 | (MsgFrameFormat.MSG_FF_EXT if msg.is_extended_id else 0)
                 | (MsgFrameFormat.MSG_FF_RTR if msg.is_remote_frame else 0),
                 msg.data,
-                msg.dlc
+                msg.dlc,
             )
             self._ucan.write_can_msg(self.channel, [message])
         except UcanException as exception:

--- a/can/interfaces/systec/ucanbus.py
+++ b/can/interfaces/systec/ucanbus.py
@@ -207,6 +207,7 @@ class UcanBus(BusABC):
                 | (MsgFrameFormat.MSG_FF_EXT if msg.is_extended_id else 0)
                 | (MsgFrameFormat.MSG_FF_RTR if msg.is_remote_frame else 0),
                 msg.data,
+                msg.dlc
             )
             self._ucan.write_can_msg(self.channel, [message])
         except UcanException as exception:


### PR DESCRIPTION
Closes #1755

Tested on sysWORXX USB CAN module2 with no regressions when leaving dlc value to default. Remote frames now include a valid dlc value rather than the default of 0.