### PR TITLE
Support 11-bit identifiers in the serial interface

### DIFF
--- a/doc/interfaces/serial.rst
+++ b/doc/interfaces/serial.rst
@@ -30,7 +30,9 @@ six parts. The start and the stop byte for the frame, the timestamp, DLC,
 arbitration ID and the payload. The payload has a variable length of between
 0 and 8 bytes, the other parts are fixed. Both, the timestamp and the
 arbitration ID will be interpreted as 4 byte unsigned integers. The DLC is
-also an unsigned integer with a length of 1 byte.
+also an unsigned integer with a length of 1 byte. Non-extended (11-bit)
+identifiers are encoded by adding 0x20000000 to the 11-bit ID. For example, an
+11-bit CAN ID of 0x123 is encoded with an arbitration ID of 0x20000123.
 
 Serial frame format
 ^^^^^^^^^^^^^^^^^^^
@@ -101,4 +103,22 @@ Examples of serial frames
 | Start of frame | Timestamp           | DLC  | Arbitration ID      | End of frame |
 +================+=====================+======+=====================+==============+
 | 0xAA           | 0x66 0x73 0x00 0x00 | 0x00 | 0x01 0x00 0x00 0x00 | 0xBB         |
++----------------+---------------------+------+---------------------+--------------+
+
+.. rubric:: CAN message with 0 byte payload with an 11-bit CAN ID
+
++----------------+---------+
+| CAN message              |
++----------------+---------+
+| Arbitration ID | Payload |
++================+=========+
+| 0x20000001 (1) | None    |
++----------------+---------+
+
++----------------+---------------------+------+---------------------+--------------+
+| Serial frame                                                                     |
++----------------+---------------------+------+---------------------+--------------+
+| Start of frame | Timestamp           | DLC  | Arbitration ID      | End of frame |
++================+=====================+======+=====================+==============+
+| 0xAA           | 0x66 0x73 0x00 0x00 | 0x00 | 0x01 0x00 0x00 0x20 | 0xBB         |
 +----------------+---------------------+------+---------------------+--------------+

--- a/test/serial_test.py
+++ b/test/serial_test.py
@@ -86,7 +86,7 @@ class SimpleSerialTestBase(ComparingMessagesTestCase):
 
     def test_rx_tx_min_id(self):
         """
-        Tests the transfer with the lowest arbitration id
+        Tests the transfer with the lowest extended arbitration id
         """
         msg = can.Message(arbitration_id=0)
         self.bus.send(msg)
@@ -95,9 +95,27 @@ class SimpleSerialTestBase(ComparingMessagesTestCase):
 
     def test_rx_tx_max_id(self):
         """
-        Tests the transfer with the highest arbitration id
+        Tests the transfer with the highest extended arbitration id
         """
         msg = can.Message(arbitration_id=536870911)
+        self.bus.send(msg)
+        msg_receive = self.bus.recv()
+        self.assertMessageEqual(msg, msg_receive)
+
+    def test_rx_tx_min_nonext_id(self):
+        """
+        Tests the transfer with the lowest non-extended arbitration id
+        """
+        msg = can.Message(arbitration_id=0x000, is_extended_id=False)
+        self.bus.send(msg)
+        msg_receive = self.bus.recv()
+        self.assertMessageEqual(msg, msg_receive)
+
+    def test_rx_tx_max_nonext_id(self):
+        """
+        Tests the transfer with the highest non-extended arbitration id
+        """
+        msg = can.Message(arbitration_id=0x7FF, is_extended_id=False)
         self.bus.send(msg)
         msg_receive = self.bus.recv()
         self.assertMessageEqual(msg, msg_receive)


### PR DESCRIPTION
### Is your feature request related to a problem? Please describe.
I'm working on a piece of software that will eventually run on a Raspberry Pi (ideally using the `SocketCAN` interface), but I would like to easily test on my local computer. I have several microcontrollers, but no way to connect the CAN bus to my computer. With the CAN serial interface, I can program the microcontrollers to act as an gateway for my computer, but the serial interface doesn't support 11-bit CAN IDs. Since my project uses 11-bit CAN IDs, I'm looking to add this support.

### Describe the solution you'd like
I added support for 11-bit CAN IDs by placing them at the end of the `arbitration_id` space for 29-bit IDs, and using the 30th bit to enable 11-bit IDs. I thought it might be useful to others, so I tested and documented the change.

### Describe alternatives you've considered
I have considered making a new interface that adds more features to serial. I have also considered using the SLCAN interface, but it's honestly easier to make this change than it is to implement full SLCAN compatibility.

### Additional context
I am new to this project, and I'm not sure if this is a feature that is really wanted in the upstream. If it is, feel free to make edits to this PR.