### PR TITLE
Fixed pcan Unpack error

### DIFF
--- a/can/interfaces/pcan/basic.py
+++ b/can/interfaces/pcan/basic.py
@@ -968,6 +968,7 @@ class PCANBasic:
                 res = self.GetValue(Channel, PCAN_ATTACHED_CHANNELS_COUNT)
                 if TPCANStatus(res[0]) != PCAN_ERROR_OK:
                     return (TPCANStatus(res[0]),)
+                    return TPCANStatus(res[0]), ()
                 mybuffer = (TPCANChannelInformation * res[1])()
 
             elif (

--- a/can/interfaces/pcan/basic.py
+++ b/can/interfaces/pcan/basic.py
@@ -967,7 +967,6 @@ class PCANBasic:
             elif Parameter == PCAN_ATTACHED_CHANNELS:
                 res = self.GetValue(Channel, PCAN_ATTACHED_CHANNELS_COUNT)
                 if TPCANStatus(res[0]) != PCAN_ERROR_OK:
-                    return (TPCANStatus(res[0]),)
                     return TPCANStatus(res[0]), ()
                 mybuffer = (TPCANChannelInformation * res[1])()
 


### PR DESCRIPTION
One of my colleagues encountered a "not enough values to unpack" error while scanning for connected dongles with PCAN drivers installed.
I couldn't replicate the error on my computer after installing the latest PCAN drivers. Still, analysing the instruction that raised that error, it seems that `PCANBasic.GetValue()` returned a wrong Tuple for a specific error condition.
That method must always return a Tuple with 2 elements, otherwise `PcanBus._detect_available_configs()` raises a "not enough values to unpack" error at line 718.