### PR TITLE
Gracefully handle errors when binding SocketCAN fails

### DIFF
--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -716,8 +716,6 @@ class SocketcanBus(BusABC):  # pylint: disable=abstract-method
             )
         except OSError as error:
             log.error("Could not access SocketCAN device %s (%s)", channel, error)
-            # Clean up so the parent class doesn't complain about not being shut down properly
-            self.shutdown()
             raise
         super().__init__(
             channel=channel,

--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -705,14 +705,20 @@ class SocketcanBus(BusABC):  # pylint: disable=abstract-method
         #     so this is always supported by the kernel
         self.socket.setsockopt(socket.SOL_SOCKET, constants.SO_TIMESTAMPNS, 1)
 
-        bind_socket(self.socket, channel)
-        kwargs.update(
-            {
-                "receive_own_messages": receive_own_messages,
-                "fd": fd,
-                "local_loopback": local_loopback,
-            }
-        )
+        try:
+            bind_socket(self.socket, channel)
+            kwargs.update(
+                {
+                    "receive_own_messages": receive_own_messages,
+                    "fd": fd,
+                    "local_loopback": local_loopback,
+                }
+            )
+        except OSError as error:
+            log.error("Could not access SocketCAN device %s (%s)", channel, error)
+            # Clean up so the parent class doesn't complain about not being shut down properly
+            self.shutdown()
+            raise
         super().__init__(
             channel=channel,
             can_filters=can_filters,


### PR DESCRIPTION
The parent class `BusABC` expects to be shutdown properly, checked via its `self._is_shutdown` flag during object deletion.  But that flag is only set when the base class' `shutdown()` is called, which doesn't happen if instantiation of the concrete class failed in `can.Bus()`.  So there is no way to avoid the warning message "SocketcanBus was not properly shut down" if the constructor raised an exception.

This change addresses that issue for the SocketCAN interface, by catching an OSError exception in `bind_socket()`, logging it, and calling `self.shutdown()` before re-raising the exception.

There might be a better approach which also works for the other backends?  The flag could be initialized to `True` and only reset to `False` when the `BusABC` constructor runs (which happens last in derived classes)?

Thus leaving this as a draft for further discussion.