### PR TITLE
Invert default value logic for BusABC._is_shutdown

### DIFF
--- a/can/bus.py
+++ b/can/bus.py
@@ -65,7 +65,8 @@ class BusABC(metaclass=ABCMeta):
     #: Log level for received messages
     RECV_LOGGING_LEVEL = 9
 
-    _is_shutdown: bool = False
+    #: Assume that no cleanup is needed until something was initialized
+    _is_shutdown: bool = True
     _can_protocol: CanProtocol = CanProtocol.CAN_20
 
     @abstractmethod
@@ -97,6 +98,10 @@ class BusABC(metaclass=ABCMeta):
         """
         self._periodic_tasks: List[_SelfRemovingCyclicTask] = []
         self.set_filters(can_filters)
+        # Flip the class default value when the constructor finishes.  That
+        # usually means the derived class constructor was also successful,
+        # since it calls this parent constructor last.
+        self._is_shutdown: bool = False
 
     def __str__(self) -> str:
         return self.channel_info


### PR DESCRIPTION
The destructor of BusABC gives a warning when shutdown() was not previously called on the object after construction.  However, if the construction fails (e.g. when the derived bus class constructor raises an exception), there is no way to call shutdown() on the unfinished object, and it is not necessary either.

Initialize the _is_shutdown flag to False initially and flip it to True only when the parent class constructor runs, which usually happens last in derived classes.  That avoids the shutdown warning for objects that failed to initialize at all.

This is an alternative approach solving the same problem as #1771, but that PR could be merged independently to have an error log message before raising the constructor exception.