### PR TITLE
Return timestamps relative to epoch in neovi interface

### DIFF
--- a/can/interfaces/ics_neovi/neovi_bus.py
+++ b/can/interfaces/ics_neovi/neovi_bus.py
@@ -12,6 +12,7 @@ import functools
 import logging
 import os
 import tempfile
+import time
 from collections import Counter, defaultdict, deque
 from functools import partial
 from itertools import cycle
@@ -67,6 +68,9 @@ except ImportError as ie:
 # When neoVI server is enabled, there is an issue with concurrent device open.
 open_lock = FileLock(os.path.join(tempfile.gettempdir(), "neovi.lock"))
 description_id = cycle(range(1, 0x8000))
+
+ICS_EPOCH = time.strptime("1/1/2007", "%m/%d/%Y")
+ICS_EPOCH_DELTA = time.mktime(ICS_EPOCH) - time.mktime(time.gmtime(0))
 
 
 class ICSApiError(CanError):
@@ -384,7 +388,7 @@ class NeoViBus(BusABC):
             return ics_msg.TimeSystem
         else:
             # This is the hardware time stamp.
-            return ics.get_timestamp_for_msg(self.dev, ics_msg)
+            return ics.get_timestamp_for_msg(self.dev, ics_msg) + ICS_EPOCH_DELTA
 
     def _ics_msg_to_message(self, ics_msg):
         is_fd = ics_msg.Protocol == ics.SPY_PROTOCOL_CANFD

--- a/can/interfaces/ics_neovi/neovi_bus.py
+++ b/can/interfaces/ics_neovi/neovi_bus.py
@@ -12,8 +12,8 @@ import functools
 import logging
 import os
 import tempfile
-import time
 from collections import Counter, defaultdict, deque
+from datetime import datetime
 from functools import partial
 from itertools import cycle
 from threading import Event
@@ -69,8 +69,8 @@ except ImportError as ie:
 open_lock = FileLock(os.path.join(tempfile.gettempdir(), "neovi.lock"))
 description_id = cycle(range(1, 0x8000))
 
-ICS_EPOCH = time.strptime("1/1/2007", "%m/%d/%Y")
-ICS_EPOCH_DELTA = time.mktime(ICS_EPOCH) - time.mktime(time.gmtime(0))
+ICS_EPOCH = datetime.fromisoformat("2007-01-01")
+ICS_EPOCH_DELTA = (ICS_EPOCH - datetime.fromisoformat("1970-01-01")).total_seconds()
 
 
 class ICSApiError(CanError):


### PR DESCRIPTION
Return timestamps relative to epoch in neovi interface.
noeVI HW timestamps are relative to Jan 1, 2007 ("ICS epoch").
Adding logic to return messages with timestamps relative to January 1, 1970 (epoch).