### PR TITLE
gs_usb command-line support (and documentation updates and stability fixes)

### DIFF
--- a/can/interfaces/gs_usb.py
+++ b/can/interfaces/gs_usb.py
@@ -17,7 +17,7 @@ class GsUsbBus(can.BusABC):
     def __init__(
         self,
         channel,
-        bitrate,
+        bitrate: int = 500_000,
         index=None,
         bus=None,
         address=None,

--- a/can/interfaces/gs_usb.py
+++ b/can/interfaces/gs_usb.py
@@ -109,7 +109,7 @@ class GsUsbBus(can.BusABC):
         frame = GsUsbFrame()
         frame.can_id = can_id
         frame.can_dlc = msg.dlc
-        frame.timestamp_us = int(msg.timestamp * 1000000)
+        frame.timestamp_us = 0  # timestamp frame field is only useful on receive
         frame.data = list(msg.data)
 
         try:

--- a/doc/interfaces/gs_usb.rst
+++ b/doc/interfaces/gs_usb.rst
@@ -8,13 +8,14 @@ and candleLight USB CAN interfaces.
 
 Install: ``pip install "python-can[gs_usb]"``
 
-Usage: pass device ``index`` (starting from 0) if using automatic device detection:
+Usage: pass device ``index`` or ``channel`` (starting from 0) if using automatic device detection:
 
 ::
 
     import can
 
     bus = can.Bus(interface="gs_usb", channel=dev.product, index=0, bitrate=250000)
+    bus = can.Bus(interface="gs_usb", channel=0, bitrate=250000)  # same
 
 Alternatively, pass ``bus`` and ``address`` to open a specific device. The parameters can be got by ``pyusb`` as shown below:
 

--- a/doc/interfaces/gs_usb.rst
+++ b/doc/interfaces/gs_usb.rst
@@ -50,7 +50,7 @@ Windows, Linux and Mac.
    ``libusb`` must be installed.
 
    On Windows a tool such as `Zadig <https://zadig.akeo.ie/>`_ can be used to set the USB device driver to
-   ``libusb-win32``.
+   ``libusbK``.
 
 
 Supplementary Info

--- a/doc/interfaces/gs_usb.rst
+++ b/doc/interfaces/gs_usb.rst
@@ -13,6 +13,8 @@ Usage: pass device ``index`` or ``channel`` (starting from 0) if using automatic
 ::
 
     import can
+    import usb
+    dev = usb.core.find(idVendor=0x1D50, idProduct=0x606F)
 
     bus = can.Bus(interface="gs_usb", channel=dev.product, index=0, bitrate=250000)
     bus = can.Bus(interface="gs_usb", channel=0, bitrate=250000)  # same


### PR DESCRIPTION
with these changes it is now possible to use the gs_usb driver with e.g. can.logger from the command line (like many other interfaces) with `python -m can.logger -i gs_usb -c 0 -b 500000`

also now possible to send CAN frames from applications that set the timestamp field of the python-can can frame object (e.g. scapy)