### PR TITLE
Release 4.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version 4.4.1
+Version 4.4.2
 =============
 
 Bug Fixes

--- a/can/__init__.py
+++ b/can/__init__.py
@@ -8,7 +8,7 @@ messages on a can bus.
 import logging
 from typing import Any, Dict
 
-__version__ = "4.4.1"
+__version__ = "4.4.2"
 __all__ = [
     "ASCReader",
     "ASCWriter",


### PR DESCRIPTION
@hardbyte I forgot to update the `__version__` in my 4.4.1 PR, so the PyPI upload failed. Then i changed the version and updated the release with a new git tag, but updating the release does not trigger a PyPI upload. 

So here is 4.4.2 😄 