### PR TITLE
Resolve AttributeError within NicanError

### DIFF
--- a/can/interfaces/nican.py
+++ b/can/interfaces/nican.py
@@ -89,7 +89,7 @@ class NicanError(CanError):
 
     def __init__(self, function, error_code: int, arguments) -> None:
         super().__init__(
-            message=f"{function} failed: {get_error_message(self.error_code)}",
+            message=f"{function} failed: {get_error_message(error_code)}",
             error_code=error_code,
         )
 


### PR DESCRIPTION
Resolves the below error:

```
Exception in thread can.notifier for bus "NI-CAN: CAN0":
Traceback (most recent call last):
  File "C:\Users\Admin\AppData\Local\Programs\Python\Python312-32\Lib\threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "C:\Users\Admin\AppData\Local\Programs\Python\Python312-32\Lib\threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\Admin\AppData\Local\Programs\Python\Python312-32\Lib\site-packages\can\notifier.py", line 124, in _rx_thread
    if msg := bus.recv(self.timeout):
              ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Admin\AppData\Local\Programs\Python\Python312-32\Lib\site-packages\can\bus.py", line 126, in recv
    msg, already_filtered = self._recv_internal(timeout=time_left)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Admin\AppData\Local\Programs\Python\Python312-32\Lib\site-packages\can\interfaces\nican.py", line 301, in _recv_internal
    nican.ncWaitForState(
  File "C:\Users\Admin\AppData\Local\Programs\Python\Python312-32\Lib\site-packages\can\interfaces\nican.py", line 120, in check_status
    raise error_class(function, result, arguments)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Admin\AppData\Local\Programs\Python\Python312-32\Lib\site-packages\can\interfaces\nican.py", line 92, in __init__
    message=f"{function} failed: {get_error_message(self.error_code)}",
                                                    ^^^^^^^^^^^^^^^
AttributeError: 'NicanOperationError' object has no attribute 'error_code'
```
