### PR TITLE
Fix ASCReader Crash on "Start of Measurement" Line

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -82,3 +82,4 @@ Felix Nieuwenhuizen
 @pkess
 @felixn
 @Tbruno25
+@RitheeshBaradwaj

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -276,7 +276,7 @@ class ASCReader(TextIOMessageReader):
                 continue
 
             # Handle the "Start of measurement" line
-            if line.startswith("0.000000") and "Start of measurement" in line:
+            if re.match(r"^\d+\.\d+\s+Start of measurement", line):
                 # Skip this line as it's just an indicator
                 continue
 

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -275,6 +275,11 @@ class ASCReader(TextIOMessageReader):
                 )
                 continue
 
+            # Handle the "Start of measurement" line
+            if line.startswith("0.000000") and "Start of measurement" in line:
+                # Skip this line as it's just an indicator
+                continue
+
             if not ASC_MESSAGE_REGEX.match(line):
                 # line might be a comment, chip status,
                 # J1939 message or some other unsupported event


### PR DESCRIPTION
### Summary

This PR addresses an issue where the ASCReader crashes when encountering the line `0.000000 CANFD Start of measurement` in ASC log files. This line is a combination of two different conventions and should not contain the "CANFD" flag.

### Changes

- Added logic in the `__iter__` method of `ASCReader` to skip lines matching the regex pattern for "Start of measurement".
- This ensures that such special indicator lines are handled separately and do not cause parsing errors.

Fixes #1786.
