### PR TITLE
Period must be >= 1ms for BCM using Win32 API

### DIFF
--- a/can/broadcastmanager.py
+++ b/can/broadcastmanager.py
@@ -308,6 +308,9 @@ class ThreadBasedCyclicSendTask(
 
         self.event: Optional[_Pywin32Event] = None
         if PYWIN32:
+            if self.period_ms == 0:
+                # A period of 0 would mean that the timer is signaled only once
+                raise ValueError("The period cannot be smaller than 0.001 (1 ms)")
             self.event = PYWIN32.create_timer()
         elif (
             sys.platform == "win32"


### PR DESCRIPTION
Using a win32 `SetWaitableTimer` with a period of `0` means that the timer will only be signaled once. This will make the `ThreadBasedCyclicSendTask` to only send one message.

https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-setwaitabletimer
> The period of the timer, in milliseconds. **If lPeriod is zero, the timer is signaled once**. If lPeriod is greater than zero, the timer is periodic. A periodic timer automatically reactivates each time the period elapses, until the timer is canceled using the [CancelWaitableTimer](https://learn.microsoft.com/en-us/windows/desktop/api/synchapi/nf-synchapi-cancelwaitabletimer) function or reset using SetWaitableTimer. If lPeriod is less than zero, the function fails.