### PR TITLE
Fix for #1849 (PCAN fails when PCAN_ERROR_ILLDATA is read via ReadFD)

### DIFF
--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -45,6 +45,7 @@ from .basic import (
     PCAN_ERROR_BUSLIGHT,
     PCAN_ERROR_OK,
     PCAN_ERROR_QRCVEMPTY,
+    PCAN_ERROR_ILLDATA,
     PCAN_FD_PARAMETER_LIST,
     PCAN_LANBUS1,
     PCAN_LISTEN_ONLY,
@@ -554,6 +555,10 @@ class PcanBus(BusABC):
 
             elif result & (PCAN_ERROR_BUSLIGHT | PCAN_ERROR_BUSHEAVY):
                 log.warning(self._get_formatted_error(result))
+
+            elif result == PCAN_ERROR_ILLDATA:
+                # Ignore this
+                pass
 
             else:
                 raise PcanCanOperationError(self._get_formatted_error(result))

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -43,9 +43,9 @@ from .basic import (
     PCAN_DICT_STATUS,
     PCAN_ERROR_BUSHEAVY,
     PCAN_ERROR_BUSLIGHT,
+    PCAN_ERROR_ILLDATA,
     PCAN_ERROR_OK,
     PCAN_ERROR_QRCVEMPTY,
-    PCAN_ERROR_ILLDATA,
     PCAN_FD_PARAMETER_LIST,
     PCAN_LANBUS1,
     PCAN_LISTEN_ONLY,
@@ -557,7 +557,9 @@ class PcanBus(BusABC):
                 log.warning(self._get_formatted_error(result))
 
             elif result == PCAN_ERROR_ILLDATA:
-                # Ignore this
+                # When there is an invalid frame on CAN bus (in our case CAN FD), PCAN first reports result PCAN_ERROR_ILLDATA
+                # and then it sends the error frame. If the PCAN_ERROR_ILLDATA is not ignored, python-can throws an exception.
+                # So we ignore any PCAN_ERROR_ILLDATA results here.
                 pass
 
             else:


### PR DESCRIPTION
When there is an invalid frame on CAN bus (in our case CAN FD), PCAN first reports result PCAN_ERROR_ILLDATA and then it send the error frame. If the PCAN_ERROR_ILLDATA is not ignored, python-can throws an exception. Reported as #1849 

This fix adds a branch in pcan.py:_recv_internal, which ignores the PCAN_ERROR_ILLDATA.