### PR TITLE
ASCWriter speed improvement

### DIFF
--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -9,7 +9,7 @@ Example .asc files:
 import logging
 import re
 from datetime import datetime
-from typing import Any, Dict, Final, Generator, List, Optional, TextIO, Union
+from typing import Any, Dict, Final, Generator, Optional, TextIO, Union
 
 from ..message import Message
 from ..typechecking import StringPathLike

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -439,10 +439,10 @@ class ASCWriter(TextIOMessageWriter):
             return
         if msg.is_remote_frame:
             dtype = f"r {msg.dlc:x}"  # New after v8.5
-            data: List[str] = []
+            data: str = ""
         else:
             dtype = f"d {msg.dlc:x}"
-            data = [f"{byte:02X}" for byte in msg.data]
+            data = msg.data.hex(" ").upper()
         arb_id = f"{msg.arbitration_id:X}"
         if msg.is_extended_id:
             arb_id += "x"
@@ -462,7 +462,7 @@ class ASCWriter(TextIOMessageWriter):
                 esi=1 if msg.error_state_indicator else 0,
                 dlc=len2dlc(msg.dlc),
                 data_length=len(msg.data),
-                data=" ".join(data),
+                data=data,
                 message_duration=0,
                 message_length=0,
                 flags=flags,
@@ -478,6 +478,6 @@ class ASCWriter(TextIOMessageWriter):
                 id=arb_id,
                 dir="Rx" if msg.is_rx else "Tx",
                 dtype=dtype,
-                data=" ".join(data),
+                data=data,
             )
         self.log_event(serialized, msg.timestamp)

--- a/test/data/single_frame.asc
+++ b/test/data/single_frame.asc
@@ -1,0 +1,7 @@
+date Sat Sep 30 15:06:13.191 2017
+base hex  timestamps absolute
+internal events logged
+Begin Triggerblock Sat Sep 30 15:06:13.191 2017
+ 0.000000 Start of measurement
+ 0.000000 1  123x            Rx   d 40 00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14 15 16 17 18 19 1A 1B 1C 1D 1E 1F 20 21 22 23 24 25 26 27 28 29 2A 2B 2C 2D 2E 2F 30 31 32 33 34 35 36 37 38 39 3A 3B 3C 3D 3E 3F
+End TriggerBlock

--- a/test/logformats_test.py
+++ b/test/logformats_test.py
@@ -667,7 +667,7 @@ class TestAscFileFormat(ReaderWriterTest):
             msg = can.Message(
                 timestamp=now.timestamp(),
                 arbitration_id=0x123,
-                data=(_ for _ in range(64)),
+                data=range(64),
             )
 
             with writer:

--- a/test/logformats_test.py
+++ b/test/logformats_test.py
@@ -665,7 +665,9 @@ class TestAscFileFormat(ReaderWriterTest):
                 writer = can.ASCWriter(self.test_file_name)
 
             msg = can.Message(
-                timestamp=now.timestamp(), arbitration_id=0x123, data=(_ for _ in range(64))
+                timestamp=now.timestamp(),
+                arbitration_id=0x123,
+                data=(_ for _ in range(64)),
             )
 
             with writer:


### PR DESCRIPTION
Changed how the message data is converted to string.


## Main
```
$ python -m timeit -s "import can; writer=can.ASCWriter('test.asc')" "writer(can.Message(data=range(64)))"
20000 loops, best of 5: 10.8 usec per loop
```

## This PR
```
$ python -m timeit -s "import can; writer=can.ASCWriter('test.asc')" "writer(can.Message(data=range(64)))"
50000 loops, best of 5: 3.97 usec per loop
```