### PR TITLE
Faster Message string representation

### DIFF
--- a/can/message.py
+++ b/can/message.py
@@ -130,12 +130,11 @@ class Message:  # pylint: disable=too-many-instance-attributes; OK for a datacla
         field_strings.append(flag_string)
 
         field_strings.append(f"DL: {self.dlc:2d}")
-        data_strings = []
+        data_strings = ""
         if self.data is not None:
-            for index in range(0, min(self.dlc, len(self.data))):
-                data_strings.append(f"{self.data[index]:02x}")
+            data_strings = self.data[: min(self.dlc, len(self.data))].hex(" ")
         if data_strings:  # if not empty
-            field_strings.append(" ".join(data_strings).ljust(24, " "))
+            field_strings.append(data_strings.ljust(24, " "))
         else:
             field_strings.append(" " * 24)
 


### PR DESCRIPTION
Improved the speed of data conversion to hex string.
This also as a result improves the `can.Printer` logger performance.

### Main Branch
```
$ python -m timeit -s "import can" "str(can.Message(data=(_ for _ in range(64))))"
20000 loops, best of 5: 14.7 usec per loop
```

### This PR
```
$ python -m timeit -s "import can" "str(can.Message(data=(_ for _ in range(64))))"
100000 loops, best of 5: 3.47 usec per loop
```