### PR TITLE
udp_multicast interface: support windows

### DIFF
--- a/can/interfaces/udp_multicast/bus.py
+++ b/can/interfaces/udp_multicast/bus.py
@@ -34,6 +34,9 @@ IP_ADDRESS_INFO = Union[IPv4_ADDRESS_INFO, IPv6_ADDRESS_INFO]
 SO_TIMESTAMPNS = 35
 SIOCGSTAMP = 0x8906
 
+# Additional constants for the interaction with the Winsock API
+WSAEINVAL = 10022
+
 
 class UdpMulticastBus(BusABC):
     """A virtual interface for CAN communications between multiple processes using UDP over Multicast IP.
@@ -279,7 +282,7 @@ class GeneralPurposeUdpMulticastBus:
                 if (
                     error.errno == errno.ENOPROTOOPT
                     or error.errno == errno.EINVAL
-                    or error.errno == errno.WSAEINVAL
+                    or error.errno == WSAEINVAL
                 ):  # It is unavailable on macOS (ENOPROTOOPT) or windows(EINVAL/WSAEINVAL)
                     self.timestamp_nanosecond = False
                 else:

--- a/can/interfaces/udp_multicast/bus.py
+++ b/can/interfaces/udp_multicast/bus.py
@@ -277,8 +277,10 @@ class GeneralPurposeUdpMulticastBus:
                 sock.setsockopt(socket.SOL_SOCKET, SO_TIMESTAMPNS, 1)
             except OSError as error:
                 if (
-                    error.errno == errno.ENOPROTOOPT or error.errno == errno.EINVAL
-                ):  # It is unavailable on macOS (ENOPROTOOPT) or windows(EINVAL)
+                    error.errno == errno.ENOPROTOOPT
+                    or error.errno == errno.EINVAL
+                    or error.errno == errno.WSAEINVAL
+                ):  # It is unavailable on macOS (ENOPROTOOPT) or windows(EINVAL/WSAEINVAL)
                     self.timestamp_nanosecond = False
                 else:
                     raise error

--- a/can/interfaces/udp_multicast/bus.py
+++ b/can/interfaces/udp_multicast/bus.py
@@ -4,7 +4,6 @@ import select
 import socket
 import struct
 import warnings
-import sys
 from datetime import datetime
 from typing import List, Optional, Tuple, Union
 

--- a/can/interfaces/udp_multicast/bus.py
+++ b/can/interfaces/udp_multicast/bus.py
@@ -3,8 +3,8 @@ import logging
 import select
 import socket
 import struct
+import time
 import warnings
-from datetime import datetime
 from typing import List, Optional, Tuple, Union
 
 import can
@@ -406,12 +406,12 @@ class GeneralPurposeUdpMulticastBus:
                         self.received_timestamp_struct, result_buffer
                     )
                 else:
-                    # fallback to datetime
-                    now = datetime.now()
+                    # fallback to time.time_ns
+                    now = time.time()
 
                     # Extract seconds and microseconds
-                    seconds = now.second
-                    microseconds = now.microsecond
+                    seconds = int(now)
+                    microseconds = int((now - seconds) * 1000000)
 
                 if microseconds >= 1e6:
                     raise can.CanOperationError(

--- a/can/interfaces/udp_multicast/bus.py
+++ b/can/interfaces/udp_multicast/bus.py
@@ -14,12 +14,12 @@ from can.typechecking import AutoDetectedConfig
 
 from .utils import check_msgpack_installed, pack_message, unpack_message
 
-ioctl_not_supported = False
+ioctl_supported = True
 
 try:
     from fcntl import ioctl
 except ModuleNotFoundError:  # Missing on Windows
-    ioctl_not_supported = True
+    ioctl_supported = False
     pass
 
 
@@ -397,7 +397,7 @@ class GeneralPurposeUdpMulticastBus:
                     self.max_buffer
                 )
 
-                if not ioctl_not_supported:
+                if ioctl_supported:
                     result_buffer = ioctl(
                         self._socket.fileno(),
                         SIOCGSTAMP,

--- a/doc/interfaces/udp_multicast.rst
+++ b/doc/interfaces/udp_multicast.rst
@@ -53,6 +53,9 @@ from ``bus_1`` to ``bus_2``:
             # give the notifier enough time to get triggered by the second bus
             time.sleep(2.0)
 
+            # clean-up
+            notifier.stop()
+
 
 Bus Class Documentation
 -----------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "wrapt~=1.10",
     "packaging >= 23.1",
     "typing_extensions>=3.10.0.0",
-    "msgpack~=1.1.0; platform_system != 'Windows'",
+    "msgpack~=1.1.0",
 ]
 requires-python = ">=3.8"
 license = { text = "LGPL v3" }

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -21,6 +21,7 @@ from .config import (
     IS_PYPY,
     IS_TRAVIS,
     IS_UNIX,
+    IS_WINDOWS,
     TEST_CAN_FD,
     TEST_INTERFACE_SOCKETCAN,
 )
@@ -303,8 +304,8 @@ class BasicTestSocketCan(Back2BackTestCase):
 # this doesn't even work on Travis CI for macOS; for example, see
 # https://travis-ci.org/github/hardbyte/python-can/jobs/745389871
 @unittest.skipUnless(
-    IS_UNIX and not (IS_CI and IS_OSX),
-    "only supported on Unix systems (but not on macOS at Travis CI and GitHub Actions)",
+    (IS_UNIX and not (IS_CI and IS_OSX)) or IS_WINDOWS,
+    "only supported on Unix and Windows systems (but not on macOS at Travis CI and GitHub Actions)",
 )
 class BasicTestUdpMulticastBusIPv4(Back2BackTestCase):
     INTERFACE_1 = "udp_multicast"
@@ -320,8 +321,8 @@ class BasicTestUdpMulticastBusIPv4(Back2BackTestCase):
 # this doesn't even work for loopback multicast addresses on Travis CI; for example, see
 # https://travis-ci.org/github/hardbyte/python-can/builds/745065503
 @unittest.skipUnless(
-    IS_UNIX and not (IS_TRAVIS or (IS_CI and IS_OSX)),
-    "only supported on Unix systems (but not on Travis CI; and not on macOS at GitHub Actions)",
+    (IS_UNIX and not (IS_TRAVIS or (IS_CI and IS_OSX))) or IS_WINDOWS,
+    "only supported on Unix and Windows systems (but not on Travis CI; and not on macOS at GitHub Actions)",
 )
 class BasicTestUdpMulticastBusIPv6(Back2BackTestCase):
     HOST_LOCAL_MCAST_GROUP_IPv6 = "ff11:7079:7468:6f6e:6465:6d6f:6d63:6173"

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -303,7 +303,8 @@ class BasicTestSocketCan(Back2BackTestCase):
 
 # this doesn't even work on Travis CI for macOS; for example, see
 # https://travis-ci.org/github/hardbyte/python-can/jobs/745389871
-@unittest.skipIf(IS_CI and IS_OSX,
+@unittest.skipIf(
+    IS_CI and IS_OSX,
     "not supported for macOS CI",
 )
 class BasicTestUdpMulticastBusIPv4(Back2BackTestCase):
@@ -319,7 +320,8 @@ class BasicTestUdpMulticastBusIPv4(Back2BackTestCase):
 
 # this doesn't even work for loopback multicast addresses on Travis CI; for example, see
 # https://travis-ci.org/github/hardbyte/python-can/builds/745065503
-@unittest.skipIf(IS_CI and IS_OSX,
+@unittest.skipIf(
+    IS_CI and IS_OSX,
     "not supported for macOS CI",
 )
 class BasicTestUdpMulticastBusIPv6(Back2BackTestCase):

--- a/test/back2back_test.py
+++ b/test/back2back_test.py
@@ -303,9 +303,8 @@ class BasicTestSocketCan(Back2BackTestCase):
 
 # this doesn't even work on Travis CI for macOS; for example, see
 # https://travis-ci.org/github/hardbyte/python-can/jobs/745389871
-@unittest.skipUnless(
-    (IS_UNIX and not (IS_CI and IS_OSX)) or IS_WINDOWS,
-    "only supported on Unix and Windows systems (but not on macOS at Travis CI and GitHub Actions)",
+@unittest.skipIf(IS_CI and IS_OSX,
+    "not supported for macOS CI",
 )
 class BasicTestUdpMulticastBusIPv4(Back2BackTestCase):
     INTERFACE_1 = "udp_multicast"
@@ -320,9 +319,8 @@ class BasicTestUdpMulticastBusIPv4(Back2BackTestCase):
 
 # this doesn't even work for loopback multicast addresses on Travis CI; for example, see
 # https://travis-ci.org/github/hardbyte/python-can/builds/745065503
-@unittest.skipUnless(
-    (IS_UNIX and not (IS_TRAVIS or (IS_CI and IS_OSX))) or IS_WINDOWS,
-    "only supported on Unix and Windows systems (but not on Travis CI; and not on macOS at GitHub Actions)",
+@unittest.skipIf(IS_CI and IS_OSX,
+    "not supported for macOS CI",
 )
 class BasicTestUdpMulticastBusIPv6(Back2BackTestCase):
     HOST_LOCAL_MCAST_GROUP_IPv6 = "ff11:7079:7468:6f6e:6465:6d6f:6d63:6173"


### PR DESCRIPTION
Neither the recvmsg() / SO_TIMESTAMPNS method, nor the SIOCGSTAMP / ioctl() method for obtaining the packet timestamp is supported on Windows.  This code switches from recvmsg to recvfrom() so that the udp_multicast works on Windows.

To support precise timestamps on Windows, Python would need to expose the WSArecvmsg() function first; see [here](https://learn.microsoft.com/en-us/windows/win32/winsock/winsock-timestamping). This PR is falling back to time.time() for now...