### PR TITLE
mf4: asammdf update to 8.0.0 for macOS build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "typing_extensions>=3.10.0.0",
     "msgpack~=1.1.0; platform_system != 'Windows'",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "LGPL v3" }
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -82,7 +82,7 @@ zlgcan = ["zlgcan-driver-py"]
 viewer = [
     "windows-curses; platform_system == 'Windows' and platform_python_implementation=='CPython'"
 ]
-mf4 = ["asammdf>=6.0.0"]
+mf4 = ["asammdf>=8.0.0"]
 
 [tool.setuptools.dynamic]
 readme = { file = "README.rst" }

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     hypothesis~=6.35.0
     pyserial~=3.5
     parameterized~=0.8
-    asammdf>=6.0; platform_python_implementation=="CPython" and python_version<"3.13"
+    asammdf>=8.0; platform_python_implementation=="CPython" and python_version<"3.14"
     pywin32>=305; platform_system=="Windows" and platform_python_implementation=="CPython" and python_version<"3.14"
 
 commands =


### PR DESCRIPTION
The current dependency of 6.0.0 fails to build on modern Apple Silicon: https://github.com/danielhrisca/asammdf/issues/1038.

Requires bump of min python-can version to 3.9 too. It looks like this was added in the 8.0.0 release. The >= 7.0.0 would still work with 3.8 if this is an issue.