### PR TITLE
Adding env marker to pywin32 requirements (extra)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ lint = [
     "black==24.10.*",
     "mypy==1.12.*",
 ]
-pywin32 = ["pywin32>=305"]
+pywin32 = ["pywin32>=305; platform_system == 'Windows' and platform_python_implementation == 'CPython'"]
 seeedstudio = ["pyserial>=3.0"]
 serial = ["pyserial~=3.0"]
 neovi = ["filelock", "python-ics>=2.12"]


### PR DESCRIPTION
As part of #1833, the `pywin32` requirements environment markers got dropped when moving the requirement to an extra.