### PR TITLE
Fix timestamp offset bug in BLFWriter

### DIFF
--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -530,7 +530,7 @@ class BLFWriter(FileIOMessageWriter):
         if timestamp is None:
             timestamp = self.stop_timestamp or time.time()
         if self.start_timestamp is None:
-            self.start_timestamp = timestamp
+            self.start_timestamp = int(timestamp * 1000) / 1000
         self.stop_timestamp = timestamp
         timestamp = int((timestamp - self.start_timestamp) * 1e9)
         header_size = OBJ_HEADER_BASE_STRUCT.size + OBJ_HEADER_V1_STRUCT.size

--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -530,6 +530,9 @@ class BLFWriter(FileIOMessageWriter):
         if timestamp is None:
             timestamp = self.stop_timestamp or time.time()
         if self.start_timestamp is None:
+            # Save start timestamp using the same precision as the BLF format
+            # Truncating to milliseconds to avoid rounding errors when calculating
+            # the timestamp difference
             self.start_timestamp = int(timestamp * 1000) / 1000
         self.stop_timestamp = timestamp
         timestamp = int((timestamp - self.start_timestamp) * 1e9)

--- a/test/data/example_data.py
+++ b/test/data/example_data.py
@@ -160,7 +160,7 @@ TEST_MESSAGES_REMOTE_FRAMES = sort_messages(
 
 TEST_MESSAGES_ERROR_FRAMES = sort_messages(
     [
-        Message(is_error_frame=True),
+        Message(is_error_frame=True, timestamp=TEST_TIME),
         Message(is_error_frame=True, timestamp=TEST_TIME + 0.170),
         Message(is_error_frame=True, timestamp=TEST_TIME + 17.157),
     ]


### PR DESCRIPTION
In the BLF files, the frame timestamp are stored as a delta from the "start time". The "start time" stored in the file is the first frame timestamp rounded to 3 decimals. When we calculate the timestamp delta for each frame, we were previously calculating it using the non-rounded "start time".

This new code, use the "start time" as the first frame timestamp truncated to 3 decimals.

This code can be used to test if the written timestamps are the same that we read back from the BLF file.

```python
import time

import can

messages = [
    can.Message(arbitration_id=_, is_fd=True, is_extended_id=False, timestamp=time.time() + _) for _ in range(10)
]


def main():
    can_log_files = [
        "logfile1.blf",
    ]

    for file_name in [None] + can_log_files:
        with can.Logger(file_name) as logger:
            for message in messages:
                logger(message)

    for file_name in can_log_files:
        print("Reading", file_name)
        with can.LogReader(file_name) as reader:
            for message in reader:
                print(message)

    for timestamp_delta in [1.0e-3, 1.0e-4, 1.0e-6]:
        print(f"timestamp_delta={timestamp_delta}")
        for file_name in can_log_files:
            with can.LogReader(file_name) as reader:
                for i, message in enumerate(reader):
                    assert message.equals(messages[i], timestamp_delta=timestamp_delta, check_channel=False), (
                    messages[i], message)
        print("OK")


if __name__ == "__main__":
    main()
```