### PR TITLE
Trc file writer add version param

### DIFF
--- a/can/io/trc.py
+++ b/can/io/trc.py
@@ -310,8 +310,15 @@ class TRCWriter(TextIOMessageWriter):
         self.header_written = False
         self.msgnr = 0
         self.first_timestamp = None
-        self.file_version = TRCFileVersion.V2_1
-        self._msg_fmt_string = self.MESSAGE_FORMAT_MAP[self.file_version]
+        self._setup_file_version(TRCFileVersion.V2_1)
+
+    def _setup_file_version(self, file_version: Union[int, TRCFileVersion]):
+        try:
+            self.file_version = TRCFileVersion(file_version)
+            self._msg_fmt_string = self.MESSAGE_FORMAT_MAP[self.file_version]
+        except (KeyError, ValueError) as exc:
+            err_msg = f"File version is not supported: {file_version}"
+            raise NotImplementedError(err_msg) from exc
 
     def _write_header_v1_0(self, start_time: datetime) -> None:
         lines = [

--- a/can/io/trc.py
+++ b/can/io/trc.py
@@ -378,7 +378,7 @@ class TRCWriter(TextIOMessageWriter):
         ]
         self.file.writelines(line + "\n" for line in lines)
 
-    def _format_message(self, msg, channel):
+    def _format_message(self, msg: Message, channel: int) -> str:
         if msg.is_extended_id:
             arb_id = f"{msg.arbitration_id:07X}"
         else:

--- a/can/io/trc.py
+++ b/can/io/trc.py
@@ -312,7 +312,6 @@ class TRCWriter(TextIOMessageWriter):
         self.first_timestamp = None
         self.file_version = TRCFileVersion.V2_1
         self._msg_fmt_string = self.MESSAGE_FORMAT_MAP[self.file_version]
-        self._format_message = self._format_message_init
 
     def _write_header_v1_0(self, start_time: datetime) -> None:
         lines = [
@@ -361,7 +360,7 @@ class TRCWriter(TextIOMessageWriter):
         ]
         self.file.writelines(line + "\n" for line in lines)
 
-    def _format_message_by_format(self, msg, channel):
+    def _format_message(self, msg, channel):
         if msg.is_extended_id:
             arb_id = f"{msg.arbitration_id:07X}"
         else:
@@ -379,17 +378,6 @@ class TRCWriter(TextIOMessageWriter):
             data=" ".join(data),
         )
         return serialized
-
-    def _format_message_init(self, msg, channel):
-        if self.file_version == TRCFileVersion.V1_0:
-            self._format_message = self._format_message_by_format
-        elif self.file_version == TRCFileVersion.V2_1:
-            self._format_message = self._format_message_by_format
-        else:
-            raise NotImplementedError("File format is not supported")
-
-        self._msg_fmt_string = self.MESSAGE_FORMAT_MAP[self.file_version]
-        return self._format_message_by_format(msg, channel)
 
     def write_header(self, timestamp: float) -> None:
         # write start of file header

--- a/can/io/trc.py
+++ b/can/io/trc.py
@@ -308,6 +308,7 @@ class TRCWriter(TextIOMessageWriter):
                      write mode, not binary write mode.
         :param channel: a default channel to use when the message does not
                         have a channel set
+        :param file_version: the trc file format version. Version 2.1 by default
         """
         super().__init__(file, mode="w")
         self.channel = channel

--- a/can/io/trc.py
+++ b/can/io/trc.py
@@ -11,7 +11,17 @@ import logging
 import os
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import Any, Callable, Dict, Generator, Optional, TextIO, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    Mapping,
+    Optional,
+    TextIO,
+    Tuple,
+    Union,
+)
 
 from ..message import Message
 from ..typechecking import StringPathLike

--- a/can/io/trc.py
+++ b/can/io/trc.py
@@ -289,6 +289,7 @@ class TRCWriter(TextIOMessageWriter):
         self,
         file: Union[StringPathLike, TextIO],
         channel: int = 1,
+        file_version: Union[int, TRCFileVersion] = TRCFileVersion.V2_1,
         **kwargs: Any,
     ) -> None:
         """
@@ -310,7 +311,7 @@ class TRCWriter(TextIOMessageWriter):
         self.header_written = False
         self.msgnr = 0
         self.first_timestamp = None
-        self._setup_file_version(TRCFileVersion.V2_1)
+        self._setup_file_version(file_version)
 
     def _setup_file_version(self, file_version: Union[int, TRCFileVersion]):
         try:


### PR DESCRIPTION
While i tried to update and finish the changes in [PR 1702](https://github.com/hardbyte/python-can/pull/1702) i saw some basic change that are quite usefull but are not the trace file version 1.1 changes itself. I collected them here now.

I also added the docstring as it was requested by @zariiii9003 .

I will create another PR for the addition of the TRC version 1.1 itself.