### PR TITLE
Fix float arithmetic in BLF reader

### DIFF
--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -17,6 +17,7 @@ import logging
 import struct
 import time
 import zlib
+from decimal import Decimal
 from typing import Any, BinaryIO, Generator, List, Optional, Tuple, Union, cast
 
 from ..message import Message
@@ -264,8 +265,8 @@ class BLFReader(BinaryIOMessageReader):
                 continue
 
             # Calculate absolute timestamp in seconds
-            factor = 1e-5 if flags == 1 else 1e-9
-            timestamp = timestamp * factor + start_timestamp
+            factor = Decimal("1e-5") if flags == 1 else Decimal("1e-9")
+            timestamp = float(Decimal(timestamp) * factor) + start_timestamp
 
             if obj_type in (CAN_MESSAGE, CAN_MESSAGE2):
                 channel, flags, dlc, can_id, can_data = unpack_can_msg(data, pos)

--- a/test/logformats_test.py
+++ b/test/logformats_test.py
@@ -694,7 +694,6 @@ class TestBlfFileFormat(ReaderWriterTest):
             check_fd=True,
             check_comments=False,
             test_append=True,
-            allowed_timestamp_delta=1.0e-6,
             preserves_channel=False,
             adds_default_channel=0,
         )


### PR DESCRIPTION
Using the Python decimal module for fast correctly rounded decimal floating-point arithmetic when applying the timestamp factor.

The BLF unit tests are also updated to reflect this new accuracy in the read timestamps.