### PR TITLE
Handle timer overflow message and build timestamp according to the epoch

### DIFF
--- a/can/interfaces/ixxat/canlib_vcinpl.py
+++ b/can/interfaces/ixxat/canlib_vcinpl.py
@@ -721,7 +721,7 @@ class IXXATBus(BusABC):
                     )
             elif self._message.uMsgInfo.Bits.type == constants.CAN_MSGTYPE_TIMEOVR:
                 # Add the number of timestamp overruns to the high word
-                self._overrunticks += (self._message.dwMsgId << 32);
+                self._overrunticks += (self._message.dwMsgId << 32)
             else:
                 log.warning(
                     "Unexpected message info type 0x%X",

--- a/can/interfaces/ixxat/canlib_vcinpl.py
+++ b/can/interfaces/ixxat/canlib_vcinpl.py
@@ -13,7 +13,6 @@ import ctypes
 import functools
 import logging
 import sys
-import time
 import warnings
 from typing import Callable, List, Optional, Sequence, Tuple, Union
 
@@ -620,15 +619,7 @@ class IXXATBus(BusABC):
                 log.info("Accepting ID: 0x%X MASK: 0x%X", code, mask)
 
         # Start the CAN controller. Messages will be forwarded to the channel
-        start_begin = time.time()
         _canlib.canControlStart(self._control_handle, constants.TRUE)
-        start_end = time.time()
-
-        # Calculate an offset to make them relative to epoch
-        # Assume that the time offset is in the middle of the start command
-        self._timeoffset = start_begin + (start_end - start_begin / 2)
-        self._overrunticks = 0
-        self._starttickoffset = 0
 
         # For cyclic transmit list. Set when .send_periodic() is first called
         self._scheduler = None
@@ -701,9 +692,6 @@ class IXXATBus(BusABC):
                         f"Unknown CAN info message code {self._message.abData[0]}",
                     )
                 )
-                # Handle CAN start info message
-                if self._message.abData[0] == constants.CAN_INFO_START:
-                    self._starttickoffset = self._message.dwTime
             elif self._message.uMsgInfo.Bits.type == constants.CAN_MSGTYPE_ERROR:
                 if self._message.uMsgInfo.Bytes.bFlags & constants.CAN_MSGFLAGS_OVR:
                     log.warning("CAN error: data overrun")
@@ -720,8 +708,7 @@ class IXXATBus(BusABC):
                         self._message.uMsgInfo.Bytes.bFlags,
                     )
             elif self._message.uMsgInfo.Bits.type == constants.CAN_MSGTYPE_TIMEOVR:
-                # Add the number of timestamp overruns to the high word
-                self._overrunticks += (self._message.dwMsgId << 32);
+                pass
             else:
                 log.warning(
                     "Unexpected message info type 0x%X",
@@ -753,9 +740,11 @@ class IXXATBus(BusABC):
             # Timed out / can message type is not DATA
             return None, True
 
+        # The _message.dwTime is a 32bit tick value and will overrun,
+        # so expect to see the value restarting from 0
         rx_msg = Message(
-            timestamp=((self._message.dwTime + self._overrunticks - self._starttickoffset)
-            / self._tick_resolution) + self._timeoffset,
+            timestamp=self._message.dwTime
+            / self._tick_resolution,  # Relative time in s
             is_remote_frame=bool(self._message.uMsgInfo.Bits.rtr),
             is_extended_id=bool(self._message.uMsgInfo.Bits.ext),
             arbitration_id=self._message.dwMsgId,

--- a/can/interfaces/ixxat/canlib_vcinpl.py
+++ b/can/interfaces/ixxat/canlib_vcinpl.py
@@ -721,7 +721,7 @@ class IXXATBus(BusABC):
                     )
             elif self._message.uMsgInfo.Bits.type == constants.CAN_MSGTYPE_TIMEOVR:
                 # Add the number of timestamp overruns to the high word
-                self._overrunticks += (self._message.dwMsgId << 32)
+                self._overrunticks += self._message.dwMsgId << 32
             else:
                 log.warning(
                     "Unexpected message info type 0x%X",
@@ -754,8 +754,11 @@ class IXXATBus(BusABC):
             return None, True
 
         rx_msg = Message(
-            timestamp=((self._message.dwTime + self._overrunticks - self._starttickoffset)
-            / self._tick_resolution) + self._timeoffset,
+            timestamp=(
+                (self._message.dwTime + self._overrunticks - self._starttickoffset)
+                / self._tick_resolution
+            )
+            + self._timeoffset,
             is_remote_frame=bool(self._message.uMsgInfo.Bits.rtr),
             is_extended_id=bool(self._message.uMsgInfo.Bits.ext),
             arbitration_id=self._message.dwMsgId,

--- a/can/interfaces/ixxat/canlib_vcinpl.py
+++ b/can/interfaces/ixxat/canlib_vcinpl.py
@@ -13,6 +13,7 @@ import ctypes
 import functools
 import logging
 import sys
+import time
 import warnings
 from typing import Callable, List, Optional, Sequence, Tuple, Union
 
@@ -619,7 +620,15 @@ class IXXATBus(BusABC):
                 log.info("Accepting ID: 0x%X MASK: 0x%X", code, mask)
 
         # Start the CAN controller. Messages will be forwarded to the channel
+        start_begin = time.time()
         _canlib.canControlStart(self._control_handle, constants.TRUE)
+        start_end = time.time()
+
+        # Calculate an offset to make them relative to epoch
+        # Assume that the time offset is in the middle of the start command
+        self._timeoffset = start_begin + (start_end - start_begin / 2)
+        self._overrunticks = 0
+        self._starttickoffset = 0
 
         # For cyclic transmit list. Set when .send_periodic() is first called
         self._scheduler = None
@@ -692,6 +701,9 @@ class IXXATBus(BusABC):
                         f"Unknown CAN info message code {self._message.abData[0]}",
                     )
                 )
+                # Handle CAN start info message
+                if self._message.abData[0] == constants.CAN_INFO_START:
+                    self._starttickoffset = self._message.dwTime
             elif self._message.uMsgInfo.Bits.type == constants.CAN_MSGTYPE_ERROR:
                 if self._message.uMsgInfo.Bytes.bFlags & constants.CAN_MSGFLAGS_OVR:
                     log.warning("CAN error: data overrun")
@@ -708,7 +720,8 @@ class IXXATBus(BusABC):
                         self._message.uMsgInfo.Bytes.bFlags,
                     )
             elif self._message.uMsgInfo.Bits.type == constants.CAN_MSGTYPE_TIMEOVR:
-                pass
+                # Add the number of timestamp overruns to the high word
+                self._overrunticks += (self._message.dwMsgId << 32);
             else:
                 log.warning(
                     "Unexpected message info type 0x%X",
@@ -740,11 +753,9 @@ class IXXATBus(BusABC):
             # Timed out / can message type is not DATA
             return None, True
 
-        # The _message.dwTime is a 32bit tick value and will overrun,
-        # so expect to see the value restarting from 0
         rx_msg = Message(
-            timestamp=self._message.dwTime
-            / self._tick_resolution,  # Relative time in s
+            timestamp=((self._message.dwTime + self._overrunticks - self._starttickoffset)
+            / self._tick_resolution) + self._timeoffset,
             is_remote_frame=bool(self._message.uMsgInfo.Bits.rtr),
             is_extended_id=bool(self._message.uMsgInfo.Bits.ext),
             arbitration_id=self._message.dwMsgId,

--- a/can/interfaces/ixxat/canlib_vcinpl2.py
+++ b/can/interfaces/ixxat/canlib_vcinpl2.py
@@ -726,7 +726,15 @@ class IXXATBus(BusABC):
                 log.info("Accepting ID: 0x%X MASK: 0x%X", code, mask)
 
         # Start the CAN controller. Messages will be forwarded to the channel
+        start_begin = time.time()
         _canlib.canControlStart(self._control_handle, constants.TRUE)
+        start_end = time.time()
+
+        # Calculate an offset to make them relative to epoch
+        # Assume that the time offset is in the middle of the start command
+        self._timeoffset = start_begin + (start_end - start_begin / 2)
+        self._overrunticks = 0
+        self._starttickoffset = 0
 
         # For cyclic transmit list. Set when .send_periodic() is first called
         self._scheduler = None
@@ -831,7 +839,9 @@ class IXXATBus(BusABC):
                                 f"Unknown CAN info message code {self._message.abData[0]}",
                             )
                         )
-
+                	# Handle CAN start info message
+                    elif self._message.abData[0] == constants.CAN_INFO_START:
+                        self._starttickoffset = self._message.dwTime
                     elif (
                         self._message.uMsgInfo.Bits.type == constants.CAN_MSGTYPE_ERROR
                     ):
@@ -853,7 +863,8 @@ class IXXATBus(BusABC):
                         self._message.uMsgInfo.Bits.type
                         == constants.CAN_MSGTYPE_TIMEOVR
                     ):
-                        pass
+                        # Add the number of timestamp overruns to the high word
+                        self._overrunticks += (self._message.dwMsgId << 32);
                     else:
                         log.warning("Unexpected message info type")
 
@@ -867,11 +878,9 @@ class IXXATBus(BusABC):
             return None, True
 
         data_len = dlc2len(self._message.uMsgInfo.Bits.dlc)
-        # The _message.dwTime is a 32bit tick value and will overrun,
-        # so expect to see the value restarting from 0
         rx_msg = Message(
-            timestamp=self._message.dwTime
-            / self._tick_resolution,  # Relative time in s
+            timestamp=((self._message.dwTime + self._overrunticks - self._starttickoffset)
+            / self._tick_resolution) + self._timeoffset,
             is_remote_frame=bool(self._message.uMsgInfo.Bits.rtr),
             is_fd=bool(self._message.uMsgInfo.Bits.edl),
             is_rx=True,

--- a/can/interfaces/ixxat/canlib_vcinpl2.py
+++ b/can/interfaces/ixxat/canlib_vcinpl2.py
@@ -839,7 +839,7 @@ class IXXATBus(BusABC):
                                 f"Unknown CAN info message code {self._message.abData[0]}",
                             )
                         )
-                	# Handle CAN start info message
+                    # Handle CAN start info message
                     elif self._message.abData[0] == constants.CAN_INFO_START:
                         self._starttickoffset = self._message.dwTime
                     elif (
@@ -864,7 +864,7 @@ class IXXATBus(BusABC):
                         == constants.CAN_MSGTYPE_TIMEOVR
                     ):
                         # Add the number of timestamp overruns to the high word
-                        self._overrunticks += (self._message.dwMsgId << 32);
+                        self._overrunticks += (self._message.dwMsgId << 32)
                     else:
                         log.warning("Unexpected message info type")
 

--- a/can/interfaces/ixxat/canlib_vcinpl2.py
+++ b/can/interfaces/ixxat/canlib_vcinpl2.py
@@ -864,7 +864,7 @@ class IXXATBus(BusABC):
                         == constants.CAN_MSGTYPE_TIMEOVR
                     ):
                         # Add the number of timestamp overruns to the high word
-                        self._overrunticks += (self._message.dwMsgId << 32)
+                        self._overrunticks += self._message.dwMsgId << 32
                     else:
                         log.warning("Unexpected message info type")
 
@@ -879,8 +879,11 @@ class IXXATBus(BusABC):
 
         data_len = dlc2len(self._message.uMsgInfo.Bits.dlc)
         rx_msg = Message(
-            timestamp=((self._message.dwTime + self._overrunticks - self._starttickoffset)
-            / self._tick_resolution) + self._timeoffset,
+            timestamp=(
+                (self._message.dwTime + self._overrunticks - self._starttickoffset)
+                / self._tick_resolution
+            )
+            + self._timeoffset,
             is_remote_frame=bool(self._message.uMsgInfo.Bits.rtr),
             is_fd=bool(self._message.uMsgInfo.Bits.edl),
             is_rx=True,

--- a/can/interfaces/ixxat/canlib_vcinpl2.py
+++ b/can/interfaces/ixxat/canlib_vcinpl2.py
@@ -726,15 +726,7 @@ class IXXATBus(BusABC):
                 log.info("Accepting ID: 0x%X MASK: 0x%X", code, mask)
 
         # Start the CAN controller. Messages will be forwarded to the channel
-        start_begin = time.time()
         _canlib.canControlStart(self._control_handle, constants.TRUE)
-        start_end = time.time()
-
-        # Calculate an offset to make them relative to epoch
-        # Assume that the time offset is in the middle of the start command
-        self._timeoffset = start_begin + (start_end - start_begin / 2)
-        self._overrunticks = 0
-        self._starttickoffset = 0
 
         # For cyclic transmit list. Set when .send_periodic() is first called
         self._scheduler = None
@@ -839,9 +831,7 @@ class IXXATBus(BusABC):
                                 f"Unknown CAN info message code {self._message.abData[0]}",
                             )
                         )
-                	# Handle CAN start info message
-                    elif self._message.abData[0] == constants.CAN_INFO_START:
-                        self._starttickoffset = self._message.dwTime
+
                     elif (
                         self._message.uMsgInfo.Bits.type == constants.CAN_MSGTYPE_ERROR
                     ):
@@ -863,8 +853,7 @@ class IXXATBus(BusABC):
                         self._message.uMsgInfo.Bits.type
                         == constants.CAN_MSGTYPE_TIMEOVR
                     ):
-                        # Add the number of timestamp overruns to the high word
-                        self._overrunticks += (self._message.dwMsgId << 32);
+                        pass
                     else:
                         log.warning("Unexpected message info type")
 
@@ -878,9 +867,11 @@ class IXXATBus(BusABC):
             return None, True
 
         data_len = dlc2len(self._message.uMsgInfo.Bits.dlc)
+        # The _message.dwTime is a 32bit tick value and will overrun,
+        # so expect to see the value restarting from 0
         rx_msg = Message(
-            timestamp=((self._message.dwTime + self._overrunticks - self._starttickoffset)
-            / self._tick_resolution) + self._timeoffset,
+            timestamp=self._message.dwTime
+            / self._tick_resolution,  # Relative time in s
             is_remote_frame=bool(self._message.uMsgInfo.Bits.rtr),
             is_fd=bool(self._message.uMsgInfo.Bits.edl),
             is_rx=True,


### PR DESCRIPTION
Handle timer overflow message and build timestamp according to the epoch in `canlib_vcinpl.py` and `canlib_vcinpl2.py`