### PR TITLE
Fix UDP multicast interface on MacOS

### DIFF
--- a/can/interfaces/udp_multicast/bus.py
+++ b/can/interfaces/udp_multicast/bus.py
@@ -274,6 +274,7 @@ class GeneralPurposeUdpMulticastBus:
 
             # Allow multiple programs to access that address + port
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
 
             # set how to receive timestamps
             try:

--- a/can/interfaces/udp_multicast/bus.py
+++ b/can/interfaces/udp_multicast/bus.py
@@ -5,6 +5,7 @@ import socket
 import struct
 import time
 import warnings
+import platform
 from typing import List, Optional, Tuple, Union
 
 import can
@@ -21,6 +22,8 @@ except ModuleNotFoundError:  # Missing on Windows
     ioctl_supported = False
     pass
 
+# All ioctls aren't supported on MacOS. 
+is_macos = platform.system() == "Darwin"
 
 log = logging.getLogger(__name__)
 
@@ -402,7 +405,7 @@ class GeneralPurposeUdpMulticastBus:
                     self.max_buffer
                 )
 
-                if ioctl_supported:
+                if ioctl_supported and not is_macos:
                     result_buffer = ioctl(
                         self._socket.fileno(),
                         SIOCGSTAMP,

--- a/can/interfaces/udp_multicast/bus.py
+++ b/can/interfaces/udp_multicast/bus.py
@@ -14,16 +14,9 @@ from can.typechecking import AutoDetectedConfig
 
 from .utils import check_msgpack_installed, pack_message, unpack_message
 
-ioctl_supported = True
-
-try:
+is_linux = platform.system() == "Linux"
+if is_linux:
     from fcntl import ioctl
-except ModuleNotFoundError:  # Missing on Windows
-    ioctl_supported = False
-    pass
-
-# All ioctls aren't supported on MacOS.
-is_macos = platform.system() == "Darwin"
 
 log = logging.getLogger(__name__)
 
@@ -408,7 +401,8 @@ class GeneralPurposeUdpMulticastBus:
                     self.max_buffer
                 )
 
-                if ioctl_supported and not is_macos:
+                if is_linux:
+                    # This ioctl isn't supported on Darwin & Windows.
                     result_buffer = ioctl(
                         self._socket.fileno(),
                         SIOCGSTAMP,

--- a/can/interfaces/udp_multicast/bus.py
+++ b/can/interfaces/udp_multicast/bus.py
@@ -1,11 +1,11 @@
 import errno
 import logging
+import platform
 import select
 import socket
 import struct
 import time
 import warnings
-import platform
 from typing import List, Optional, Tuple, Union
 
 import can
@@ -22,7 +22,7 @@ except ModuleNotFoundError:  # Missing on Windows
     ioctl_supported = False
     pass
 
-# All ioctls aren't supported on MacOS. 
+# All ioctls aren't supported on MacOS.
 is_macos = platform.system() == "Darwin"
 
 log = logging.getLogger(__name__)
@@ -277,7 +277,10 @@ class GeneralPurposeUdpMulticastBus:
 
             # Allow multiple programs to access that address + port
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+
+            # Option not supported on Windows.
+            if hasattr(socket, "SO_REUSEPORT"):
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
 
             # set how to receive timestamps
             try:


### PR DESCRIPTION
Hi, 

This fixes https://github.com/hardbyte/python-can/issues/1760 to allow usage of the UDP Multicast backend on MacOS. 

The ioctl check before timestamping in recv was only partially fixed for Windows on main, but MacOS still doesn't support this ioctl. 

The second change is adding the SO_REUSEPORT option. 