### PR TITLE
parse socketcand error messages to create a CAN error frame

### DIFF
--- a/can/interfaces/socketcand/socketcand.py
+++ b/can/interfaces/socketcand/socketcand.py
@@ -125,10 +125,11 @@ def detect_beacon(timeout_ms: int = 3100) -> List[can.typechecking.AutoDetectedC
 
 
 def convert_ascii_message_to_can_message(ascii_msg: str) -> can.Message:
-    if not ascii_msg.startswith("< frame ") or not ascii_msg.endswith(" >"):
-        log.warning(f"Could not parse ascii message: {ascii_msg}")
+    if not ascii_msg.endswith(" >"):
+        log.warning(f"Missing ending character in ascii message: {ascii_msg}")
         return None
-    else:
+
+    if ascii_msg.startswith("< frame "):
         # frame_string = ascii_msg.removeprefix("< frame ").removesuffix(" >")
         frame_string = ascii_msg[8:-2]
         parts = frame_string.split(" ", 3)
@@ -146,6 +147,31 @@ def convert_ascii_message_to_can_message(ascii_msg: str) -> can.Message:
             is_rx=True,
         )
         return can_message
+
+    if ascii_msg.startswith("< error "):
+        frame_string = ascii_msg[8:-2]
+        parts = frame_string.split(" ", 3)
+        can_id, timestamp = int(parts[0], 16), float(parts[1])
+        is_ext = len(parts[0]) != 3
+
+        # socketcand sends no data in the error message so we don't have information
+        # about the error details, therefore the can frame is created with one
+        # data byte set to zero
+        data = bytearray([0])
+        can_dlc = len(data)
+        can_message = can.Message(
+            timestamp=timestamp,
+            arbitration_id=can_id & 0x1FFFFFFF,
+            is_error_frame=True,
+            data=data,
+            dlc=can_dlc,
+            is_extended_id=True,
+            is_rx=True,
+        )
+        return can_message
+
+    log.warning(f"Could not parse ascii message: {ascii_msg}")
+    return None
 
 
 def convert_can_message_to_ascii_message(can_message: can.Message) -> str:

--- a/test/test_socketcand.py
+++ b/test/test_socketcand.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+import unittest
+import can
+from can.interfaces.socketcand import socketcand
+
+
+class TestConvertAsciiMessageToCanMessage(unittest.TestCase):
+    def test_valid_frame_message(self):
+        # Example: < frame 123 1680000000.0 01020304 >
+        ascii_msg = "< frame 123 1680000000.0 01020304 >"
+        msg = socketcand.convert_ascii_message_to_can_message(ascii_msg)
+        self.assertIsInstance(msg, can.Message)
+        self.assertEqual(msg.arbitration_id, 0x123)
+        self.assertEqual(msg.timestamp, 1680000000.0)
+        self.assertEqual(msg.data, bytearray([1, 2, 3, 4]))
+        self.assertEqual(msg.dlc, 4)
+        self.assertFalse(msg.is_extended_id)
+        self.assertTrue(msg.is_rx)
+
+    def test_valid_error_message(self):
+        # Example: < error 1ABCDEF0 1680000001.0 >
+        ascii_msg = "< error 1ABCDEF0 1680000001.0 >"
+        msg = socketcand.convert_ascii_message_to_can_message(ascii_msg)
+        self.assertIsInstance(msg, can.Message)
+        self.assertEqual(msg.arbitration_id, 0x1ABCDEF0)
+        self.assertEqual(msg.timestamp, 1680000001.0)
+        self.assertEqual(msg.data, bytearray([0]))
+        self.assertEqual(msg.dlc, 1)
+        self.assertTrue(msg.is_extended_id)
+        self.assertTrue(msg.is_error_frame)
+        self.assertTrue(msg.is_rx)
+
+    def test_invalid_message(self):
+        ascii_msg = "< unknown 123 0.0 >"
+        msg = socketcand.convert_ascii_message_to_can_message(ascii_msg)
+        self.assertIsNone(msg)
+
+    def test_missing_ending_character(self):
+        ascii_msg = "< frame 123 1680000000.0 01020304"
+        msg = socketcand.convert_ascii_message_to_can_message(ascii_msg)
+        self.assertIsNone(msg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Summary
Recently socketcand project merged a PR to enable error CAN frames ( https://github.com/linux-can/socketcand/pull/67 ) so now it can send error messages through the TCP socket when an error frame is generated by the CAN driver.

This PR updates the python-can socketcand interface to generate an error CAN message when socketcand error message is received 