### PR TITLE
Add public functions for creating bus command lines options

### DIFF
--- a/can/cli.py
+++ b/can/cli.py
@@ -1,0 +1,320 @@
+import argparse
+import re
+from collections.abc import Sequence
+from typing import Any, Optional, Union
+
+import can
+from can.typechecking import CanFilter, TAdditionalCliArgs
+from can.util import _dict2timing, cast_from_string
+
+
+def add_bus_arguments(
+    parser: argparse.ArgumentParser,
+    *,
+    filter_arg: bool = False,
+    prefix: Optional[str] = None,
+    group_title: Optional[str] = None,
+) -> None:
+    """Adds CAN bus configuration options to an argument parser.
+
+    :param parser:
+        The argument parser to which the options will be added.
+    :param filter_arg:
+        Whether to include the filter argument.
+    :param prefix:
+        An optional prefix for the argument names, allowing configuration of multiple buses.
+    :param group_title:
+        The title of the argument group. If not provided, a default title will be generated
+        based on the prefix. For example, "bus arguments (prefix)" if a prefix is specified,
+        or "bus arguments" otherwise.
+    """
+    if group_title is None:
+        group_title = f"bus arguments ({prefix})" if prefix else "bus arguments"
+
+    group = parser.add_argument_group(group_title)
+
+    flags = [f"--{prefix}-channel"] if prefix else ["-c", "--channel"]
+    dest = f"{prefix}_channel" if prefix else "channel"
+    group.add_argument(
+        *flags,
+        dest=dest,
+        default=argparse.SUPPRESS,
+        metavar="CHANNEL",
+        help=r"Most backend interfaces require some sort of channel. For "
+        r"example with the serial interface the channel might be a rfcomm"
+        r' device: "/dev/rfcomm0". With the socketcan interface valid '
+        r'channel examples include: "can0", "vcan0".',
+    )
+
+    flags = [f"--{prefix}-interface"] if prefix else ["-i", "--interface"]
+    dest = f"{prefix}_interface" if prefix else "interface"
+    group.add_argument(
+        *flags,
+        dest=dest,
+        default=argparse.SUPPRESS,
+        choices=sorted(can.VALID_INTERFACES),
+        help="""Specify the backend CAN interface to use. If left blank,
+                        fall back to reading from configuration files.""",
+    )
+
+    flags = [f"--{prefix}-bitrate"] if prefix else ["-b", "--bitrate"]
+    dest = f"{prefix}_bitrate" if prefix else "bitrate"
+    group.add_argument(
+        *flags,
+        dest=dest,
+        type=int,
+        default=argparse.SUPPRESS,
+        metavar="BITRATE",
+        help="Bitrate to use for the CAN bus.",
+    )
+
+    flags = [f"--{prefix}-fd"] if prefix else ["--fd"]
+    dest = f"{prefix}_fd" if prefix else "fd"
+    group.add_argument(
+        *flags,
+        dest=dest,
+        default=argparse.SUPPRESS,
+        action="store_true",
+        help="Activate CAN-FD support",
+    )
+
+    flags = [f"--{prefix}-data-bitrate"] if prefix else ["--data-bitrate"]
+    dest = f"{prefix}_data_bitrate" if prefix else "data_bitrate"
+    group.add_argument(
+        *flags,
+        dest=dest,
+        type=int,
+        default=argparse.SUPPRESS,
+        metavar="DATA_BITRATE",
+        help="Bitrate to use for the data phase in case of CAN-FD.",
+    )
+
+    flags = [f"--{prefix}-timing"] if prefix else ["--timing"]
+    dest = f"{prefix}_timing" if prefix else "timing"
+    group.add_argument(
+        *flags,
+        dest=dest,
+        action=_BitTimingAction,
+        nargs=argparse.ONE_OR_MORE,
+        default=argparse.SUPPRESS,
+        metavar="TIMING_ARG",
+        help="Configure bit rate and bit timing. For example, use "
+        "`--timing f_clock=8_000_000 tseg1=5 tseg2=2 sjw=2 brp=2 nof_samples=1` for classical CAN "
+        "or `--timing f_clock=80_000_000 nom_tseg1=119 nom_tseg2=40 nom_sjw=40 nom_brp=1 "
+        "data_tseg1=29 data_tseg2=10 data_sjw=10 data_brp=1` for CAN FD. "
+        "Check the python-can documentation to verify whether your "
+        "CAN interface supports the `timing` argument.",
+    )
+
+    if filter_arg:
+        flags = [f"--{prefix}-filter"] if prefix else ["--filter"]
+        dest = f"{prefix}_can_filters" if prefix else "can_filters"
+        group.add_argument(
+            *flags,
+            dest=dest,
+            nargs=argparse.ONE_OR_MORE,
+            action=_CanFilterAction,
+            default=argparse.SUPPRESS,
+            metavar="{<can_id>:<can_mask>,<can_id>~<can_mask>}",
+            help="R|Space separated CAN filters for the given CAN interface:"
+            "\n      <can_id>:<can_mask> (matches when <received_can_id> & mask =="
+            " can_id & mask)"
+            "\n      <can_id>~<can_mask> (matches when <received_can_id> & mask !="
+            " can_id & mask)"
+            "\nFx to show only frames with ID 0x100 to 0x103 and 0x200 to 0x20F:"
+            "\n      python -m can.viewer --filter 100:7FC 200:7F0"
+            "\nNote that the ID and mask are always interpreted as hex values",
+        )
+
+    flags = [f"--{prefix}-bus-kwargs"] if prefix else ["--bus-kwargs"]
+    dest = f"{prefix}_bus_kwargs" if prefix else "bus_kwargs"
+    group.add_argument(
+        *flags,
+        dest=dest,
+        action=_BusKwargsAction,
+        nargs=argparse.ONE_OR_MORE,
+        default=argparse.SUPPRESS,
+        metavar="BUS_KWARG",
+        help="Pass keyword arguments down to the instantiation of the bus class. "
+        "For example, `-i vector -c 1 --bus-kwargs app_name=MyCanApp serial=1234` is equivalent "
+        "to opening the bus with `can.Bus('vector', channel=1, app_name='MyCanApp', serial=1234)",
+    )
+
+
+def create_bus_from_namespace(
+    namespace: argparse.Namespace,
+    *,
+    prefix: Optional[str] = None,
+    **kwargs: Any,
+) -> can.BusABC:
+    """Creates and returns a CAN bus instance based on the provided namespace and arguments.
+
+    :param namespace:
+        The namespace containing parsed arguments.
+    :param prefix:
+        An optional prefix for the argument names, enabling support for multiple buses.
+    :param kwargs:
+        Additional keyword arguments to configure the bus.
+    :return:
+        A CAN bus instance.
+    """
+    config: dict[str, Any] = {"single_handle": True, **kwargs}
+
+    for keyword in (
+        "channel",
+        "interface",
+        "bitrate",
+        "fd",
+        "data_bitrate",
+        "can_filters",
+        "timing",
+        "bus_kwargs",
+    ):
+        prefixed_keyword = f"{prefix}_{keyword}" if prefix else keyword
+
+        if prefixed_keyword in namespace:
+            value = getattr(namespace, prefixed_keyword)
+
+            if keyword == "bus_kwargs":
+                config.update(value)
+            else:
+                config[keyword] = value
+
+    try:
+        return can.Bus(**config)
+    except Exception as exc:
+        err_msg = f"Unable to instantiate bus from arguments {vars(namespace)}."
+        raise argparse.ArgumentError(None, err_msg) from exc
+
+
+class _CanFilterAction(argparse.Action):
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = None,
+    ) -> None:
+        if not isinstance(values, list):
+            raise argparse.ArgumentError(self, "Invalid filter argument")
+
+        print(f"Adding filter(s): {values}")
+        can_filters: list[CanFilter] = []
+
+        for filt in values:
+            if ":" in filt:
+                parts = filt.split(":")
+                can_id = int(parts[0], base=16)
+                can_mask = int(parts[1], base=16)
+            elif "~" in filt:
+                parts = filt.split("~")
+                can_id = int(parts[0], base=16) | 0x20000000  # CAN_INV_FILTER
+                can_mask = int(parts[1], base=16) & 0x20000000  # socket.CAN_ERR_FLAG
+            else:
+                raise argparse.ArgumentError(self, "Invalid filter argument")
+            can_filters.append({"can_id": can_id, "can_mask": can_mask})
+
+        setattr(namespace, self.dest, can_filters)
+
+
+class _BitTimingAction(argparse.Action):
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = None,
+    ) -> None:
+        if not isinstance(values, list):
+            raise argparse.ArgumentError(self, "Invalid --timing argument")
+
+        timing_dict: dict[str, int] = {}
+        for arg in values:
+            try:
+                key, value_string = arg.split("=")
+                value = int(value_string)
+                timing_dict[key] = value
+            except ValueError:
+                raise argparse.ArgumentError(
+                    self, f"Invalid timing argument: {arg}"
+                ) from None
+
+        if not (timing := _dict2timing(timing_dict)):
+            err_msg = "Invalid --timing argument. Incomplete parameters."
+            raise argparse.ArgumentError(self, err_msg)
+
+        setattr(namespace, self.dest, timing)
+        print(timing)
+
+
+class _BusKwargsAction(argparse.Action):
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Union[str, Sequence[Any], None],
+        option_string: Optional[str] = None,
+    ) -> None:
+        if not isinstance(values, list):
+            raise argparse.ArgumentError(self, "Invalid --bus-kwargs argument")
+
+        bus_kwargs: dict[str, Union[str, int, float, bool]] = {}
+
+        for arg in values:
+            try:
+                match = re.match(
+                    r"^(?P<name>[_a-zA-Z][_a-zA-Z0-9]*)=(?P<value>\S*?)$",
+                    arg,
+                )
+                if not match:
+                    raise ValueError
+                key = match["name"].replace("-", "_")
+                string_val = match["value"]
+                bus_kwargs[key] = cast_from_string(string_val)
+            except ValueError:
+                raise argparse.ArgumentError(
+                    self,
+                    f"Unable to parse bus keyword argument '{arg}'",
+                ) from None
+
+        setattr(namespace, self.dest, bus_kwargs)
+
+
+def _add_extra_args(
+    parser: Union[argparse.ArgumentParser, argparse._ArgumentGroup],
+) -> None:
+    parser.add_argument(
+        "extra_args",
+        nargs=argparse.REMAINDER,
+        help="The remaining arguments will be used for logger/player initialisation. "
+        "For example, `can_logger -i virtual -c test -f logfile.blf --compression-level=9` "
+        "passes the keyword argument `compression_level=9` to the BlfWriter.",
+    )
+
+
+def _parse_additional_config(unknown_args: Sequence[str]) -> TAdditionalCliArgs:
+    for arg in unknown_args:
+        if not re.match(r"^--[a-zA-Z][a-zA-Z0-9\-]*=\S*?$", arg):
+            raise ValueError(f"Parsing argument {arg} failed")
+
+    def _split_arg(_arg: str) -> tuple[str, str]:
+        left, right = _arg.split("=", 1)
+        return left.lstrip("-").replace("-", "_"), right
+
+    args: dict[str, Union[str, int, float, bool]] = {}
+    for key, string_val in map(_split_arg, unknown_args):
+        args[key] = cast_from_string(string_val)
+    return args
+
+
+def _set_logging_level_from_namespace(namespace: argparse.Namespace) -> None:
+    if "verbosity" in namespace:
+        logging_level_names = [
+            "critical",
+            "error",
+            "warning",
+            "info",
+            "debug",
+            "subdebug",
+        ]
+        can.set_logging_level(logging_level_names[min(5, namespace.verbosity)])

--- a/can/logger.py
+++ b/can/logger.py
@@ -1,203 +1,25 @@
 import argparse
 import errno
-import re
 import sys
-from collections.abc import Sequence
 from datetime import datetime
 from typing import (
     TYPE_CHECKING,
-    Any,
-    Optional,
     Union,
 )
 
-import can
-from can import Bus, BusState, Logger, SizedRotatingLogger
+from can import BusState, Logger, SizedRotatingLogger
+from can.cli import (
+    _add_extra_args,
+    _parse_additional_config,
+    _set_logging_level_from_namespace,
+    add_bus_arguments,
+    create_bus_from_namespace,
+)
 from can.typechecking import TAdditionalCliArgs
-from can.util import _dict2timing, cast_from_string
 
 if TYPE_CHECKING:
     from can.io import BaseRotatingLogger
     from can.io.generic import MessageWriter
-    from can.typechecking import CanFilter
-
-
-def _create_base_argument_parser(parser: argparse.ArgumentParser) -> None:
-    """Adds common options to an argument parser."""
-
-    parser.add_argument(
-        "-c",
-        "--channel",
-        help=r"Most backend interfaces require some sort of channel. For "
-        r"example with the serial interface the channel might be a rfcomm"
-        r' device: "/dev/rfcomm0". With the socketcan interface valid '
-        r'channel examples include: "can0", "vcan0".',
-    )
-
-    parser.add_argument(
-        "-i",
-        "--interface",
-        dest="interface",
-        help="""Specify the backend CAN interface to use. If left blank,
-                        fall back to reading from configuration files.""",
-        choices=sorted(can.VALID_INTERFACES),
-    )
-
-    parser.add_argument(
-        "-b", "--bitrate", type=int, help="Bitrate to use for the CAN bus."
-    )
-
-    parser.add_argument("--fd", help="Activate CAN-FD support", action="store_true")
-
-    parser.add_argument(
-        "--data_bitrate",
-        type=int,
-        help="Bitrate to use for the data phase in case of CAN-FD.",
-    )
-
-    parser.add_argument(
-        "--timing",
-        action=_BitTimingAction,
-        nargs=argparse.ONE_OR_MORE,
-        help="Configure bit rate and bit timing. For example, use "
-        "`--timing f_clock=8_000_000 tseg1=5 tseg2=2 sjw=2 brp=2 nof_samples=1` for classical CAN "
-        "or `--timing f_clock=80_000_000 nom_tseg1=119 nom_tseg2=40 nom_sjw=40 nom_brp=1 "
-        "data_tseg1=29 data_tseg2=10 data_sjw=10 data_brp=1` for CAN FD. "
-        "Check the python-can documentation to verify whether your "
-        "CAN interface supports the `timing` argument.",
-        metavar="TIMING_ARG",
-    )
-
-    parser.add_argument(
-        "extra_args",
-        nargs=argparse.REMAINDER,
-        help="The remaining arguments will be used for the interface and "
-        "logger/player initialisation. "
-        "For example, `-i vector -c 1 --app-name=MyCanApp` is the equivalent "
-        "to opening the bus with `Bus('vector', channel=1, app_name='MyCanApp')",
-    )
-
-
-def _append_filter_argument(
-    parser: Union[argparse.ArgumentParser, argparse._ArgumentGroup],
-    *args: str,
-    **kwargs: Any,
-) -> None:
-    """Adds the ``filter`` option to an argument parser."""
-
-    parser.add_argument(
-        *args,
-        "--filter",
-        help="R|Space separated CAN filters for the given CAN interface:"
-        "\n      <can_id>:<can_mask> (matches when <received_can_id> & mask =="
-        " can_id & mask)"
-        "\n      <can_id>~<can_mask> (matches when <received_can_id> & mask !="
-        " can_id & mask)"
-        "\nFx to show only frames with ID 0x100 to 0x103 and 0x200 to 0x20F:"
-        "\n      python -m can.viewer --filter 100:7FC 200:7F0"
-        "\nNote that the ID and mask are always interpreted as hex values",
-        metavar="{<can_id>:<can_mask>,<can_id>~<can_mask>}",
-        nargs=argparse.ONE_OR_MORE,
-        action=_CanFilterAction,
-        dest="can_filters",
-        **kwargs,
-    )
-
-
-def _create_bus(parsed_args: argparse.Namespace, **kwargs: Any) -> can.BusABC:
-    logging_level_names = ["critical", "error", "warning", "info", "debug", "subdebug"]
-    can.set_logging_level(logging_level_names[min(5, parsed_args.verbosity)])
-
-    config: dict[str, Any] = {"single_handle": True, **kwargs}
-    if parsed_args.interface:
-        config["interface"] = parsed_args.interface
-    if parsed_args.bitrate:
-        config["bitrate"] = parsed_args.bitrate
-    if parsed_args.fd:
-        config["fd"] = True
-    if parsed_args.data_bitrate:
-        config["data_bitrate"] = parsed_args.data_bitrate
-    if getattr(parsed_args, "can_filters", None):
-        config["can_filters"] = parsed_args.can_filters
-    if parsed_args.timing:
-        config["timing"] = parsed_args.timing
-
-    return Bus(parsed_args.channel, **config)
-
-
-class _CanFilterAction(argparse.Action):
-    def __call__(
-        self,
-        parser: argparse.ArgumentParser,
-        namespace: argparse.Namespace,
-        values: Union[str, Sequence[Any], None],
-        option_string: Optional[str] = None,
-    ) -> None:
-        if not isinstance(values, list):
-            raise argparse.ArgumentError(None, "Invalid filter argument")
-
-        print(f"Adding filter(s): {values}")
-        can_filters: list[CanFilter] = []
-
-        for filt in values:
-            if ":" in filt:
-                parts = filt.split(":")
-                can_id = int(parts[0], base=16)
-                can_mask = int(parts[1], base=16)
-            elif "~" in filt:
-                parts = filt.split("~")
-                can_id = int(parts[0], base=16) | 0x20000000  # CAN_INV_FILTER
-                can_mask = int(parts[1], base=16) & 0x20000000  # socket.CAN_ERR_FLAG
-            else:
-                raise argparse.ArgumentError(None, "Invalid filter argument")
-            can_filters.append({"can_id": can_id, "can_mask": can_mask})
-
-        setattr(namespace, self.dest, can_filters)
-
-
-class _BitTimingAction(argparse.Action):
-    def __call__(
-        self,
-        parser: argparse.ArgumentParser,
-        namespace: argparse.Namespace,
-        values: Union[str, Sequence[Any], None],
-        option_string: Optional[str] = None,
-    ) -> None:
-        if not isinstance(values, list):
-            raise argparse.ArgumentError(None, "Invalid --timing argument")
-
-        timing_dict: dict[str, int] = {}
-        for arg in values:
-            try:
-                key, value_string = arg.split("=")
-                value = int(value_string)
-                timing_dict[key] = value
-            except ValueError:
-                raise argparse.ArgumentError(
-                    None, f"Invalid timing argument: {arg}"
-                ) from None
-
-        if not (timing := _dict2timing(timing_dict)):
-            err_msg = "Invalid --timing argument. Incomplete parameters."
-            raise argparse.ArgumentError(None, err_msg)
-
-        setattr(namespace, self.dest, timing)
-        print(timing)
-
-
-def _parse_additional_config(unknown_args: Sequence[str]) -> TAdditionalCliArgs:
-    for arg in unknown_args:
-        if not re.match(r"^--[a-zA-Z][a-zA-Z0-9\-]*=\S*?$", arg):
-            raise ValueError(f"Parsing argument {arg} failed")
-
-    def _split_arg(_arg: str) -> tuple[str, str]:
-        left, right = _arg.split("=", 1)
-        return left.lstrip("-").replace("-", "_"), right
-
-    args: dict[str, Union[str, int, float, bool]] = {}
-    for key, string_val in map(_split_arg, unknown_args):
-        args[key] = cast_from_string(string_val)
-    return args
 
 
 def _parse_logger_args(
@@ -210,11 +32,9 @@ def _parse_logger_args(
         "given file.",
     )
 
-    # Generate the standard arguments:
-    # Channel, bitrate, data_bitrate, interface, app_name, CAN-FD support
-    _create_base_argument_parser(parser)
+    logger_group = parser.add_argument_group("logger arguments")
 
-    parser.add_argument(
+    logger_group.add_argument(
         "-f",
         "--file_name",
         dest="log_file",
@@ -222,7 +42,7 @@ def _parse_logger_args(
         default=None,
     )
 
-    parser.add_argument(
+    logger_group.add_argument(
         "-a",
         "--append",
         dest="append",
@@ -230,7 +50,7 @@ def _parse_logger_args(
         action="store_true",
     )
 
-    parser.add_argument(
+    logger_group.add_argument(
         "-s",
         "--file_size",
         dest="file_size",
@@ -242,7 +62,7 @@ def _parse_logger_args(
         default=None,
     )
 
-    parser.add_argument(
+    logger_group.add_argument(
         "-v",
         action="count",
         dest="verbosity",
@@ -251,9 +71,7 @@ def _parse_logger_args(
         default=2,
     )
 
-    _append_filter_argument(parser)
-
-    state_group = parser.add_mutually_exclusive_group(required=False)
+    state_group = logger_group.add_mutually_exclusive_group(required=False)
     state_group.add_argument(
         "--active",
         help="Start the bus as active, this is applied by default.",
@@ -262,6 +80,12 @@ def _parse_logger_args(
     state_group.add_argument(
         "--passive", help="Start the bus as passive.", action="store_true"
     )
+
+    # handle remaining arguments
+    _add_extra_args(logger_group)
+
+    # add bus options
+    add_bus_arguments(parser, filter_arg=True)
 
     # print help message when no arguments were given
     if not args:
@@ -275,7 +99,8 @@ def _parse_logger_args(
 
 def main() -> None:
     results, additional_config = _parse_logger_args(sys.argv[1:])
-    bus = _create_bus(results, **additional_config)
+    bus = create_bus_from_namespace(results)
+    _set_logging_level_from_namespace(results)
 
     if results.active:
         bus.state = BusState.ACTIVE

--- a/can/player.py
+++ b/can/player.py
@@ -12,8 +12,13 @@ from datetime import datetime
 from typing import TYPE_CHECKING, cast
 
 from can import LogReader, MessageSync
-
-from .logger import _create_base_argument_parser, _create_bus, _parse_additional_config
+from can.cli import (
+    _add_extra_args,
+    _parse_additional_config,
+    _set_logging_level_from_namespace,
+    add_bus_arguments,
+    create_bus_from_namespace,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -24,9 +29,9 @@ if TYPE_CHECKING:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Replay CAN traffic.")
 
-    _create_base_argument_parser(parser)
+    player_group = parser.add_argument_group("Player arguments")
 
-    parser.add_argument(
+    player_group.add_argument(
         "-f",
         "--file_name",
         dest="log_file",
@@ -34,7 +39,7 @@ def main() -> None:
         default=None,
     )
 
-    parser.add_argument(
+    player_group.add_argument(
         "-v",
         action="count",
         dest="verbosity",
@@ -43,27 +48,27 @@ def main() -> None:
         default=2,
     )
 
-    parser.add_argument(
+    player_group.add_argument(
         "--ignore-timestamps",
         dest="timestamps",
         help="""Ignore timestamps (send all frames immediately with minimum gap between frames)""",
         action="store_false",
     )
 
-    parser.add_argument(
+    player_group.add_argument(
         "--error-frames",
         help="Also send error frames to the interface.",
         action="store_true",
     )
 
-    parser.add_argument(
+    player_group.add_argument(
         "-g",
         "--gap",
         type=float,
         help="<s> minimum time between replayed frames",
         default=0.0001,
     )
-    parser.add_argument(
+    player_group.add_argument(
         "-s",
         "--skip",
         type=float,
@@ -71,12 +76,18 @@ def main() -> None:
         help="<s> skip gaps greater than 's' seconds",
     )
 
-    parser.add_argument(
+    player_group.add_argument(
         "infile",
         metavar="input-file",
         type=str,
         help="The file to replay. For supported types see can.LogReader.",
     )
+
+    # handle remaining arguments
+    _add_extra_args(player_group)
+
+    # add bus options
+    add_bus_arguments(parser)
 
     # print help message when no arguments were given
     if len(sys.argv) < 2:
@@ -86,11 +97,12 @@ def main() -> None:
     results, unknown_args = parser.parse_known_args()
     additional_config = _parse_additional_config([*results.extra_args, *unknown_args])
 
+    _set_logging_level_from_namespace(results)
     verbosity = results.verbosity
 
     error_frames = results.error_frames
 
-    with _create_bus(results, **additional_config) as bus:
+    with create_bus_from_namespace(results) as bus:
         with LogReader(results.infile, **additional_config) as reader:
             in_sync = MessageSync(
                 cast("Iterable[Message]", reader),

--- a/doc/utils.rst
+++ b/doc/utils.rst
@@ -4,4 +4,7 @@ Utilities
 
 .. autofunction:: can.detect_available_configs
 
+.. autofunction:: can.cli.add_bus_arguments
+
+.. autofunction:: can.cli.create_bus_from_namespace
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,8 +182,10 @@ ignore = [
     "PGH003",  # blanket-type-ignore
     "RUF012",  # mutable-class-default
 ]
+"can/cli.py" = ["T20"]  # flake8-print
 "can/logger.py" = ["T20"]  # flake8-print
 "can/player.py" = ["T20"]  # flake8-print
+"can/viewer.py" = ["T20"]  # flake8-print
 "examples/*" = ["T20"]  # flake8-print
 
 [tool.ruff.lint.isort]

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,154 @@
+import argparse
+import unittest
+from unittest.mock import patch
+
+from can.cli import add_bus_arguments, create_bus_from_namespace
+
+
+class TestCliUtils(unittest.TestCase):
+    def test_add_bus_arguments(self):
+        parser = argparse.ArgumentParser()
+        add_bus_arguments(parser, filter_arg=True, prefix="test")
+
+        parsed_args = parser.parse_args(
+            [
+                "--test-channel",
+                "0",
+                "--test-interface",
+                "vector",
+                "--test-timing",
+                "f_clock=8000000",
+                "brp=4",
+                "tseg1=11",
+                "tseg2=4",
+                "sjw=2",
+                "nof_samples=3",
+                "--test-filter",
+                "100:7FF",
+                "200~7F0",
+                "--test-bus-kwargs",
+                "app_name=MyApp",
+                "serial=1234",
+            ]
+        )
+
+        self.assertNotIn("channel", parsed_args)
+        self.assertNotIn("test_bitrate", parsed_args)
+        self.assertNotIn("test_data_bitrate", parsed_args)
+        self.assertNotIn("test_fd", parsed_args)
+
+        self.assertEqual(parsed_args.test_channel, "0")
+        self.assertEqual(parsed_args.test_interface, "vector")
+        self.assertEqual(parsed_args.test_timing.f_clock, 8000000)
+        self.assertEqual(parsed_args.test_timing.brp, 4)
+        self.assertEqual(parsed_args.test_timing.tseg1, 11)
+        self.assertEqual(parsed_args.test_timing.tseg2, 4)
+        self.assertEqual(parsed_args.test_timing.sjw, 2)
+        self.assertEqual(parsed_args.test_timing.nof_samples, 3)
+        self.assertEqual(len(parsed_args.test_can_filters), 2)
+        self.assertEqual(parsed_args.test_can_filters[0]["can_id"], 0x100)
+        self.assertEqual(parsed_args.test_can_filters[0]["can_mask"], 0x7FF)
+        self.assertEqual(parsed_args.test_can_filters[1]["can_id"], 0x200 | 0x20000000)
+        self.assertEqual(
+            parsed_args.test_can_filters[1]["can_mask"], 0x7F0 & 0x20000000
+        )
+        self.assertEqual(parsed_args.test_bus_kwargs["app_name"], "MyApp")
+        self.assertEqual(parsed_args.test_bus_kwargs["serial"], 1234)
+
+    def test_add_bus_arguments_no_prefix(self):
+        parser = argparse.ArgumentParser()
+        add_bus_arguments(parser, filter_arg=True)
+
+        parsed_args = parser.parse_args(
+            [
+                "--channel",
+                "0",
+                "--interface",
+                "vector",
+                "--timing",
+                "f_clock=8000000",
+                "brp=4",
+                "tseg1=11",
+                "tseg2=4",
+                "sjw=2",
+                "nof_samples=3",
+                "--filter",
+                "100:7FF",
+                "200~7F0",
+                "--bus-kwargs",
+                "app_name=MyApp",
+                "serial=1234",
+            ]
+        )
+
+        self.assertEqual(parsed_args.channel, "0")
+        self.assertEqual(parsed_args.interface, "vector")
+        self.assertEqual(parsed_args.timing.f_clock, 8000000)
+        self.assertEqual(parsed_args.timing.brp, 4)
+        self.assertEqual(parsed_args.timing.tseg1, 11)
+        self.assertEqual(parsed_args.timing.tseg2, 4)
+        self.assertEqual(parsed_args.timing.sjw, 2)
+        self.assertEqual(parsed_args.timing.nof_samples, 3)
+        self.assertEqual(len(parsed_args.can_filters), 2)
+        self.assertEqual(parsed_args.can_filters[0]["can_id"], 0x100)
+        self.assertEqual(parsed_args.can_filters[0]["can_mask"], 0x7FF)
+        self.assertEqual(parsed_args.can_filters[1]["can_id"], 0x200 | 0x20000000)
+        self.assertEqual(parsed_args.can_filters[1]["can_mask"], 0x7F0 & 0x20000000)
+        self.assertEqual(parsed_args.bus_kwargs["app_name"], "MyApp")
+        self.assertEqual(parsed_args.bus_kwargs["serial"], 1234)
+
+    @patch("can.Bus")
+    def test_create_bus_from_namespace(self, mock_bus):
+        namespace = argparse.Namespace(
+            test_channel="vcan0",
+            test_interface="virtual",
+            test_bitrate=500000,
+            test_data_bitrate=2000000,
+            test_fd=True,
+            test_can_filters=[{"can_id": 0x100, "can_mask": 0x7FF}],
+            test_bus_kwargs={"app_name": "MyApp", "serial": 1234},
+        )
+
+        create_bus_from_namespace(namespace, prefix="test")
+
+        mock_bus.assert_called_once_with(
+            channel="vcan0",
+            interface="virtual",
+            bitrate=500000,
+            data_bitrate=2000000,
+            fd=True,
+            can_filters=[{"can_id": 0x100, "can_mask": 0x7FF}],
+            app_name="MyApp",
+            serial=1234,
+            single_handle=True,
+        )
+
+    @patch("can.Bus")
+    def test_create_bus_from_namespace_no_prefix(self, mock_bus):
+        namespace = argparse.Namespace(
+            channel="vcan0",
+            interface="virtual",
+            bitrate=500000,
+            data_bitrate=2000000,
+            fd=True,
+            can_filters=[{"can_id": 0x100, "can_mask": 0x7FF}],
+            bus_kwargs={"app_name": "MyApp", "serial": 1234},
+        )
+
+        create_bus_from_namespace(namespace)
+
+        mock_bus.assert_called_once_with(
+            channel="vcan0",
+            interface="virtual",
+            bitrate=500000,
+            data_bitrate=2000000,
+            fd=True,
+            can_filters=[{"can_id": 0x100, "can_mask": 0x7FF}],
+            app_name="MyApp",
+            serial=1234,
+            single_handle=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -14,6 +14,7 @@ from unittest.mock import Mock
 import pytest
 
 import can
+import can.cli
 import can.logger
 
 
@@ -89,7 +90,7 @@ class TestLoggerScriptModule(unittest.TestCase):
             "--bitrate",
             "250000",
             "--fd",
-            "--data_bitrate",
+            "--data-bitrate",
             "2000000",
         ]
         can.logger.main()
@@ -111,7 +112,7 @@ class TestLoggerScriptModule(unittest.TestCase):
             "--bitrate",
             "250000",
             "--fd",
-            "--data_bitrate",
+            "--data-bitrate",
             "2000000",
             "--receive-own-messages=True",
         ]
@@ -205,7 +206,7 @@ class TestLoggerScriptModule(unittest.TestCase):
             "--offset=1.5",
             "--tseg1-abr=127",
         ]
-        parsed_args = can.logger._parse_additional_config(unknown_args)
+        parsed_args = can.cli._parse_additional_config(unknown_args)
 
         assert "app_name" in parsed_args
         assert parsed_args["app_name"] == "CANalyzer"
@@ -232,16 +233,16 @@ class TestLoggerScriptModule(unittest.TestCase):
         assert parsed_args["tseg1_abr"] == 127
 
         with pytest.raises(ValueError):
-            can.logger._parse_additional_config(["--wrong-format"])
+            can.cli._parse_additional_config(["--wrong-format"])
 
         with pytest.raises(ValueError):
-            can.logger._parse_additional_config(["-wrongformat=value"])
+            can.cli._parse_additional_config(["-wrongformat=value"])
 
         with pytest.raises(ValueError):
-            can.logger._parse_additional_config(["--wrongformat=value1 value2"])
+            can.cli._parse_additional_config(["--wrongformat=value1 value2"])
 
         with pytest.raises(ValueError):
-            can.logger._parse_additional_config(["wrongformat="])
+            can.cli._parse_additional_config(["wrongformat="])
 
 
 class TestLoggerCompressedFile(unittest.TestCase):

--- a/test/test_viewer.py
+++ b/test/test_viewer.py
@@ -397,19 +397,19 @@ class CanViewerTest(unittest.TestCase):
             )
 
     def test_parse_args(self):
-        parsed_args, _, _ = _parse_viewer_args(["-b", "250000"])
+        parsed_args, _ = _parse_viewer_args(["-b", "250000"])
         self.assertEqual(parsed_args.bitrate, 250000)
 
-        parsed_args, _, _ = _parse_viewer_args(["--bitrate", "500000"])
+        parsed_args, _ = _parse_viewer_args(["--bitrate", "500000"])
         self.assertEqual(parsed_args.bitrate, 500000)
 
-        parsed_args, _, _ = _parse_viewer_args(["-c", "can0"])
+        parsed_args, _ = _parse_viewer_args(["-c", "can0"])
         self.assertEqual(parsed_args.channel, "can0")
 
-        parsed_args, _, _ = _parse_viewer_args(["--channel", "PCAN_USBBUS1"])
+        parsed_args, _ = _parse_viewer_args(["--channel", "PCAN_USBBUS1"])
         self.assertEqual(parsed_args.channel, "PCAN_USBBUS1")
 
-        parsed_args, data_structs, _ = _parse_viewer_args(["-d", "100:<L"])
+        parsed_args, data_structs = _parse_viewer_args(["-d", "100:<L"])
         self.assertEqual(parsed_args.decode, ["100:<L"])
 
         self.assertIsInstance(data_structs, dict)
@@ -422,7 +422,7 @@ class CanViewerTest(unittest.TestCase):
         f = open("test.txt", "w")
         f.write("100:<BB\n101:<HH\n")
         f.close()
-        parsed_args, data_structs, _ = _parse_viewer_args(["-d", "test.txt"])
+        parsed_args, data_structs = _parse_viewer_args(["-d", "test.txt"])
 
         self.assertIsInstance(data_structs, dict)
         self.assertEqual(len(data_structs), 2)
@@ -436,7 +436,7 @@ class CanViewerTest(unittest.TestCase):
         self.assertEqual(data_structs[0x101].size, 4)
         os.remove("test.txt")
 
-        parsed_args, data_structs, _ = _parse_viewer_args(
+        parsed_args, data_structs = _parse_viewer_args(
             ["--decode", "100:<LH:10.:100.", "101:<ff", "102:<Bf:1:57.3"]
         )
         self.assertEqual(
@@ -469,13 +469,13 @@ class CanViewerTest(unittest.TestCase):
         self.assertEqual(data_structs[0x102][1], 1)
         self.assertAlmostEqual(data_structs[0x102][2], 57.3)
 
-        parsed_args, _, _ = _parse_viewer_args(["-f", "100:7FF"])
+        parsed_args, _ = _parse_viewer_args(["--filter", "100:7FF"])
         self.assertIsInstance(parsed_args.can_filters, list)
         self.assertIsInstance(parsed_args.can_filters[0], dict)
         self.assertEqual(parsed_args.can_filters[0]["can_id"], 0x100)
         self.assertEqual(parsed_args.can_filters[0]["can_mask"], 0x7FF)
 
-        parsed_args, _, _ = _parse_viewer_args(["-f", "101:7FF", "102:7FC"])
+        parsed_args, _ = _parse_viewer_args(["--filter", "101:7FF", "102:7FC"])
         self.assertIsInstance(parsed_args.can_filters, list)
         self.assertIsInstance(parsed_args.can_filters[0], dict)
         self.assertIsInstance(parsed_args.can_filters[1], dict)
@@ -485,18 +485,18 @@ class CanViewerTest(unittest.TestCase):
         self.assertEqual(parsed_args.can_filters[1]["can_mask"], 0x7FC)
 
         with self.assertRaises(SystemExit):
-            _parse_viewer_args(["-f", "101,7FF"])
+            _parse_viewer_args(["--filter", "101,7FF"])
 
-        parsed_args, _, _ = _parse_viewer_args(["--filter", "100~7FF"])
+        parsed_args, _ = _parse_viewer_args(["--filter", "100~7FF"])
         self.assertIsInstance(parsed_args.can_filters, list)
         self.assertIsInstance(parsed_args.can_filters[0], dict)
         self.assertEqual(parsed_args.can_filters[0]["can_id"], 0x100 | 0x20000000)
         self.assertEqual(parsed_args.can_filters[0]["can_mask"], 0x7FF & 0x20000000)
 
-        parsed_args, _, _ = _parse_viewer_args(["-i", "socketcan"])
+        parsed_args, _ = _parse_viewer_args(["-i", "socketcan"])
         self.assertEqual(parsed_args.interface, "socketcan")
 
-        parsed_args, _, _ = _parse_viewer_args(["--interface", "pcan"])
+        parsed_args, _ = _parse_viewer_args(["--interface", "pcan"])
         self.assertEqual(parsed_args.interface, "pcan")
 
         # Make sure it exits with the correct error code when displaying the help page


### PR DESCRIPTION
Currently downstream packages need their own logic to configure python-can buses. With `add_bus_arguments()` they can just add our options to their `argparse.ArgumentParser`.

This also enables setup of multiple bus instances from command line via prefixes (may be helpful for #1923).