### PR TITLE
Improve `can.io.*` type hierarchy and annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.13"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/can/_entry_points.py
+++ b/can/_entry_points.py
@@ -30,5 +30,5 @@ else:
     def read_entry_points(group: str) -> list[_EntryPoint]:
         return [
             _EntryPoint(ep.name, *ep.value.split(":", maxsplit=1))
-            for ep in entry_points().get(group, [])
+            for ep in entry_points().get(group, [])  # pylint: disable=no-member
         ]

--- a/can/io/asc.py
+++ b/can/io/asc.py
@@ -39,8 +39,6 @@ class ASCReader(TextIOMessageReader):
     bus statistics, J1939 Transport Protocol messages) is ignored.
     """
 
-    file: TextIO
-
     def __init__(
         self,
         file: Union[StringPathLike, TextIO],
@@ -321,8 +319,6 @@ class ASCWriter(TextIOMessageWriter):
     it gets assigned the timestamp that was written for the last message.
     It the first message does not have a timestamp, it is set to zero.
     """
-
-    file: TextIO
 
     FORMAT_MESSAGE = "{channel}  {id:<15} {dir:<4} {dtype} {data}"
     FORMAT_MESSAGE_FD = " ".join(

--- a/can/io/canutils.py
+++ b/can/io/canutils.py
@@ -6,7 +6,7 @@ It is is compatible with "candump -L" from the canutils program
 
 import logging
 from collections.abc import Generator
-from typing import Any, TextIO, Union
+from typing import Any, Optional, TextIO, Union
 
 from can.message import Message
 
@@ -33,8 +33,6 @@ class CanutilsLogReader(TextIOMessageReader):
 
         ``(0.0) vcan0 001#8d00100100820100``
     """
-
-    file: TextIO
 
     def __init__(
         self,
@@ -148,13 +146,12 @@ class CanutilsLogWriter(TextIOMessageWriter):
         :param bool append: if set to `True` messages are appended to
                             the file, else the file is truncated
         """
-        mode = "a" if append else "w"
-        super().__init__(file, mode=mode)
+        super().__init__(file, mode="a" if append else "w")
 
         self.channel = channel
-        self.last_timestamp = None
+        self.last_timestamp: Optional[float] = None
 
-    def on_message_received(self, msg):
+    def on_message_received(self, msg: Message) -> None:
         # this is the case for the very first message:
         if self.last_timestamp is None:
             self.last_timestamp = msg.timestamp or 0.0

--- a/can/io/csv.py
+++ b/can/io/csv.py
@@ -28,8 +28,6 @@ class CSVReader(TextIOMessageReader):
     Any line separator is accepted.
     """
 
-    file: TextIO
-
     def __init__(
         self,
         file: Union[StringPathLike, TextIO],
@@ -89,8 +87,6 @@ class CSVWriter(TextIOMessageWriter):
     Each line is terminated with a platform specific line separator.
     """
 
-    file: TextIO
-
     def __init__(
         self,
         file: Union[StringPathLike, TextIO],
@@ -106,8 +102,7 @@ class CSVWriter(TextIOMessageWriter):
                             the file is truncated and starts with a newly
                             written header line
         """
-        mode = "a" if append else "w"
-        super().__init__(file, mode=mode)
+        super().__init__(file, mode="a" if append else "w")
 
         # Write a header row
         if not append:

--- a/can/io/generic.py
+++ b/can/io/generic.py
@@ -1,69 +1,187 @@
-"""Contains generic base classes for file IO."""
+"""This module provides abstract base classes for CAN message reading and writing operations
+to various file formats.
 
-import gzip
+.. note::
+    All classes in this module are abstract and should be subclassed to implement
+    specific file format handling.
+"""
+
 import locale
-from abc import ABCMeta
+import os
+from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from contextlib import AbstractContextManager
+from io import BufferedIOBase, TextIOWrapper
+from pathlib import Path
 from types import TracebackType
 from typing import (
+    TYPE_CHECKING,
     Any,
     BinaryIO,
+    Generic,
     Literal,
     Optional,
     TextIO,
+    TypeVar,
     Union,
-    cast,
 )
 
 from typing_extensions import Self
 
-from .. import typechecking
 from ..listener import Listener
 from ..message import Message
+from ..typechecking import FileLike, StringPathLike
+
+if TYPE_CHECKING:
+    from _typeshed import (
+        OpenBinaryModeReading,
+        OpenBinaryModeUpdating,
+        OpenBinaryModeWriting,
+        OpenTextModeReading,
+        OpenTextModeUpdating,
+        OpenTextModeWriting,
+    )
 
 
-class BaseIOHandler(AbstractContextManager):
-    """A generic file handler that can be used for reading and writing.
+#: type parameter used in generic classes :class:`MessageReader` and :class:`MessageWriter`
+_IoTypeVar = TypeVar("_IoTypeVar", bound=FileLike)
 
-    Can be used as a context manager.
 
-    :attr file:
-        the file-like object that is kept internally, or `None` if none
-        was opened
+class MessageWriter(AbstractContextManager["MessageWriter"], Listener, ABC):
+    """Abstract base class for all CAN message writers.
+
+    This class serves as a foundation for implementing different message writer formats.
+    It combines context manager capabilities with the message listener interface.
+
+    :param file: Path-like object or string representing the output file location
+    :param kwargs: Additional keyword arguments for specific writer implementations
     """
 
-    file: Optional[typechecking.FileLike]
+    @abstractmethod
+    def __init__(self, file: StringPathLike, **kwargs: Any) -> None:
+        pass
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Stop handling messages and cleanup any resources."""
+
+    def __enter__(self) -> Self:
+        """Enter the context manager."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> Literal[False]:
+        """Exit the context manager and ensure proper cleanup."""
+        self.stop()
+        return False
+
+
+class SizedMessageWriter(MessageWriter, ABC):
+    """Abstract base class for message writers that can report their file size.
+
+    This class extends :class:`MessageWriter` with the ability to determine the size
+    of the output file.
+    """
+
+    @abstractmethod
+    def file_size(self) -> int:
+        """Get the current size of the output file in bytes.
+
+        :return: The size of the file in bytes
+        :rtype: int
+        """
+
+
+class FileIOMessageWriter(SizedMessageWriter, Generic[_IoTypeVar]):
+    """Base class for writers that operate on file descriptors.
+
+    This class provides common functionality for writers that work with file objects.
+
+    :param file: A path-like object or file object to write to
+    :param kwargs: Additional keyword arguments for specific writer implementations
+
+    :ivar file: The file object being written to
+    """
+
+    file: _IoTypeVar
+
+    @abstractmethod
+    def __init__(self, file: Union[StringPathLike, _IoTypeVar], **kwargs: Any) -> None:
+        pass
+
+    def stop(self) -> None:
+        """Close the file and stop writing."""
+        self.file.close()
+
+    def file_size(self) -> int:
+        """Get the current file size."""
+        return self.file.tell()
+
+
+class TextIOMessageWriter(FileIOMessageWriter[Union[TextIO, TextIOWrapper]], ABC):
+    """Text-based message writer implementation.
+
+    :param file: Text file to write to
+    :param mode: File open mode for text operations
+    :param kwargs: Additional arguments like encoding
+    """
 
     def __init__(
         self,
-        file: Optional[typechecking.AcceptedIOType],
-        mode: str = "rt",
+        file: Union[StringPathLike, TextIO, TextIOWrapper],
+        mode: "Union[OpenTextModeUpdating, OpenTextModeWriting]" = "w",
         **kwargs: Any,
     ) -> None:
-        """
-        :param file: a path-like object to open a file, a file-like object
-                     to be used as a file or `None` to not use a file at all
-        :param mode: the mode that should be used to open the file, see
-                     :func:`open`, ignored if *file* is `None`
-        """
-        if file is None or (hasattr(file, "read") and hasattr(file, "write")):
-            # file is None or some file-like object
-            self.file = cast("Optional[typechecking.FileLike]", file)
-        else:
-            encoding: Optional[str] = (
-                None
-                if "b" in mode
-                else kwargs.get("encoding", locale.getpreferredencoding(False))
-            )
+        if isinstance(file, (str, os.PathLike)):
+            encoding: str = kwargs.get("encoding", locale.getpreferredencoding(False))
             # pylint: disable=consider-using-with
-            # file is some path-like object
-            self.file = cast(
-                "typechecking.FileLike", open(file, mode, encoding=encoding)
-            )
+            self.file = Path(file).open(mode=mode, encoding=encoding)
+        else:
+            self.file = file
 
-        # for multiple inheritance
-        super().__init__()
+
+class BinaryIOMessageWriter(FileIOMessageWriter[Union[BinaryIO, BufferedIOBase]], ABC):
+    """Binary file message writer implementation.
+
+    :param file: Binary file to write to
+    :param mode: File open mode for binary operations
+    :param kwargs: Additional implementation specific arguments
+    """
+
+    def __init__(
+        self,
+        file: Union[StringPathLike, BinaryIO, BufferedIOBase],
+        mode: "Union[OpenBinaryModeUpdating, OpenBinaryModeWriting]" = "wb",
+        **kwargs: Any,
+    ) -> None:
+        if isinstance(file, (str, os.PathLike)):
+            # pylint: disable=consider-using-with,unspecified-encoding
+            self.file = Path(file).open(mode=mode)
+        else:
+            self.file = file
+
+
+class MessageReader(AbstractContextManager["MessageReader"], Iterable[Message], ABC):
+    """Abstract base class for all CAN message readers.
+
+    This class serves as a foundation for implementing different message reader formats.
+    It combines context manager capabilities with iteration interface.
+
+    :param file: Path-like object or string representing the input file location
+    :param kwargs: Additional keyword arguments for specific reader implementations
+    """
+
+    @abstractmethod
+    def __init__(self, file: StringPathLike, **kwargs: Any) -> None:
+        pass
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Stop reading messages and cleanup any resources."""
 
     def __enter__(self) -> Self:
         return self
@@ -71,59 +189,72 @@ class BaseIOHandler(AbstractContextManager):
     def __exit__(
         self,
         exc_type: Optional[type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
     ) -> Literal[False]:
         self.stop()
         return False
 
+
+class FileIOMessageReader(MessageReader, Generic[_IoTypeVar]):
+    """Base class for readers that operate on file descriptors.
+
+    This class provides common functionality for readers that work with file objects.
+
+    :param file: A path-like object or file object to read from
+    :param kwargs: Additional keyword arguments for specific reader implementations
+
+    :ivar file: The file object being read from
+    """
+
+    file: _IoTypeVar
+
+    @abstractmethod
+    def __init__(self, file: Union[StringPathLike, _IoTypeVar], **kwargs: Any) -> None:
+        pass
+
     def stop(self) -> None:
-        """Closes the underlying file-like object and flushes it, if it was opened in write mode."""
-        if self.file is not None:
-            # this also implies a flush()
-            self.file.close()
+        self.file.close()
 
 
-class MessageWriter(BaseIOHandler, Listener, metaclass=ABCMeta):
-    """The base class for all writers."""
+class TextIOMessageReader(FileIOMessageReader[Union[TextIO, TextIOWrapper]], ABC):
+    """Text-based message reader implementation.
 
-    file: Optional[typechecking.FileLike]
-
-
-class FileIOMessageWriter(MessageWriter, metaclass=ABCMeta):
-    """A specialized base class for all writers with file descriptors."""
-
-    file: typechecking.FileLike
+    :param file: Text file to read from
+    :param mode: File open mode for text operations
+    :param kwargs: Additional arguments like encoding
+    """
 
     def __init__(
-        self, file: typechecking.AcceptedIOType, mode: str = "wt", **kwargs: Any
+        self,
+        file: Union[StringPathLike, TextIO, TextIOWrapper],
+        mode: "OpenTextModeReading" = "r",
+        **kwargs: Any,
     ) -> None:
-        # Not possible with the type signature, but be verbose for user-friendliness
-        if file is None:
-            raise ValueError("The given file cannot be None")
-
-        super().__init__(file, mode, **kwargs)
-
-    def file_size(self) -> int:
-        """Return an estimate of the current file size in bytes."""
-        return self.file.tell()
+        if isinstance(file, (str, os.PathLike)):
+            encoding: str = kwargs.get("encoding", locale.getpreferredencoding(False))
+            # pylint: disable=consider-using-with
+            self.file = Path(file).open(mode=mode, encoding=encoding)
+        else:
+            self.file = file
 
 
-class TextIOMessageWriter(FileIOMessageWriter, metaclass=ABCMeta):
-    file: TextIO
+class BinaryIOMessageReader(FileIOMessageReader[Union[BinaryIO, BufferedIOBase]], ABC):
+    """Binary file message reader implementation.
 
+    :param file: Binary file to read from
+    :param mode: File open mode for binary operations
+    :param kwargs: Additional implementation specific arguments
+    """
 
-class BinaryIOMessageWriter(FileIOMessageWriter, metaclass=ABCMeta):
-    file: Union[BinaryIO, gzip.GzipFile]
-
-
-class MessageReader(BaseIOHandler, Iterable[Message], metaclass=ABCMeta):
-    """The base class for all readers."""
-
-
-class TextIOMessageReader(MessageReader, metaclass=ABCMeta):
-    file: TextIO
-
-
-class BinaryIOMessageReader(MessageReader, metaclass=ABCMeta):
-    file: Union[BinaryIO, gzip.GzipFile]
+    def __init__(
+        self,
+        file: Union[StringPathLike, BinaryIO, BufferedIOBase],
+        mode: "OpenBinaryModeReading" = "rb",
+        **kwargs: Any,
+    ) -> None:
+        if isinstance(file, (str, os.PathLike)):
+            # pylint: disable=consider-using-with,unspecified-encoding
+            self.file = Path(file).open(mode=mode)
+        else:
+            self.file = file

--- a/can/io/player.py
+++ b/can/io/player.py
@@ -11,17 +11,16 @@ from collections.abc import Generator, Iterable
 from typing import (
     Any,
     Final,
-    Union,
 )
 
 from .._entry_points import read_entry_points
 from ..message import Message
-from ..typechecking import AcceptedIOType, FileLike, StringPathLike
+from ..typechecking import StringPathLike
 from .asc import ASCReader
 from .blf import BLFReader
 from .canutils import CanutilsLogReader
 from .csv import CSVReader
-from .generic import BinaryIOMessageReader, MessageReader
+from .generic import BinaryIOMessageReader, MessageReader, TextIOMessageReader
 from .mf4 import MF4Reader
 from .sqlite import SqliteReader
 from .trc import TRCReader
@@ -58,24 +57,25 @@ def _get_logger_for_suffix(suffix: str) -> type[MessageReader]:
         raise ValueError(f'No read support for unknown log format "{suffix}"') from None
 
 
-def _decompress(
-    filename: StringPathLike,
-) -> tuple[type[MessageReader], Union[str, FileLike]]:
+def _decompress(filename: StringPathLike, **kwargs: Any) -> MessageReader:
     """
     Return the suffix and io object of the decompressed file.
     """
     suffixes = pathlib.Path(filename).suffixes
     if len(suffixes) != 2:
         raise ValueError(
-            f"No write support for unknown log format \"{''.join(suffixes)}\""
-        ) from None
+            f"No read support for unknown log format \"{''.join(suffixes)}\""
+        )
 
     real_suffix = suffixes[-2].lower()
     reader_type = _get_logger_for_suffix(real_suffix)
 
-    mode = "rb" if issubclass(reader_type, BinaryIOMessageReader) else "rt"
+    if issubclass(reader_type, TextIOMessageReader):
+        return reader_type(gzip.open(filename, mode="rt"), **kwargs)
+    elif issubclass(reader_type, BinaryIOMessageReader):
+        return reader_type(gzip.open(filename, mode="rb"), **kwargs)
 
-    return reader_type, gzip.open(filename, mode)
+    raise ValueError(f"No read support for unknown log format \"{''.join(suffixes)}\"")
 
 
 def LogReader(filename: StringPathLike, **kwargs: Any) -> MessageReader:  # noqa: N802
@@ -118,12 +118,11 @@ def LogReader(filename: StringPathLike, **kwargs: Any) -> MessageReader:  # noqa
     _update_reader_plugins()
 
     suffix = pathlib.PurePath(filename).suffix.lower()
-    file_or_filename: AcceptedIOType = filename
     if suffix == ".gz":
-        reader_type, file_or_filename = _decompress(filename)
-    else:
-        reader_type = _get_logger_for_suffix(suffix)
-    return reader_type(file=file_or_filename, **kwargs)
+        return _decompress(filename)
+
+    reader_type = _get_logger_for_suffix(suffix)
+    return reader_type(file=filename, **kwargs)
 
 
 class MessageSync:

--- a/can/listener.py
+++ b/can/listener.py
@@ -147,7 +147,9 @@ class AsyncBufferedReader(
                 stacklevel=2,
             )
             if sys.version_info < (3, 10):
-                self.buffer = asyncio.Queue(loop=kwargs["loop"])
+                self.buffer = asyncio.Queue(  # pylint: disable=unexpected-keyword-arg
+                    loop=kwargs["loop"]
+                )
                 return
 
         self.buffer = asyncio.Queue()

--- a/can/typechecking.py
+++ b/can/typechecking.py
@@ -1,9 +1,9 @@
 """Types for mypy type-checking"""
 
-import gzip
-import struct
+import io
 import sys
-import typing
+from collections.abc import Iterable, Sequence
+from typing import IO, TYPE_CHECKING, Any, NewType, Union
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
@@ -16,8 +16,9 @@ else:
     from typing_extensions import TypedDict
 
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     import os
+    import struct
 
 
 class CanFilter(TypedDict):
@@ -31,32 +32,31 @@ class CanFilterExtended(TypedDict):
     extended: bool
 
 
-CanFilters = typing.Sequence[typing.Union[CanFilter, CanFilterExtended]]
+CanFilters = Sequence[Union[CanFilter, CanFilterExtended]]
 
 # TODO: Once buffer protocol support lands in typing, we should switch to that,
 # since can.message.Message attempts to call bytearray() on the given data, so
 # this should have the same typing info.
 #
 # See: https://github.com/python/typing/issues/593
-CanData = typing.Union[bytes, bytearray, int, typing.Iterable[int]]
+CanData = Union[bytes, bytearray, int, Iterable[int]]
 
 # Used for the Abstract Base Class
 ChannelStr = str
 ChannelInt = int
-Channel = typing.Union[ChannelInt, ChannelStr]
+Channel = Union[ChannelInt, ChannelStr, Sequence[ChannelInt]]
 
 # Used by the IO module
-FileLike = typing.Union[typing.TextIO, typing.BinaryIO, gzip.GzipFile]
-StringPathLike = typing.Union[str, "os.PathLike[str]"]
-AcceptedIOType = typing.Union[FileLike, StringPathLike]
+FileLike = Union[IO[Any], io.TextIOWrapper, io.BufferedIOBase]
+StringPathLike = Union[str, "os.PathLike[str]"]
 
-BusConfig = typing.NewType("BusConfig", dict[str, typing.Any])
+BusConfig = NewType("BusConfig", dict[str, Any])
 
 # Used by CLI scripts
-TAdditionalCliArgs: TypeAlias = dict[str, typing.Union[str, int, float, bool]]
+TAdditionalCliArgs: TypeAlias = dict[str, Union[str, int, float, bool]]
 TDataStructs: TypeAlias = dict[
-    typing.Union[int, tuple[int, ...]],
-    typing.Union[struct.Struct, tuple, None],
+    Union[int, tuple[int, ...]],
+    "Union[struct.Struct, tuple[struct.Struct, *tuple[float, ...]]]",
 ]
 
 
@@ -65,7 +65,7 @@ class AutoDetectedConfig(TypedDict):
     channel: Channel
 
 
-ReadableBytesLike = typing.Union[bytes, bytearray, memoryview]
+ReadableBytesLike = Union[bytes, bytearray, memoryview]
 
 
 class BitTimingDict(TypedDict):

--- a/can/util.py
+++ b/can/util.py
@@ -50,7 +50,7 @@ elif platform.system() == "Windows" or platform.python_implementation() == "Iron
 
 
 def load_file_config(
-    path: Optional[typechecking.AcceptedIOType] = None, section: str = "default"
+    path: Optional[typechecking.StringPathLike] = None, section: str = "default"
 ) -> dict[str, str]:
     """
     Loads configuration from file with following content::
@@ -120,7 +120,7 @@ def load_environment_config(context: Optional[str] = None) -> dict[str, str]:
 
 
 def load_config(
-    path: Optional[typechecking.AcceptedIOType] = None,
+    path: Optional[typechecking.StringPathLike] = None,
     config: Optional[dict[str, Any]] = None,
     context: Optional[str] = None,
 ) -> typechecking.BusConfig:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -122,6 +122,12 @@ autodoc_typehints = "description"
 # disable specific warnings
 nitpick_ignore = [
     # Ignore warnings for type aliases. Remove once Sphinx supports PEP613
+    ("py:class", "OpenTextModeUpdating"),
+    ("py:class", "OpenTextModeWriting"),
+    ("py:class", "OpenBinaryModeUpdating"),
+    ("py:class", "OpenBinaryModeWriting"),
+    ("py:class", "OpenTextModeReading"),
+    ("py:class", "OpenBinaryModeReading"),
     ("py:class", "BusConfig"),
     ("py:class", "can.typechecking.BusConfig"),
     ("py:class", "can.typechecking.CanFilter"),

--- a/doc/file_io.rst
+++ b/doc/file_io.rst
@@ -94,7 +94,7 @@ as further references can-utils can be used:
 Log (.log can-utils Logging format)
 -----------------------------------
 
-CanutilsLogWriter logs CAN data to an ASCII log file compatible with `can-utils <https://github.com/linux-can/can-utils>`
+CanutilsLogWriter logs CAN data to an ASCII log file compatible with `can-utils <https://github.com/linux-can/can-utils>`_
 As specification following references can-utils can be used: 
 `asc2log <https://github.com/linux-can/can-utils/blob/master/asc2log.c>`_,
 `log2asc <https://github.com/linux-can/can-utils/blob/master/log2asc.c>`_.

--- a/doc/internal-api.rst
+++ b/doc/internal-api.rst
@@ -90,8 +90,8 @@ About the IO module
 
 Handling of the different file formats is implemented in ``can.io``.
 Each file/IO type is within a separate module and ideally implements both a *Reader* and a *Writer*.
-The reader usually extends :class:`can.io.generic.BaseIOHandler`, while
-the writer often additionally extends :class:`can.Listener`,
+The reader extends :class:`can.io.generic.MessageReader`, while the writer extends
+:class:`can.io.generic.MessageWriter`, a subclass of the :class:`can.Listener`,
 to be able to be passed directly to a :class:`can.Notifier`.
 
 
@@ -104,9 +104,9 @@ Ideally add both reading and writing support for the new file format, although t
 
 1. Create a new module: *can/io/canstore.py*
    (*or* simply copy some existing one like *can/io/csv.py*)
-2. Implement a reader ``CanstoreReader`` (which often extends :class:`can.io.generic.BaseIOHandler`, but does not have to).
+2. Implement a reader ``CanstoreReader`` which extends :class:`can.io.generic.MessageReader`.
    Besides from a constructor, only ``__iter__(self)`` needs to be implemented.
-3. Implement a writer ``CanstoreWriter`` (which often extends :class:`can.io.generic.BaseIOHandler` and :class:`can.Listener`, but does not have to).
+3. Implement a writer ``CanstoreWriter`` which extends :class:`can.io.generic.MessageWriter`.
    Besides from a constructor, only ``on_message_received(self, msg)`` needs to be implemented.
 4. Add a case to ``can.io.player.LogReader``'s ``__new__()``.
 5. Document the two new classes (and possibly additional helpers) with docstrings and comments.
@@ -126,7 +126,9 @@ IO Utilities
 
 
 .. automodule:: can.io.generic
+    :show-inheritance:
     :members:
+    :private-members:
     :member-order: bysource
 
 

--- a/doc/notifier.rst
+++ b/doc/notifier.rst
@@ -58,7 +58,8 @@ readers are also documented here.
     be added using the ``can.io.message_writer`` entry point.
 
     The format of the entry point is ``reader_name=module:classname`` where ``classname``
-    is a :class:`can.io.generic.BaseIOHandler` concrete implementation.
+    is a concrete implementation of :class:`~can.io.generic.MessageReader` or
+    :class:`~can.io.generic.MessageWriter`.
 
     ::
 

--- a/test/logformats_test.py
+++ b/test/logformats_test.py
@@ -137,6 +137,7 @@ class ReaderWriterTest(unittest.TestCase, ComparingMessagesTestCase, metaclass=A
         allowed_timestamp_delta=0.0,
         preserves_channel=True,
         adds_default_channel=None,
+        assert_file_closed=True,
     ):
         """
         :param Callable writer_constructor: the constructor of the writer class
@@ -187,6 +188,7 @@ class ReaderWriterTest(unittest.TestCase, ComparingMessagesTestCase, metaclass=A
         self.reader_constructor = reader_constructor
         self.binary_file = binary_file
         self.test_append_enabled = test_append
+        self.assert_file_closed = assert_file_closed
 
         ComparingMessagesTestCase.__init__(
             self,
@@ -212,7 +214,7 @@ class ReaderWriterTest(unittest.TestCase, ComparingMessagesTestCase, metaclass=A
         self._write_all(writer)
         self._ensure_fsync(writer)
         writer.stop()
-        if hasattr(writer.file, "closed"):
+        if self.assert_file_closed:
             self.assertTrue(writer.file.closed)
 
         print("reading all messages")
@@ -220,7 +222,7 @@ class ReaderWriterTest(unittest.TestCase, ComparingMessagesTestCase, metaclass=A
         read_messages = list(reader)
         # redundant, but this checks if stop() can be called multiple times
         reader.stop()
-        if hasattr(writer.file, "closed"):
+        if self.assert_file_closed:
             self.assertTrue(writer.file.closed)
 
         # check if at least the number of messages matches
@@ -243,7 +245,7 @@ class ReaderWriterTest(unittest.TestCase, ComparingMessagesTestCase, metaclass=A
             self._write_all(writer)
             self._ensure_fsync(writer)
             w = writer
-        if hasattr(w.file, "closed"):
+        if self.assert_file_closed:
             self.assertTrue(w.file.closed)
 
         # read all written messages
@@ -251,7 +253,7 @@ class ReaderWriterTest(unittest.TestCase, ComparingMessagesTestCase, metaclass=A
         with self.reader_constructor(self.test_file_name) as reader:
             read_messages = list(reader)
             r = reader
-        if hasattr(r.file, "closed"):
+        if self.assert_file_closed:
             self.assertTrue(r.file.closed)
 
         # check if at least the number of messages matches;
@@ -274,7 +276,7 @@ class ReaderWriterTest(unittest.TestCase, ComparingMessagesTestCase, metaclass=A
         self._write_all(writer)
         self._ensure_fsync(writer)
         writer.stop()
-        if hasattr(my_file, "closed"):
+        if self.assert_file_closed:
             self.assertTrue(my_file.closed)
 
         print("reading all messages")
@@ -283,7 +285,7 @@ class ReaderWriterTest(unittest.TestCase, ComparingMessagesTestCase, metaclass=A
         read_messages = list(reader)
         # redundant, but this checks if stop() can be called multiple times
         reader.stop()
-        if hasattr(my_file, "closed"):
+        if self.assert_file_closed:
             self.assertTrue(my_file.closed)
 
         # check if at least the number of messages matches
@@ -307,7 +309,7 @@ class ReaderWriterTest(unittest.TestCase, ComparingMessagesTestCase, metaclass=A
             self._write_all(writer)
             self._ensure_fsync(writer)
             w = writer
-        if hasattr(my_file, "closed"):
+        if self.assert_file_closed:
             self.assertTrue(my_file.closed)
 
         # read all written messages
@@ -316,7 +318,7 @@ class ReaderWriterTest(unittest.TestCase, ComparingMessagesTestCase, metaclass=A
         with self.reader_constructor(my_file) as reader:
             read_messages = list(reader)
             r = reader
-        if hasattr(my_file, "closed"):
+        if self.assert_file_closed:
             self.assertTrue(my_file.closed)
 
         # check if at least the number of messages matches;
@@ -380,7 +382,7 @@ class ReaderWriterTest(unittest.TestCase, ComparingMessagesTestCase, metaclass=A
                 writer(msg)
 
     def _ensure_fsync(self, io_handler):
-        if hasattr(io_handler.file, "fileno"):
+        if hasattr(io_handler, "file") and hasattr(io_handler.file, "fileno"):
             io_handler.file.flush()
             os.fsync(io_handler.file.fileno())
 
@@ -871,6 +873,7 @@ class TestSqliteDatabaseFormat(ReaderWriterTest):
             check_comments=False,
             preserves_channel=False,
             adds_default_channel=None,
+            assert_file_closed=False,
         )
 
     @unittest.skip("not implemented")


### PR DESCRIPTION
- Remove BaseIOHandler and use generics instead to narrow types.
- Add missing type annotations log formats.

 Other than `can.io.mf4`, this does pass mypy in strict mode.