### PR TITLE
Full featured CAN driver for Geschwister Schneider and candleLight

### DIFF
--- a/doc/plugin-interface.rst
+++ b/doc/plugin-interface.rst
@@ -77,6 +77,8 @@ The table below lists interface drivers that can be added by installing addition
 +----------------------------+-------------------------------------------------------+
 | `python-can-cando`_        | Python wrapper for Netronics' CANdo and CANdoISO      |
 +----------------------------+-------------------------------------------------------+
+| `python-can-candle`_       | A full-featured driver for candleLight                |
++----------------------------+-------------------------------------------------------+
 
 .. _python-can-canine: https://github.com/tinymovr/python-can-canine
 .. _python-can-cvector: https://github.com/zariiii9003/python-can-cvector
@@ -84,4 +86,5 @@ The table below lists interface drivers that can be added by installing addition
 .. _python-can-sontheim: https://github.com/MattWoodhead/python-can-sontheim
 .. _zlgcan: https://github.com/jesses2025smith/zlgcan-driver
 .. _python-can-cando: https://github.com/belliriccardo/python-can-cando
+.. _python-can-candle: https://github.com/BIRLab/python-can-candle
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ remote = ["python-can-remote"]
 sontheim = ["python-can-sontheim>=0.1.2"]
 canine = ["python-can-canine>=0.2.2"]
 zlgcan = ["zlgcan"]
+candle = ["python-can-candle>=1.2.2"]
 viewer = [
     "windows-curses; platform_system == 'Windows' and platform_python_implementation=='CPython'"
 ]


### PR DESCRIPTION
Currently, **python-can** provides native support for such devices through [`gs_usb.py`](https://github.com/hardbyte/python-can/blob/main/can/interfaces/gs_usb.py). However, the existing **gs\_usb** interface lacks support for several important features—such as multichannel, CAN FD, and termination—and also suffers from performance issues. This plugin is implemented using `pybind11` and `libusb`, aiming to improve transfer performance and offer more comprehensive feature support for the devices.
