### PR TITLE
Convert BusState to enum when read with configparser

### DIFF
--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -268,12 +268,6 @@ class PcanBus(BusABC):
 
         self.check_api_version()
 
-        if not isinstance(state, BusState):
-            try:
-                state = BusState[state]
-            except KeyError as e:
-                raise ValueError("State must be ACTIVE or PASSIVE") from e
-
         if state in [BusState.ACTIVE, BusState.PASSIVE]:
             self.state = state
         else:

--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -268,6 +268,12 @@ class PcanBus(BusABC):
 
         self.check_api_version()
 
+        if not isinstance(state, BusState):
+            try:
+                state = BusState[state]
+            except KeyError as e:
+                raise ValueError("State must be ACTIVE or PASSIVE") from e
+
         if state in [BusState.ACTIVE, BusState.PASSIVE]:
             self.state = state
         else:

--- a/can/util.py
+++ b/can/util.py
@@ -249,7 +249,7 @@ def _create_bus_config(config: dict[str, Any]) -> typechecking.BusConfig:
     if "fd" in config:
         config["fd"] = config["fd"] not in (0, False)
 
-    if "state" in config:
+    if "state" in config and not isinstance(config["state"], can.BusState):
         try:
             config["state"] = can.BusState[config["state"]]
         except KeyError as e:

--- a/can/util.py
+++ b/can/util.py
@@ -249,6 +249,12 @@ def _create_bus_config(config: dict[str, Any]) -> typechecking.BusConfig:
     if "fd" in config:
         config["fd"] = config["fd"] not in (0, False)
 
+    if "state" in config:
+        try:
+            config["state"] = can.BusState[config["state"]]
+        except KeyError as e:
+            raise ValueError("State config not valid!") from e
+
     return cast("typechecking.BusConfig", config)
 
 

--- a/doc/interfaces/pcan.rst
+++ b/doc/interfaces/pcan.rst
@@ -15,7 +15,7 @@ Here is an example configuration file for using `PCAN-USB <https://www.peak-syst
     [default]
     interface = pcan
     channel = PCAN_USBBUS1
-    state = can.bus.BusState.PASSIVE
+    state = PASSIVE
     bitrate = 500000
 
 ``channel`` (default ``"PCAN_USBBUS1"``)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -209,6 +209,28 @@ class TestBusConfig(unittest.TestCase):
         assert timing.data_tseg2 == 10
         assert timing.data_sjw == 10
 
+    def test_state_with_str(self):
+        can_cfg = _create_bus_config(
+            {
+                **self.base_config,
+                "state": "PASSIVE",
+            }
+        )
+        state = can_cfg["state"]
+        assert isinstance(state, can.BusState)
+        assert state == can.BusState.PASSIVE
+
+    def test_state_with_enum(self):
+        expected_state = can.BusState.PASSIVE
+        can_cfg = _create_bus_config(
+            {
+                **self.base_config,
+                "state": expected_state,
+            }
+        )
+        state = can_cfg["state"]
+        assert isinstance(state, can.BusState)
+        assert state == expected_state
 
 class TestChannel2Int(unittest.TestCase):
     def test_channel2int(self) -> None:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -232,6 +232,7 @@ class TestBusConfig(unittest.TestCase):
         assert isinstance(state, can.BusState)
         assert state == expected_state
 
+
 class TestChannel2Int(unittest.TestCase):
     def test_channel2int(self) -> None:
         self.assertEqual(0, channel2int("can0"))

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -218,7 +218,7 @@ class TestBusConfig(unittest.TestCase):
         )
         state = can_cfg["state"]
         assert isinstance(state, can.BusState)
-        assert state == can.BusState.PASSIVE
+        assert state is can.BusState.PASSIVE
 
     def test_state_with_enum(self):
         expected_state = can.BusState.PASSIVE
@@ -230,7 +230,7 @@ class TestBusConfig(unittest.TestCase):
         )
         state = can_cfg["state"]
         assert isinstance(state, can.BusState)
-        assert state == expected_state
+        assert state is expected_state
 
 
 class TestChannel2Int(unittest.TestCase):


### PR DESCRIPTION
Fix bug in pcan interface where state values cannot be read from config files.