### PR TITLE
reader: mf4: test for 'S' type .Dir like asammdf

### DIFF
--- a/can/io/mf4.py
+++ b/can/io/mf4.py
@@ -352,7 +352,10 @@ class MF4Reader(BinaryIOMessageReader):
                     if "CAN_DataFrame.BusChannel" in names:
                         kv["channel"] = int(data["CAN_DataFrame.BusChannel"][i])
                     if "CAN_DataFrame.Dir" in names:
-                        kv["is_rx"] = int(data["CAN_DataFrame.Dir"][i]) == 0
+                        if data["CAN_DataFrame.Dir"][i].dtype.kind == "S":
+                            kv["is_rx"] = data["CAN_DataFrame.Dir"][i] == b'Rx'
+                        else:
+                            kv["is_rx"] = int(data["CAN_DataFrame.Dir"][i]) == 0
                     if "CAN_DataFrame.IDE" in names:
                         kv["is_extended_id"] = bool(data["CAN_DataFrame.IDE"][i])
                     if "CAN_DataFrame.EDL" in names:
@@ -387,7 +390,10 @@ class MF4Reader(BinaryIOMessageReader):
                     if "CAN_ErrorFrame.BusChannel" in names:
                         kv["channel"] = int(data["CAN_ErrorFrame.BusChannel"][i])
                     if "CAN_ErrorFrame.Dir" in names:
-                        kv["is_rx"] = int(data["CAN_ErrorFrame.Dir"][i]) == 0
+                        if data["CAN_ErrorFrame.Dir"][i].dtype.kind == "S":
+                            kv["is_rx"] = data["CAN_ErrorFrame.Dir"][i] == b'Rx'
+                        else:
+                            kv["is_rx"] = int(data["CAN_ErrorFrame.Dir"][i]) == 0
                     if "CAN_ErrorFrame.ID" in names:
                         kv["arbitration_id"] = (
                             int(data["CAN_ErrorFrame.ID"][i]) & 0x1FFFFFFF
@@ -441,7 +447,10 @@ class MF4Reader(BinaryIOMessageReader):
                     if "CAN_RemoteFrame.BusChannel" in names:
                         kv["channel"] = int(data["CAN_RemoteFrame.BusChannel"][i])
                     if "CAN_RemoteFrame.Dir" in names:
-                        kv["is_rx"] = int(data["CAN_RemoteFrame.Dir"][i]) == 0
+                        if data["CAN_RemoteFrame.Dir"][i].dtype.kind == "S":
+                            kv["is_rx"] = data["CAN_RemoteFrame.Dir"][i] == b'Rx'
+                        else:
+                            kv["is_rx"] = int(data["CAN_RemoteFrame.Dir"][i]) == 0
                     if "CAN_RemoteFrame.IDE" in names:
                         kv["is_extended_id"] = bool(data["CAN_RemoteFrame.IDE"][i])
 


### PR DESCRIPTION
I could not decode a mf4 file created by [mdflib](https://github.com/ihedvall/mdflib). It creates `.Dir` channels with string values not int: https://github.com/ihedvall/mdflib/blob/main/mdflib/src/canconfigadapter.cpp#L321

Not sure if this is standard in MDF but since the note said the reader iterators are based on the asammdf GUI code, I took a look. It does a check on the [attached type](https://github.com/danielhrisca/asammdf/blob/ca8182a80125bbb01f6bb394710b8d7f9c84b1f5/src/asammdf/mdf.py#L6135).

Commit adds the same for python-can so that it can decode files with a string value for `.Dir`.