### PR TITLE
Fix tests to avoid unclosed files and failed PyPy tests

### DIFF
--- a/can/io/logger.py
+++ b/can/io/logger.py
@@ -290,7 +290,8 @@ class BaseRotatingLogger(MessageWriter, ABC):
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> Literal[False]:
-        return self.writer.__exit__(exc_type, exc_val, exc_tb)
+        self.stop()
+        return False
 
     @abstractmethod
     def should_rollover(self, msg: Message) -> bool:


### PR DESCRIPTION
<!--
Thank you for contributing to python-can!
Please fill out the following template to help us review your pull request.
-->

## Summary of Changes

<!-- Briefly describe what your pull request does. -->

- `__unused.txt` was not explicitly closed which caused warnings on PyPy. These warnings caused other tests to fail, which checked for warnings.

## Related Issues / Pull Requests

<!-- List any related issues, pull requests, or discussions. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] Other (please describe): Improve tests

## Checklist

- [x] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [x] I have added or updated tests as appropriate.
- [ ] I have added or updated documentation as appropriate.
- [ ] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [x] All checks and tests pass (`tox`).

