### PR TITLE
Change the default to 0, which is a no-op for data_bitrate.

### DIFF
--- a/can/interfaces/slcan.py
+++ b/can/interfaces/slcan.py
@@ -166,7 +166,7 @@ class slcanBus(BusABC):
 
         super().__init__(channel, **kwargs)
 
-    def set_bitrate(self, bitrate: int, data_bitrate: Optional[int] = None) -> None:
+    def set_bitrate(self, bitrate: int, data_bitrate: Optional[int] = 0) -> None:
         """
         :param bitrate:
             Bitrate in bit/s


### PR DESCRIPTION
<!--
Thank you for contributing to python-can!
Please fill out the following template to help us review your pull request.
-->

## Summary of Changes

<!-- Briefly describe what your pull request does. -->

- 

## Related Issues / Pull Requests

<!-- List any related issues, pull requests, or discussions. -->

- Closes #
- Related to #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [ ] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [ ] I have added or updated tests as appropriate.
- [ ] I have added or updated documentation as appropriate.
- [ ] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [ ] All checks and tests pass (`tox`).

## Additional Notes

<!-- Add any other information or context you want to share. -->
