### PR TITLE
Allow wrapt 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["readme", "version"]
 description = "Controller Area Network interface module for Python"
 authors = [{ name = "python-can contributors" }]
 dependencies = [
-    "wrapt~=1.10",
+    "wrapt >= 1.10, < 3",
     "packaging >= 23.1",
     "typing_extensions>=3.10.0.0",
 ]


### PR DESCRIPTION
<!--
Thank you for contributing to python-can!
Please fill out the following template to help us review your pull request.
-->

## Summary of Changes

<!-- Briefly describe what your pull request does. -->

- Widened the version bound on the `wrapt` dependency to allow 2.x

## Related Issues / Pull Requests

<!-- List any related issues, pull requests, or discussions. -->

<!--
- Closes #
- Related to #
-->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] Other (please describe): dependency update

## Checklist

- [x] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [x] I have added or updated tests as appropriate. **N/A**
- [X] I have added or updated documentation as appropriate. **N/A**
- [ ] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [x] All checks and tests pass (`tox`).

## Additional Notes

<!-- Add any other information or context you want to share. -->
This is based on testing with `wrapt` 2.0.0rc1, https://github.com/GrahamDumpleton/wrapt/blob/2.0.0rc1/docs/changes.rst.

```
$ uv venv
$ . .venv/bin/activate
(python-can) $ uv sync
(python-can) $ uv pip install -e .[canalystii,mf4,multicast,pywin32,serial,viewer]
(python-can) $ pytest -v
[everything succeeds]
(python-can) $ uv pip install wrapt==2.0.0rc1
[everything still succeeds]
```

I maintain the [`python-wrapt` package](https://src.fedoraproject.org/rpms/python-wrapt) in Fedora, and this PR is part of my work to make sure that I am ready to ship `wrapt` 2.0.0 in Rawhide, the development version of Fedora, as soon as 2.0.0 final is released.