### PR TITLE
Keep a reference to asyncio tasks

### DIFF
--- a/doc/changelog.d/1938.fixed.md
+++ b/doc/changelog.d/1938.fixed.md
@@ -1,0 +1,1 @@
+Keep a reference to asyncio tasks in `can.Notifier` as recommended by [python documentation](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task).


### PR DESCRIPTION
<!--
Thank you for contributing to python-can!
Please fill out the following template to help us review your pull request.
-->

## Summary of Changes

In `can.Notifier._on_message_received()` save a reference of each created `asyncio.Task` into a set and automatically discard it once it is fnished.

## Related Issues / Pull Requests

<!-- List any related issues, pull requests, or discussions. -->

- Closes #1938

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [X] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [ ] I have added or updated tests as appropriate.
- [ ] I have added or updated documentation as appropriate.
- [x] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [x] All checks and tests pass (`tox`).

## Additional Notes

<!-- Add any other information or context you want to share. -->
