### PR TITLE
Add COE interface plugin to the list.

### DIFF
--- a/doc/changelog.d/1987.added.md
+++ b/doc/changelog.d/1987.added.md
@@ -1,0 +1,1 @@
+Add [python-can-coe](https://c0d3.sh/smarthome/python-can-coe) interface plugin to the documentation.

--- a/doc/plugin-interface.rst
+++ b/doc/plugin-interface.rst
@@ -62,23 +62,25 @@ The table below lists interface drivers that can be added by installing addition
 .. note::
    The packages listed below are maintained by other authors. Any issues should be reported in their corresponding repository and **not** in the python-can repository.
 
-+----------------------------+-------------------------------------------------------+
-| Name                       | Description                                           |
-+============================+=======================================================+
-| `python-can-canine`_       | CAN Driver for the CANine CAN interface               |
-+----------------------------+-------------------------------------------------------+
-| `python-can-cvector`_      | Cython based version of the 'VectorBus'               |
-+----------------------------+-------------------------------------------------------+
-| `python-can-remote`_       | CAN over network bridge                               |
-+----------------------------+-------------------------------------------------------+
-| `python-can-sontheim`_     | CAN Driver for Sontheim CAN interfaces (e.g. CANfox)  |
-+----------------------------+-------------------------------------------------------+
-| `zlgcan`_                  | Python wrapper for zlgcan-driver-rs                   |
-+----------------------------+-------------------------------------------------------+
-| `python-can-cando`_        | Python wrapper for Netronics' CANdo and CANdoISO      |
-+----------------------------+-------------------------------------------------------+
-| `python-can-candle`_       | A full-featured driver for candleLight                |
-+----------------------------+-------------------------------------------------------+
++----------------------------+----------------------------------------------------------+
+| Name                       | Description                                              |
++============================+==========================================================+
+| `python-can-canine`_       | CAN Driver for the CANine CAN interface                  |
++----------------------------+----------------------------------------------------------+
+| `python-can-cvector`_      | Cython based version of the 'VectorBus'                  |
++----------------------------+----------------------------------------------------------+
+| `python-can-remote`_       | CAN over network bridge                                  |
++----------------------------+----------------------------------------------------------+
+| `python-can-sontheim`_     | CAN Driver for Sontheim CAN interfaces (e.g. CANfox)     |
++----------------------------+----------------------------------------------------------+
+| `zlgcan`_                  | Python wrapper for zlgcan-driver-rs                      |
++----------------------------+----------------------------------------------------------+
+| `python-can-cando`_        | Python wrapper for Netronics' CANdo and CANdoISO         |
++----------------------------+----------------------------------------------------------+
+| `python-can-candle`_       | A full-featured driver for candleLight                   |
++----------------------------+----------------------------------------------------------+
+| `python-can-coe`_          | A CAN-over-Ethernet interface for Technische Alternative |
++----------------------------+----------------------------------------------------------+
 
 .. _python-can-canine: https://github.com/tinymovr/python-can-canine
 .. _python-can-cvector: https://github.com/zariiii9003/python-can-cvector
@@ -87,4 +89,5 @@ The table below lists interface drivers that can be added by installing addition
 .. _zlgcan: https://github.com/jesses2025smith/zlgcan-driver
 .. _python-can-cando: https://github.com/belliriccardo/python-can-cando
 .. _python-can-candle: https://github.com/BIRLab/python-can-candle
+.. _python-can-coe: https://c0d3.sh/smarthome/python-can-coe
 


### PR DESCRIPTION
## Summary of Changes

- Add python-can-coe to the list of plugin interfaces

## Related Issues / Pull Requests

- Related to #1909

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [X] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [ ] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [ ] I have added or updated tests as appropriate.
- [X] I have added or updated documentation as appropriate.
- [x] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [ ] All checks and tests pass (`tox`).

## Additional Notes
