### PR TITLE
FIX: Some hardware ID are not compatible with ascii, in that case fal…

### DIFF
--- a/can/interfaces/ixxat/canlib_vcinpl.py
+++ b/can/interfaces/ixxat/canlib_vcinpl.py
@@ -523,9 +523,12 @@ class IXXATBus(BusABC):
                     hwid = self._device_info.UniqueHardwareId.AsChar.decode("ascii")
                 except:
                     guid = self._device_info.UniqueHardwareId.AsGuid
-                    hwid = '{{{0:x}-{1:x}-{2:x}-{3}}}'.format(guid.Data1,guid.Data2,guid.Data3,guid.Data4.hex())
+                    hwid = '{{{0:x}-{1:x}-{2:x}-{3}}}'.format(
+                        guid.Data1,guid.Data2,guid.Data3,guid.Data4.hex()
+                    )
                     
-                if (unique_hardware_id is None) or ( bytes(hwid, "ascii") == bytes(unique_hardware_id, "ascii") 
+                if (unique_hardware_id is None) or ( 
+                    bytes(hwid, "ascii") == bytes(unique_hardware_id, "ascii") 
                 ):
                     break
 
@@ -977,7 +980,9 @@ def get_ixxat_hwids():
                 hwids.append(device_info.UniqueHardwareId.AsChar.decode("ascii"))
             except:
                 guid = device_info.UniqueHardwareId.AsGuid
-                hwids.append('{{{0:x}-{1:x}-{2:x}-{3}}}'.format(guid.Data1,guid.Data2,guid.Data3,guid.Data4.hex()))
+                hwids.append('{{{0:x}-{1:x}-{2:x}-{3}}}'.format(
+                    guid.Data1,guid.Data2,guid.Data3,guid.Data4.hex())
+                )
     _canlib.vciEnumDeviceClose(device_handle)
 
     return hwids
@@ -1006,7 +1011,9 @@ def _detect_available_configs() -> Sequence["AutoDetectedIxxatConfig"]:
                     hwid = device_info.UniqueHardwareId.AsChar.decode("ascii")
                 except:
                     guid = device_info.UniqueHardwareId.AsGuid
-                    hwid = '{{{0:x}-{1:x}-{2:x}-{3}}}'.format(guid.Data1,guid.Data2,guid.Data3,guid.Data4.hex())
+                    hwid = '{{{0:x}-{1:x}-{2:x}-{3}}}'.format(
+                        guid.Data1,guid.Data2,guid.Data3,guid.Data4.hex()
+                    )
                 _canlib.vciDeviceOpen(
                     ctypes.byref(device_info.VciObjectId),
                     ctypes.byref(device_handle2),

--- a/can/interfaces/ixxat/canlib_vcinpl.py
+++ b/can/interfaces/ixxat/canlib_vcinpl.py
@@ -521,11 +521,9 @@ class IXXATBus(BusABC):
             else:
                 try:
                     hwid = self._device_info.UniqueHardwareId.AsChar.decode("ascii")
-                except:
+                except UnicodeDecodeError:
                     guid = self._device_info.UniqueHardwareId.AsGuid
-                    hwid = "{{{0:x}-{1:x}-{2:x}-{3}}}".format(
-                        guid.Data1, guid.Data2, guid.Data3, guid.Data4.hex()
-                    )
+                    hwid = f"{{{guid.Data1:x}-{guid.Data2:x}-{guid.Data3:x}-{guid.Data4.hex()}}}"
 
                 if (unique_hardware_id is None) or (
                     bytes(hwid, "ascii") == bytes(unique_hardware_id, "ascii")
@@ -978,12 +976,10 @@ def get_ixxat_hwids():
         else:
             try:
                 hwids.append(device_info.UniqueHardwareId.AsChar.decode("ascii"))
-            except:
+            except UnicodeDecodeError:
                 guid = device_info.UniqueHardwareId.AsGuid
                 hwids.append(
-                    "{{{0:x}-{1:x}-{2:x}-{3}}}".format(
-                        guid.Data1, guid.Data2, guid.Data3, guid.Data4.hex()
-                    )
+                    f"{{{guid.Data1:x}-{guid.Data2:x}-{guid.Data3:x}-{guid.Data4.hex()}}}"
                 )
     _canlib.vciEnumDeviceClose(device_handle)
 
@@ -1011,11 +1007,9 @@ def _detect_available_configs() -> Sequence["AutoDetectedIxxatConfig"]:
             else:
                 try:
                     hwid = device_info.UniqueHardwareId.AsChar.decode("ascii")
-                except:
+                except UnicodeDecodeError:
                     guid = device_info.UniqueHardwareId.AsGuid
-                    hwid = "{{{0:x}-{1:x}-{2:x}-{3}}}".format(
-                        guid.Data1, guid.Data2, guid.Data3, guid.Data4.hex()
-                    )
+                    hwid = f"{{{guid.Data1:x}-{guid.Data2:x}-{guid.Data3:x}-{guid.Data4.hex()}}}"
                 _canlib.vciDeviceOpen(
                     ctypes.byref(device_info.VciObjectId),
                     ctypes.byref(device_handle2),

--- a/can/interfaces/ixxat/canlib_vcinpl.py
+++ b/can/interfaces/ixxat/canlib_vcinpl.py
@@ -523,12 +523,12 @@ class IXXATBus(BusABC):
                     hwid = self._device_info.UniqueHardwareId.AsChar.decode("ascii")
                 except:
                     guid = self._device_info.UniqueHardwareId.AsGuid
-                    hwid = '{{{0:x}-{1:x}-{2:x}-{3}}}'.format(
-                        guid.Data1,guid.Data2,guid.Data3,guid.Data4.hex()
+                    hwid = "{{{0:x}-{1:x}-{2:x}-{3}}}".format(
+                        guid.Data1, guid.Data2, guid.Data3, guid.Data4.hex()
                     )
-                    
-                if (unique_hardware_id is None) or ( 
-                    bytes(hwid, "ascii") == bytes(unique_hardware_id, "ascii") 
+
+                if (unique_hardware_id is None) or (
+                    bytes(hwid, "ascii") == bytes(unique_hardware_id, "ascii")
                 ):
                     break
 
@@ -980,8 +980,10 @@ def get_ixxat_hwids():
                 hwids.append(device_info.UniqueHardwareId.AsChar.decode("ascii"))
             except:
                 guid = device_info.UniqueHardwareId.AsGuid
-                hwids.append('{{{0:x}-{1:x}-{2:x}-{3}}}'.format(
-                    guid.Data1,guid.Data2,guid.Data3,guid.Data4.hex())
+                hwids.append(
+                    "{{{0:x}-{1:x}-{2:x}-{3}}}".format(
+                        guid.Data1, guid.Data2, guid.Data3, guid.Data4.hex()
+                    )
                 )
     _canlib.vciEnumDeviceClose(device_handle)
 
@@ -1011,8 +1013,8 @@ def _detect_available_configs() -> Sequence["AutoDetectedIxxatConfig"]:
                     hwid = device_info.UniqueHardwareId.AsChar.decode("ascii")
                 except:
                     guid = device_info.UniqueHardwareId.AsGuid
-                    hwid = '{{{0:x}-{1:x}-{2:x}-{3}}}'.format(
-                        guid.Data1,guid.Data2,guid.Data3,guid.Data4.hex()
+                    hwid = "{{{0:x}-{1:x}-{2:x}-{3}}}".format(
+                        guid.Data1, guid.Data2, guid.Data3, guid.Data4.hex()
                     )
                 _canlib.vciDeviceOpen(
                     ctypes.byref(device_info.VciObjectId),


### PR DESCRIPTION
…lback to guid

<!--
Thank you for contributing to python-can!
Please fill out the following template to help us review your pull request.
-->

## Summary of Changes

This change correct detection of hardware id for legacy product and VCI 3.5 (i.e {xxxxxx-xxxx-xxxx-xxxxxxxxxxxx}). decode("ascii") is not able to produce a result and trig an exception.
For this particular situation we use AsGuid and compute string  {xxxxxx-xxxx-xxxx-xxxxxxxxxxxx} the same that is reported by iXXat cananalizer. Also update config hwid detection.

- 

## Related Issues / Pull Requests

Not linked to Issue yet

- Closes #
- Related to #

## Type of Change

- [x ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [x ] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [ ] I have added or updated tests as appropriate.
- [ ] I have added or updated documentation as appropriate.
- [ ] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [ ] All checks and tests pass (`tox`).

## Additional Notes

<!-- Add any other information or context you want to share. -->
