### PR TITLE
Add python-can-damiao plugin support

### DIFF
--- a/doc/plugin-interface.rst
+++ b/doc/plugin-interface.rst
@@ -83,6 +83,8 @@ The table below lists interface drivers that can be added by installing addition
 +----------------------------+----------------------------------------------------------+
 | `RP1210`_                  | CAN channels in RP1210 Vehicle Diagnostic Adapters       |
 +----------------------------+----------------------------------------------------------+
+| `python-can-damiao`_       | Interface for Damiao USB-CAN adapters                    |
++----------------------------+----------------------------------------------------------+
 
 .. _python-can-canine: https://github.com/tinymovr/python-can-canine
 .. _python-can-cvector: https://github.com/zariiii9003/python-can-cvector
@@ -93,4 +95,5 @@ The table below lists interface drivers that can be added by installing addition
 .. _python-can-candle: https://github.com/BIRLab/python-can-candle
 .. _python-can-coe: https://c0d3.sh/smarthome/python-can-coe
 .. _RP1210: https://github.com/dfieschko/RP1210
+.. _python-can-damiao: https://github.com/gaoyichuan/python-can-damiao
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ canine = ["python-can-canine>=0.2.2"]
 zlgcan = ["zlgcan"]
 candle = ["python-can-candle>=1.2.2"]
 rp1210 = ["rp1210>=1.0.1"]
+damiao = ["python-can-damiao"]
 viewer = [
     "windows-curses; platform_system == 'Windows' and platform_python_implementation=='CPython'"
 ]


### PR DESCRIPTION
## Summary of Changes

Add python-can-damiao as an optional dependency plugin, providing support for Damiao USB-CAN adapters.

The plugin enables CAN communication through Damiao USB-CAN adapters with a simple interface following the python-can plugin API.

**Plugin Repository:** https://github.com/gaoyichuan/python-can-damiao

## Related Issues / Pull Requests

- N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [ ] I have added or updated tests as appropriate.
- [x] I have added or updated documentation as appropriate.
- [ ] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [ ] All checks and tests pass (`tox`).

## Additional Notes

This plugin is tested with:
- [Damiao USB-CAN adapter](https://gitee.com/kit-miao/dm-tools/tree/master/USB%E8%BD%ACCAN)
- DM4310 motor
