### PR TITLE
IXXAT: improve handling of controller errors

### DIFF
--- a/can/interfaces/ixxat/canlib_vcinpl2.py
+++ b/can/interfaces/ixxat/canlib_vcinpl2.py
@@ -857,7 +857,7 @@ class IXXATBus(BusABC):
                     ):
                         log.info(_format_can_status(self._message.abData[0]))
                         if self._message.abData[0] & constants.CAN_STATUS_BUSOFF:
-                            raise VCIBusOffError()
+                            raise VCIBusOffError("Controller is in BUSOFF state")
 
                     elif (
                         self._message.uMsgInfo.Bits.type

--- a/can/interfaces/ixxat/exceptions.py
+++ b/can/interfaces/ixxat/exceptions.py
@@ -12,9 +12,12 @@ from can import (
 )
 
 __all__ = [
+    "VCIBusCouplingError",
     "VCIBusOffError",
+    "VCIDataOverrunError",
     "VCIDeviceNotFoundError",
     "VCIError",
+    "VCIErrorLimitExceededError",
     "VCIRxQueueEmptyError",
     "VCITimeout",
 ]
@@ -36,8 +39,19 @@ class VCIRxQueueEmptyError(VCIError):
 
 
 class VCIBusOffError(VCIError):
-    def __init__(self):
-        super().__init__("Controller is in BUSOFF state")
+    """Controller is in BUSOFF state"""
+
+
+class VCIErrorLimitExceededError(VCIError):
+    """overrun of error counter occurred"""
+
+
+class VCIDataOverrunError(VCIError):
+    """data overrun in receive buffer occurred"""
+
+
+class VCIBusCouplingError(VCIError):
+    """Bus coupling error occurred"""
 
 
 class VCIDeviceNotFoundError(CanInitializationError):

--- a/doc/changelog.d/2023.changed.md
+++ b/doc/changelog.d/2023.changed.md
@@ -1,0 +1,1 @@
+Improve IXXAT VCI exception handling


### PR DESCRIPTION
## Summary of Changes

<!-- Briefly describe what your pull request does. -->

I encountered an issue that came down to the current handling of the data overrun flag in the IXXAT recv function. When some other controller would write data with an invalid baudrate to the CAN bus, the IXXAT would generate so many error frames that would rather quickly cause the receive fifo to overrun.
In its current state this would cause python-can to raise a VCIError("Data overrun occurred") for every recv() call till the controller is reset. On other words: This exception raising is not stopping even if the wrong-baudrate-situation is over.
This is because the meaning of the CAN_STATUS_OVRRUN flag of the CANLINESTATUS struct is basically whether an overflow has ever occurred during the lifetime of the channel, so I think it should not be used for exception raising. My patch adapts the recv-function to raise the "Data overrun occurred" exception based on actual error frames instead of this status flag. This allows my application to ignore these errors till the baudrate on the bus has normalized and everything is working again.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [x] I have added or updated tests as appropriate.
- [x] I have added or updated documentation as appropriate.
- [x] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [x] All checks and tests pass (`tox`).

## Additional Notes

<!-- Add any other information or context you want to share. -->
