### PR TITLE
interfaces/cantact: Handle None timeout by setting to 0xFFF...

### DIFF
--- a/can/interfaces/cantact.py
+++ b/can/interfaces/cantact.py
@@ -125,9 +125,7 @@ class CantactBus(BusABC):
 
     def _recv_internal(self, timeout: float | None) -> tuple[Message | None, bool]:
         if timeout is None:
-            raise TypeError(
-                f"{self.__class__.__name__} expects a numeric `timeout` value."
-            )
+            timeout = 2**64 - 1
 
         with error_check("Cannot receive message"):
             frame = self.interface.recv(int(timeout * 1000))

--- a/doc/changelog.d/2026.changed.md
+++ b/doc/changelog.d/2026.changed.md
@@ -1,0 +1,1 @@
+* cantact: handle None timeouts as 'forever' (with 0xFFF....)


### PR DESCRIPTION

<!--
Thank you for contributing to python-can!
Please fill out the following template to help us review your pull request.
-->

## Summary of Changes

There are definitely cases of client code that end up passing timeout=None to _recv_internal(). Several other interfaces/*.py are prepared for this e.g. canalystii usb2can canlib_vcinpl2 gs_usb.py

For cantact I think the right thing to do is set default timeout to 0 if None is provided.
There are definitely cases of client code that end up passing timeout=None to _recv_internal(). Several other interfaces/*.py are prepared for this e.g. canalystii usb2can canlib_vcinpl2 gs_usb.py

For cantact I think the right thing to do is set default timeout to 0 if None is provided.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [X] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [ ] I have added or updated tests as appropriate.
- [ ] I have added or updated documentation as appropriate.
- [ ] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [X] All checks and tests pass (`tox`).
