### PR TITLE
Fix seedstudio dongle bug

### DIFF
--- a/can/interfaces/seeedstudio/seeedstudio.py
+++ b/can/interfaces/seeedstudio/seeedstudio.py
@@ -265,7 +265,13 @@ class SeeedBus(BusABC):
 
         if rx_byte_1 and ord(rx_byte_1) == 0xAA:
             try:
-                rx_byte_2 = ord(self.ser.read())
+                if self.ser.in_waiting >= 1:
+                    rx_byte_2_opt = self.ser.read()
+                else:
+                    # Should not get to this line
+                    logger.debug("received 0xAA, then serial stopped")
+                    rx_byte_2_opt = 0x00
+                rx_byte_2 = ord(rx_byte_2_opt)
 
                 time_stamp = time()
                 if rx_byte_2 == 0x55:
@@ -286,7 +292,21 @@ class SeeedBus(BusABC):
                         arb_id = (struct.unpack("<H", s_3_4))[0]
 
                     data = bytearray(self.ser.read(length))
-                    end_packet = ord(self.ser.read())
+
+                    if self.ser.in_waiting >= 1:
+                        end_packet_opt = self.ser.read()
+                    else:
+                        logger.debug("no end byte?")
+                        # Seems to be a bug in the seeedstudio-dongle, rarely
+                        # the end-byte is missing. Rarely: ~0.1% of the packets?
+                        # The communication works otherwise fine, no bad data
+                        # packets have been observed. Probably the underlying
+                        # usb-driver serves as a good protection.
+                        # No bad packets (corrupted data), despite this one
+                        # end-byte has been observed.
+                        # To ensure no data is lost, we fake an end-byte here.
+                        end_packet_opt = "U"
+                    end_packet = ord(end_packet_opt)
                     if end_packet == 0x55:
                         msg = Message(
                             timestamp=time_stamp,


### PR DESCRIPTION
## Summary of Changes

It fixes all my issues with seeedstudio can dongle.
Also, python-can does not throw any TypeError's anymore due to "ord()" not failing due to missing data from the serial port.

## Related Issues / Pull Requests

- Closes: https://github.com/hardbyte/python-can/issues/2024

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html). (I did not use tox)
- [ ] I have added or updated tests as appropriate.
- [ ] I have added or updated documentation as appropriate.
- [ ] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [ ] All checks and tests pass (`tox`). (Don't know how to run tox on nixos)

## Additional Notes

<!-- Add any other information or context you want to share. -->
