### PR TITLE
Added notifier restart method and tests

### DIFF
--- a/can/notifier.py
+++ b/can/notifier.py
@@ -10,11 +10,7 @@ import time
 from collections.abc import Awaitable, Callable, Iterable
 from contextlib import AbstractContextManager
 from types import TracebackType
-from typing import (
-    Any,
-    Final,
-    NamedTuple,
-)
+from typing import Any, Final, NamedTuple
 
 from can.bus import BusABC
 from can.listener import Listener
@@ -101,7 +97,6 @@ class _NotifierRegistry:
 
 
 class Notifier(AbstractContextManager["Notifier"]):
-
     _registry: Final = _NotifierRegistry()
 
     def __init__(
@@ -316,20 +311,20 @@ class Notifier(AbstractContextManager["Notifier"]):
 
     def restart(self) -> None:
         """Restarts the Notifier if it has been stopped.
-        
+
         :raises RuntimeWarning: If the notifier is already running.
         """
         with self._lock:
             if not self._stopped:
                 raise RuntimeWarning("Notifier is already running.")
-            
+
             self._stopped = False
             self.exception = None
             # Note: _bus_list is preserved from previous run
-            
+
             for bus in self._bus_list:
                 self._start_reader(bus)
-            
+
             # Re-trigger listeners if they have a start method
             for listener in self.listeners:
                 if hasattr(listener, "start"):

--- a/can/notifier.py
+++ b/can/notifier.py
@@ -12,6 +12,7 @@ from contextlib import AbstractContextManager
 from types import TracebackType
 from typing import Any, Final, NamedTuple
 
+from can import CanError
 from can.bus import BusABC
 from can.listener import Listener
 from can.message import Message
@@ -225,18 +226,20 @@ class Notifier(AbstractContextManager["Notifier"]):
                 if msg := bus.recv(self.timeout):
                     with self._lock:
                         handle_message(msg)
-            except Exception as exc:  # pylint: disable=broad-except
+            except CanError as exc:
                 self.exception = exc
+                # Always notify the system when the bus fails
                 if self._loop is not None:
                     self._loop.call_soon_threadsafe(self._on_error, exc)
-                    # Raise anyway
-                    raise
-                elif not self._on_error(exc):
-                    # If it was not handled, raise the exception here
-                    raise
                 else:
-                    # It was handled, so only log it
-                    logger.debug("suppressed exception: %s", exc)
+                    self._on_error(exc)
+                logger.error("CAN error in notifier thread: %s", exc)
+            except Exception as exc:
+                # Catching other runtime errors to prevent silent thread death
+                self.exception = exc
+                logger.critical("Unexpected error in notifier thread: %s", exc)
+                self._on_error(exc)
+                raise  # Re-raise unexpected non-CAN errors
 
     def _on_message_available(self, bus: BusABC) -> None:
         if msg := bus.recv(0):
@@ -330,7 +333,7 @@ class Notifier(AbstractContextManager["Notifier"]):
                 if hasattr(listener, "start"):
                     try:
                         listener.start()
-                    except Exception as e:
+                    except (AttributeError, RuntimeError, TypeError, ValueError) as e:
                         logger.error("Failed to restart listener: %s", e)
 
     def __exit__(

--- a/can/notifier.py
+++ b/can/notifier.py
@@ -158,28 +158,21 @@ class Notifier(AbstractContextManager["Notifier"]):
         return tuple(self._bus_list)
 
     def add_bus(self, bus: BusABC) -> None:
-        """Add a bus for notification.
-
-        :param bus:
-            CAN bus instance.
-        :raises ValueError:
-            If the *bus* is already assigned to an active :class:`~can.Notifier`.
-        """
-        # add bus to notifier registry
-        Notifier._registry.register(bus, self)
-
-        # add bus to internal bus list
+        """Add a bus for notification."""
         self._bus_list.append(bus)
+        self._start_reader(bus)
+
+    def _start_reader(self, bus: BusABC) -> None:
+        """Internal helper to spin up the actual background worker for a bus."""
+        Notifier._registry.register(bus, self)
 
         file_descriptor: int = -1
         try:
             file_descriptor = bus.fileno()
         except NotImplementedError:
-            # Bus doesn't support fileno, we fall back to thread based reader
             pass
 
         if self._loop is not None and file_descriptor >= 0:
-            # Use bus file descriptor to watch for messages
             self._loop.add_reader(file_descriptor, self._on_message_available, bus)
             self._readers.append(file_descriptor)
         else:
@@ -217,6 +210,10 @@ class Notifier(AbstractContextManager["Notifier"]):
         # remove bus from registry
         for bus in self._bus_list:
             Notifier._registry.unregister(bus, self)
+
+        self._readers = []
+        # Clear any pending asyncio tasks to prevent stale references
+        self._tasks.clear()
 
     def _rx_thread(self, bus: BusABC) -> None:
         # determine message handling callable early, not inside while loop
@@ -316,6 +313,30 @@ class Notifier(AbstractContextManager["Notifier"]):
             A tuple of :class:`~can.Notifier` instances associated with the given bus.
         """
         return Notifier._registry.find_instances(bus)
+
+    def restart(self) -> None:
+        """Restarts the Notifier if it has been stopped.
+        
+        :raises RuntimeWarning: If the notifier is already running.
+        """
+        with self._lock:
+            if not self._stopped:
+                raise RuntimeWarning("Notifier is already running.")
+            
+            self._stopped = False
+            self.exception = None
+            # Note: _bus_list is preserved from previous run
+            
+            for bus in self._bus_list:
+                self._start_reader(bus)
+            
+            # Re-trigger listeners if they have a start method
+            for listener in self.listeners:
+                if hasattr(listener, "start"):
+                    try:
+                        listener.start()
+                    except Exception as e:
+                        logger.error("Failed to restart listener: %s", e)
 
     def __exit__(
         self,

--- a/doc/changelog.d/2055.added.rst
+++ b/doc/changelog.d/2055.added.rst
@@ -1,1 +1,1 @@
-Added new Notifier Restart method
+Added new Notifier Restart method.

--- a/doc/changelog.d/2055.added.rst
+++ b/doc/changelog.d/2055.added.rst
@@ -1,0 +1,1 @@
+Added new Notifier Restart method

--- a/test/notifier_test.py
+++ b/test/notifier_test.py
@@ -72,6 +72,58 @@ class NotifierTest(unittest.TestCase):
                 # find_instance must return the existing instance
                 self.assertEqual(can.Notifier.find_instances(bus), (notifier,))
 
+    def test_restart(self):
+        with can.Bus("test", interface="virtual", receive_own_messages=True) as bus:
+            reader = can.BufferedReader()
+            notifier = can.Notifier(bus, [reader], 0.1)
+            
+            bus.send(can.Message(arbitration_id=0x123))
+            self.assertIsNotNone(reader.get_message(1))
+            
+            notifier.stop()
+            self.assertTrue(notifier.stopped)
+            
+            new_reader = can.BufferedReader()
+            notifier.listeners = [new_reader]
+            
+            notifier.restart()
+            self.assertFalse(notifier.stopped)
+            
+            # Small settling time for the thread to actually start
+            time.sleep(0.2)
+            
+            # Send and Verify
+            msg = can.Message(arbitration_id=0xABC)
+            bus.send(msg)
+            
+            recv = new_reader.get_message(1)
+            self.assertIsNotNone(recv, "Failed to receive message after restart")
+            self.assertEqual(recv.arbitration_id, 0xABC)
+            
+            notifier.stop()
+
+    def test_restart_registry_lifecycle(self):
+        with can.Bus("test", interface="virtual", receive_own_messages=True) as bus:
+            notifier = can.Notifier(bus, [], 0.1)
+            notifier.stop()
+            
+            # Verify it is removed from registry
+            self.assertEqual(can.Notifier.find_instances(bus), ())
+            
+            notifier.restart()
+            
+            # Verify it is back in the registry and blocking others
+            self.assertEqual(can.Notifier.find_instances(bus), (notifier,))
+            self.assertRaises(ValueError, can.Notifier, bus, [], 0.1)
+            
+            notifier.stop()
+
+    def test_double_restart_warning(self):
+        with can.Bus("test", interface="virtual", receive_own_messages=True) as bus:
+            with can.Notifier(bus, [], 0.1) as notifier:
+                # Attempting to restart an already running notifier should warn
+                with self.assertRaises(RuntimeWarning):
+                    notifier.restart()
 
 class AsyncNotifierTest(unittest.TestCase):
     def test_asyncio_notifier(self):
@@ -84,6 +136,36 @@ class AsyncNotifierTest(unittest.TestCase):
                 bus.send(can.Message())
                 recv_msg = await asyncio.wait_for(reader.get_message(), 0.5)
                 self.assertIsNotNone(recv_msg)
+                notifier.stop()
+
+        asyncio.run(run_it())
+
+    def test_asyncio_notifier_restart(self):
+        async def run_it():
+            with can.Bus("test", interface="virtual", receive_own_messages=True) as bus:
+                reader = can.AsyncBufferedReader()
+                notifier = can.Notifier(
+                    bus, [reader], 0.1, loop=asyncio.get_running_loop()
+                )
+                
+                notifier.stop()
+                
+                # In some cases, creating a new listener is the safest path for a restart
+                new_reader = can.AsyncBufferedReader()
+                notifier.listeners = [new_reader] 
+                
+                notifier.restart()
+                
+                # Small yield to let the selector register the FD
+                await asyncio.sleep(0.1)
+                
+                bus.send(can.Message(arbitration_id=0x123))
+                
+                recv_msg = await asyncio.wait_for(new_reader.get_message(), 1.5)
+                
+                self.assertIsNotNone(recv_msg)
+                self.assertEqual(recv_msg.arbitration_id, 0x123)
+                
                 notifier.stop()
 
         asyncio.run(run_it())

--- a/test/notifier_test.py
+++ b/test/notifier_test.py
@@ -76,46 +76,46 @@ class NotifierTest(unittest.TestCase):
         with can.Bus("test", interface="virtual", receive_own_messages=True) as bus:
             reader = can.BufferedReader()
             notifier = can.Notifier(bus, [reader], 0.1)
-            
+
             bus.send(can.Message(arbitration_id=0x123))
             self.assertIsNotNone(reader.get_message(1))
-            
+
             notifier.stop()
             self.assertTrue(notifier.stopped)
-            
+
             new_reader = can.BufferedReader()
             notifier.listeners = [new_reader]
-            
+
             notifier.restart()
             self.assertFalse(notifier.stopped)
-            
+
             # Small settling time for the thread to actually start
             time.sleep(0.2)
-            
+
             # Send and Verify
             msg = can.Message(arbitration_id=0xABC)
             bus.send(msg)
-            
+
             recv = new_reader.get_message(1)
             self.assertIsNotNone(recv, "Failed to receive message after restart")
             self.assertEqual(recv.arbitration_id, 0xABC)
-            
+
             notifier.stop()
 
     def test_restart_registry_lifecycle(self):
         with can.Bus("test", interface="virtual", receive_own_messages=True) as bus:
             notifier = can.Notifier(bus, [], 0.1)
             notifier.stop()
-            
+
             # Verify it is removed from registry
             self.assertEqual(can.Notifier.find_instances(bus), ())
-            
+
             notifier.restart()
-            
+
             # Verify it is back in the registry and blocking others
             self.assertEqual(can.Notifier.find_instances(bus), (notifier,))
             self.assertRaises(ValueError, can.Notifier, bus, [], 0.1)
-            
+
             notifier.stop()
 
     def test_double_restart_warning(self):
@@ -124,6 +124,7 @@ class NotifierTest(unittest.TestCase):
                 # Attempting to restart an already running notifier should warn
                 with self.assertRaises(RuntimeWarning):
                     notifier.restart()
+
 
 class AsyncNotifierTest(unittest.TestCase):
     def test_asyncio_notifier(self):
@@ -147,25 +148,25 @@ class AsyncNotifierTest(unittest.TestCase):
                 notifier = can.Notifier(
                     bus, [reader], 0.1, loop=asyncio.get_running_loop()
                 )
-                
+
                 notifier.stop()
-                
+
                 # In some cases, creating a new listener is the safest path for a restart
                 new_reader = can.AsyncBufferedReader()
-                notifier.listeners = [new_reader] 
-                
+                notifier.listeners = [new_reader]
+
                 notifier.restart()
-                
+
                 # Small yield to let the selector register the FD
                 await asyncio.sleep(0.1)
-                
+
                 bus.send(can.Message(arbitration_id=0x123))
-                
+
                 recv_msg = await asyncio.wait_for(new_reader.get_message(), 1.5)
-                
+
                 self.assertIsNotNone(recv_msg)
                 self.assertEqual(recv_msg.arbitration_id, 0x123)
-                
+
                 notifier.stop()
 
         asyncio.run(run_it())


### PR DESCRIPTION
<!--
Thank you for contributing to python-can!
Please fill out the following template to help us review your pull request.
-->

## Summary of Changes

<!-- Briefly describe what your pull request does. -->
Adds notifier restart function as requested in #2030 .
- 

## Related Issues / Pull Requests

<!-- List any related issues, pull requests, or discussions. -->

- Closes #2030 
- Related to #

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [X] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [X] I have added or updated tests as appropriate.
- [X] I have added or updated documentation as appropriate.
- [x] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [X] All checks and tests pass (`tox`).

## Additional Notes

<!-- Add any other information or context you want to share. -->
