### PR TITLE
Replaced select.select() with select.epoll() in SocketcanBus

### DIFF
--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -5,8 +5,8 @@ along some internal methods.
 At the end of the file the usage of the internal methods is shown.
 """
 
+# pylint: disable=too-many-lines
 import ctypes
-import ctypes.util
 import errno
 import logging
 import select
@@ -786,6 +786,10 @@ class SocketcanBus(BusABC):  # pylint: disable=abstract-method
         #     so this is always supported by the kernel
         self.socket.setsockopt(socket.SOL_SOCKET, constants.SO_TIMESTAMPNS, 1)
 
+        # Create epoll instance and register socket for read and write events
+        self._epoll = select.epoll()
+        self._epoll.register(self.socket.fileno(), select.EPOLLIN | select.EPOLLOUT)
+
         try:
             bind_socket(self.socket, channel)
             kwargs.update(
@@ -810,6 +814,9 @@ class SocketcanBus(BusABC):  # pylint: disable=abstract-method
         for channel, bcm_socket in self._bcm_sockets.items():
             log.debug("Closing bcm socket for channel %s", channel)
             bcm_socket.close()
+        if not self._epoll.closed:
+            self._epoll.unregister(self.socket.fileno())
+            self._epoll.close()
         log.debug("Closing raw can socket")
         self.socket.close()
 
@@ -817,7 +824,9 @@ class SocketcanBus(BusABC):  # pylint: disable=abstract-method
         try:
             # get all sockets that are ready (can be a list with a single value
             # being self.socket or an empty list if self.socket is not ready)
-            ready_receive_sockets, _, _ = select.select([self.socket], [], [], timeout)
+            epoll_timeout = timeout if timeout is not None else -1
+            events = self._epoll.poll(epoll_timeout)
+            ready_receive_sockets = any(event & select.EPOLLIN for _, event in events)
         except OSError as error:
             # something bad happened (e.g. the interface went down)
             raise can.CanOperationError(
@@ -859,7 +868,8 @@ class SocketcanBus(BusABC):  # pylint: disable=abstract-method
 
         while time_left >= 0:
             # Wait for write availability
-            ready = select.select([], [self.socket], [], time_left)[1]
+            events = self._epoll.poll(time_left)
+            ready = any(event & select.EPOLLOUT for _, event in events)
             if not ready:
                 # Timeout
                 break

--- a/doc/changelog.d/2053.fixed.rst
+++ b/doc/changelog.d/2053.fixed.rst
@@ -1,0 +1,1 @@
+Replaced select.select() with select.epoll() in SocketcanBus

--- a/test/test_socketcan.py
+++ b/test/test_socketcan.py
@@ -5,10 +5,14 @@ Test functions in `can.interfaces.socketcan.socketcan`.
 """
 
 import ctypes
+import os
+import resource
 import struct
 import sys
+import tempfile
 import unittest
 import warnings
+from contextlib import ExitStack
 from unittest.mock import patch
 
 import can
@@ -389,6 +393,34 @@ class SocketCANTest(unittest.TestCase):
                     "Please check if PyPy has implemented raw CAN socket support! "
                     "See: https://github.com/pypy/pypy/issues/3808"
                 )
+
+    @unittest.skipUnless(TEST_INTERFACE_SOCKETCAN, "Only run when vcan0 is available")
+    @unittest.skipUnless(
+        resource.getrlimit(resource.RLIMIT_NOFILE)[0] > 1024,
+        "Only run when the system supports high file limit",
+    )
+    def test_high_socket_fileno(self):
+        """send() and recv() succeed when socket fileno > 1023."""
+        num_open_files = len(os.listdir("/proc/self/fd"))
+        num_files_to_open = 1024 - num_open_files
+        with ExitStack() as stack:
+            for _ in range(num_files_to_open):
+                stack.enter_context(tempfile.TemporaryFile())
+
+            bus1 = can.Bus(interface="socketcan", channel="vcan0")
+            bus2 = can.Bus(interface="socketcan", channel="vcan0")
+            msg = can.Message(
+                is_extended_id=False,
+                arbitration_id=0x100,
+                data=[1, 2, 3, 4, 5, 6, 7, 8],
+            )
+
+            timeout = 1.0 if IS_PYPY else 0.1
+            bus1.send(msg)
+            recv_msg = bus2.recv(timeout)
+            self.assertIsNotNone(recv_msg)
+            self.assertEqual(recv_msg.arbitration_id, 0x100)
+            self.assertEqual(recv_msg.data, bytearray([1, 2, 3, 4, 5, 6, 7, 8]))
 
 
 if __name__ == "__main__":

--- a/test/test_socketcan.py
+++ b/test/test_socketcan.py
@@ -6,7 +6,6 @@ Test functions in `can.interfaces.socketcan.socketcan`.
 
 import ctypes
 import os
-import resource
 import struct
 import sys
 import tempfile
@@ -32,7 +31,20 @@ from can.interfaces.socketcan.socketcan import (
     build_bcm_update_header,
 )
 
-from .config import IS_LINUX, IS_PYPY, TEST_INTERFACE_SOCKETCAN
+from .config import IS_LINUX, IS_PYPY, IS_WINDOWS, TEST_INTERFACE_SOCKETCAN
+
+if IS_WINDOWS:
+
+    def get_fd_limit() -> int:
+        """Get the current limit on the number of file descriptors."""
+        return ctypes.CDLL("msvcrt")._getmaxstdio()
+
+else:
+    import resource
+
+    def get_fd_limit() -> int:
+        """Get the current limit on the number of file descriptors."""
+        return resource.getrlimit(resource.RLIMIT_NOFILE)[0]
 
 
 class SocketCANTest(unittest.TestCase):
@@ -396,7 +408,7 @@ class SocketCANTest(unittest.TestCase):
 
     @unittest.skipUnless(TEST_INTERFACE_SOCKETCAN, "Only run when vcan0 is available")
     @unittest.skipUnless(
-        resource.getrlimit(resource.RLIMIT_NOFILE)[0] > 1024,
+        get_fd_limit() > 1024,
         "Only run when the system supports high file limit",
     )
     def test_high_socket_fileno(self):


### PR DESCRIPTION
<!--
Thank you for contributing to python-can!
Please fill out the following template to help us review your pull request.
-->

## Summary of Changes

<!-- Briefly describe what your pull request does. -->

- Replace usage of `select.select()` with `select.epoll()` in `SocketcanBus` to avoid a `ValueError` being raised when a high number of files (>1024) are open

## Related Issues / Pull Requests

<!-- List any related issues, pull requests, or discussions. -->

- Closes #2053 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [x] I have added or updated tests as appropriate.
- [x] I have added or updated documentation as appropriate.
- [x] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [x] All checks and tests pass (`tox`).

## Additional Notes

<!-- Add any other information or context you want to share. -->