### PR TITLE
fix(pcan): swap SetValue and GetErrorText docstrings

### DIFF
--- a/can/interfaces/pcan/basic.py
+++ b/can/interfaces/pcan/basic.py
@@ -990,12 +990,10 @@ class PCANBasic:
             logger.error("Exception on PCANBasic.GetValue")
             raise
 
-    # Returns a descriptive text of a given TPCANStatus
-    # error code, in any desired language
+    # Configures or sets a PCAN Channel value
     #
     def SetValue(self, Channel, Parameter, Buffer):
-        """Returns a descriptive text of a given TPCANStatus error
-        code, in any desired language
+        """Configures or sets a PCAN Channel value
 
         Remarks:
           Parameters can be present or not according with the kind
@@ -1036,7 +1034,8 @@ class PCANBasic:
             raise
 
     def GetErrorText(self, Error, Language=0):
-        """Configures or sets a PCAN Channel value
+        """Returns a descriptive text of a given TPCANStatus error
+        code, in any desired language
 
         Remarks:
 


### PR DESCRIPTION
Fixes #2047.

In `can/interfaces/pcan/basic.py`, the docstrings (and the preceding `# Returns a descriptive text...` C-style comment) on `SetValue` and `GetErrorText` were swapped:

- `SetValue` (line 996) described "Returns a descriptive text of a given TPCANStatus error code".
- `GetErrorText` (line 1038) described "Configures or sets a PCAN Channel value".

Both functions' implementations are correct; only the docstrings disagreed with the code. This swap restores each docstring to its matching function, so `help(PCANBasic.SetValue)` and `help(PCANBasic.GetErrorText)` describe what they actually do.

Verified locally: `python -c "from can.interfaces.pcan.basic import PCANBasic; help(PCANBasic.SetValue)"` now reports "Configures or sets a PCAN Channel value".