### PR TITLE
fix: only call _validate() when strict=True

### DIFF
--- a/can/bit_timing.py
+++ b/can/bit_timing.py
@@ -74,8 +74,8 @@ class BitTiming(Mapping[str, int]):
             "sjw": sjw,
             "nof_samples": nof_samples,
         }
-        self._validate()
         if strict:
+            self._validate()
             self._restrict_to_minimum_range()
 
     def _validate(self) -> None:

--- a/doc/changelog.d/2061.fixed.rst
+++ b/doc/changelog.d/2061.fixed.rst
@@ -1,0 +1,1 @@
+Fix ``can.BitTiming`` rejecting bit rate prescaler values greater than 64 even when ``strict=False``.


### PR DESCRIPTION
## Summary

Fix BitTiming rejecting brp values > 64 even when `strict=False`.

## Root Cause

`self._validate()` was called unconditionally in `__init__`, even when `strict=False`. The validation rejects brp values outside [1,64], which is too restrictive for peripherals like FYSETC UCAN that support brp up to 1024.

## Fix

Only call `_validate()` when `strict=True`:



This makes validation consistent - both  and  only run when `strict=True`.

## Testing

With this fix, peripherals like FYSETC UCAN (candleLight firmware) can use brp > 64 without ValueError.

Closes #2061