### PR TITLE
refactor(notifier): change listeners from list to set for uniqueness

### DIFF
--- a/can/notifier.py
+++ b/can/notifier.py
@@ -133,7 +133,7 @@ class Notifier(AbstractContextManager["Notifier"]):
         :raises ValueError:
             If a passed in *bus* is already assigned to an active :class:`~can.Notifier`.
         """
-        self.listeners: list[MessageRecipient] = list(listeners)
+        self.listeners: set[MessageRecipient] = set(listeners)
         self._bus_list: list[BusABC] = []
         self.timeout = timeout
         self._loop = loop
@@ -278,20 +278,18 @@ class Notifier(AbstractContextManager["Notifier"]):
         return was_handled
 
     def add_listener(self, listener: MessageRecipient) -> None:
-        """Add new Listener to the notification list.
-        If it is already present, it will be called two times
-        each time a message arrives.
+        """Add new Listener to the notification set.
 
         :param listener: Listener to be added to the list to be notified
         """
-        self.listeners.append(listener)
+        self.listeners.add(listener)
 
     def remove_listener(self, listener: MessageRecipient) -> None:
-        """Remove a listener from the notification list. This method
+        """Remove a listener from the notification set. This method
         throws an exception if the given listener is not part of the
         stored listeners.
 
-        :param listener: Listener to be removed from the list to be notified
+        :param listener: Listener to be removed from the set to be notified
         :raises ValueError: if `listener` was never added to this notifier
         """
         self.listeners.remove(listener)


### PR DESCRIPTION
<!--
Thank you for contributing to python-can!
Please fill out the following template to help us review your pull request.
-->

## Summary of Changes

<!-- Briefly describe what your pull request does. -->

Change listeners in the Notifier from list to set for uniqueness
This prevents adding the same listener multiple times

## Related Issues / Pull Requests

<!-- List any related issues, pull requests, or discussions. -->

- Closes #
- Related to #

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [x] I have added or updated tests as appropriate.
- [x] I have added or updated documentation as appropriate.
- [ ] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [x] All checks and tests pass (`tox`).

## Additional Notes

<!-- Add any other information or context you want to share. -->
