### PR TITLE
Implement support for timing parameters in can.ini for pcan

### DIFF
--- a/can/interfaces/pcan/pcan.py
+++ b/can/interfaces/pcan/pcan.py
@@ -273,6 +273,19 @@ class PcanBus(BusABC):
         else:
             raise ValueError("BusState must be Active or Passive")
 
+    
+        # Check if the user provided parameters to build a BitTiming object
+        timing_keys = {"f_clock", "brp", "tseg1", "tseg2", "sjw"}
+        if timing is None and not is_fd and timing_keys.issubset(kwargs.keys()):
+            timing = BitTiming(
+                f_clock=kwargs.get("f_clock"),
+                brp=kwargs.get("brp"),
+                tseg1=kwargs.get("tseg1"),
+                tseg2=kwargs.get("tseg2"),
+                sjw=kwargs.get("sjw"),
+            )
+
+
         if isinstance(timing, BitTiming):
             timing = check_or_adjust_timing_clock(timing, VALID_PCAN_CAN_CLOCKS)
             pcan_bitrate = TPCANBaudrate(timing.btr0 << 8 | timing.btr1)

--- a/doc/changelog.d/2069.support_timing_can_ini_pcan.rst
+++ b/doc/changelog.d/2069.support_timing_can_ini_pcan.rst
@@ -1,0 +1,1 @@
+Add support for bit CAN timing parameters in can.ini for pcan interface.


### PR DESCRIPTION

<!--
Thank you for contributing to python-can!
Please fill out the following template to help us review your pull request.
-->

## Summary of Changes

Add support for building BitTiming object from kwargs, which makes it possible to support timing parameters from can.ini. Whether this should be considered a new feature, or a bugfix for something that would be expected to be supported already, I leave up to others to decide.

This makes standard definitions like the example below work as expected in can.ini. CAN-FD support has not been implemented.
```
[pcan_125_kbit_50_perc]
interface = pcan
channel = PCAN_USBBUS1
f_clock = 8000000
brp=8
tseg1 = 3
tseg2 = 4
sjw = 2
```
## Related Issues / Pull Requests

This fixes #2068 for standard CAN

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [ ] I have added or updated tests as appropriate.
- [ ] I have added or updated documentation as appropriate.
- [x] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [ ] All checks and tests pass (`tox`).

## Additional Notes

<!-- Add any other information or context you want to share. -->
