### PR TITLE
Fix SeeedStudio recv crash on empty serial read

### DIFF
--- a/can/interfaces/seeedstudio/seeedstudio.py
+++ b/can/interfaces/seeedstudio/seeedstudio.py
@@ -265,7 +265,10 @@ class SeeedBus(BusABC):
 
         if rx_byte_1 and ord(rx_byte_1) == 0xAA:
             try:
-                rx_byte_2 = ord(self.ser.read())
+                rx_byte_2_raw = self.ser.read()
+                if not rx_byte_2_raw:
+                    return None, self._is_filtered
+                rx_byte_2 = rx_byte_2_raw[0]
 
                 time_stamp = time()
                 if rx_byte_2 == 0x55:
@@ -286,7 +289,10 @@ class SeeedBus(BusABC):
                         arb_id = (struct.unpack("<H", s_3_4))[0]
 
                     data = bytearray(self.ser.read(length))
-                    end_packet = ord(self.ser.read())
+                    end_packet_raw = self.ser.read()
+                    if not end_packet_raw:
+                        return None, self._is_filtered
+                    end_packet = end_packet_raw[0]
                     if end_packet == 0x55:
                         msg = Message(
                             timestamp=time_stamp,


### PR DESCRIPTION
<!--
Thank you for contributing to python-can!
Please fill out the following template to help us review your pull request.
-->

## Summary of Changes

Fix Seeed Studio CAN interface handling of empty reads.

- 

## Related Issues / Pull Requests

<!-- List any related issues, pull requests, or discussions. -->

- Closes #2024
- Related to #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [x] I have added or updated tests as appropriate.
- [ ] I have added or updated documentation as appropriate.
- [ ] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [ ] All checks and tests pass (`tox`).

## Additional Notes

This fixes the crash described in #2024 by guarding against empty reads before trying to parse the returned data. I reproduced the failure path, confirmed that an empty read could be returned, and updated the receive logic so empty data is skipped instead of being treated as a valid frame.