### PR TITLE
SocketCAN send timeout semantics

### DIFF
--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -841,7 +841,7 @@ class SocketcanBus(BusABC):  # pylint: disable=abstract-method
         :param msg: A message object.
         :param timeout:
             Wait up to this many seconds for the transmit queue to be ready.
-            If not given, the call may fail immediately.
+            If not given, wait indefinitely.
 
         :raises ~can.exceptions.CanError:
             if the message could not be written.
@@ -851,13 +851,10 @@ class SocketcanBus(BusABC):  # pylint: disable=abstract-method
         logger_tx.debug("sending: %s", msg)
 
         started = time.time()
-        # If no timeout is given, poll for availability
-        if timeout is None:
-            timeout = 0
         time_left = timeout
         data = build_can_frame(msg)
 
-        while time_left >= 0:
+        while time_left is None or time_left >= 0:
             # Wait for write availability
             ready = select.select([], [self.socket], [], time_left)[1]
             if not ready:
@@ -869,7 +866,8 @@ class SocketcanBus(BusABC):  # pylint: disable=abstract-method
                 return
             # Not all data were sent, try again with remaining data
             data = data[sent:]
-            time_left = timeout - (time.time() - started)
+            if timeout is not None:
+                time_left = timeout - (time.time() - started)
 
         raise can.CanOperationError("Transmit buffer full")
 

--- a/test/test_socketcan.py
+++ b/test/test_socketcan.py
@@ -9,7 +9,7 @@ import struct
 import sys
 import unittest
 import warnings
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import can
 from can.interfaces.socketcan.constants import (
@@ -21,6 +21,7 @@ from can.interfaces.socketcan.constants import (
 )
 from can.interfaces.socketcan.socketcan import (
     BcmMsgHead,
+    SocketcanBus,
     bcm_header_factory,
     build_bcm_header,
     build_bcm_transmit_header,
@@ -35,6 +36,19 @@ class SocketCANTest(unittest.TestCase):
     def setUp(self):
         self._ctypes_sizeof = ctypes.sizeof
         self._ctypes_alignment = ctypes.alignment
+
+    @patch("can.interfaces.socketcan.socketcan.select.select")
+    def test_send_without_timeout_blocks_indefinitely(self, select):
+        bus = SocketcanBus.__new__(SocketcanBus)
+        bus.channel = "can0"
+        bus.socket = MagicMock()
+        bus._send_once = MagicMock(side_effect=[1, 15])
+        select.return_value = ([], [bus.socket], [])
+
+        bus.send(can.Message(arbitration_id=0x123, data=[1, 2, 3, 4]))
+
+        self.assertEqual(2, select.call_count)
+        self.assertTrue(all(call.args[3] is None for call in select.call_args_list))
 
     @unittest.skipIf(sys.version_info >= (3, 14), "Fails on Python 3.14 or newer")
     @patch("ctypes.sizeof")


### PR DESCRIPTION
Fixes #2005.

SocketCAN now follows the BusABC timeout contract: `send(timeout=None)` waits indefinitely for the transmit queue instead of polling immediately.

Validation:
- `python -m pytest test/test_socketcan.py -q`
- `python -m compileall can/interfaces/socketcan/socketcan.py`