### PR TITLE
Optimize slcan serial read and buffer processing

### DIFF
--- a/can/interfaces/slcan.py
+++ b/can/interfaces/slcan.py
@@ -219,21 +219,28 @@ class slcanBus(BusABC):
 
         with error_check("Could not read from serial device"):
             while True:
-                # Due to accessing `serialPortOrig.in_waiting` too often will reduce
-                # the performance. We read the `serialPortOrig.in_waiting` only once here.
-                size = self.serialPortOrig.in_waiting or 1
-                self._buffer.extend(self.serialPortOrig.read(size))
-
-                for i, byte in enumerate(self._buffer):
-                    if byte in (self._OK[0], self._ERROR[0]):
-                        string = self._buffer[: i + 1].decode()
-                        del self._buffer[: i + 1]
-                        return string
-
-                if _timeout.expired():
-                    break
-
-            return None
+                size = self.serialPortOrig.in_waiting or 1          # read the `serialPortOrig.in_waiting` only once.
+                self._buffer.extend(self.serialPortOrig.read(size)) # read serial at once
+    
+                i1 = self._buffer.find(self._OK)                    # bytearray.find() or byte.find() is in C level
+                i2 = self._buffer.find(self._ERROR)
+    
+                if i1 >= 0 and i2 >= 0:
+                    i = i1 if i1 < i2 else i2                       # python if/else branch is faster than min()/max()
+                elif i1 >= 0:
+                    i = i1
+                elif i2 >= 0:
+                    i = i2
+                else:
+                    if _timeout.expired():
+                        break
+                    continue
+    
+                string = self._buffer[:i + 1].decode()
+                del self._buffer[:i + 1]
+                return string
+    
+        return None
 
     def flush(self) -> None:
         self._buffer.clear()


### PR DESCRIPTION
Refactor reading from serial to improve performance by using C level's bytearray.find() to replace `for` iteration.

<!--
Thank you for contributing to python-can!
Please fill out the following template to help us review your pull request.
-->

## Summary of Changes

<!-- Briefly describe what your pull request does. -->

Key changes:
- Removed the Python-level `for i, byte in enumerate(buffer): if byte in (ok, err): ...` loop
- Replaced with two `buffer.find(byte)` calls at C level for terminator detection

## Related Issues / Pull Requests

- None

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [x] I have added or updated tests as appropriate.
- [ ] I have added or updated documentation as appropriate.
- [ ] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [x] All checks and tests pass (`tox`).

## Additional Notes

<!-- Add any other information or context you want to share. -->

| Method                   | vs `bytearray.find` (v5) |
|--------------------------|--------------------------|
| v1  for loop             | ~2–4× slower             |
| v2  single-pass local    | ~2–4× slower             |
| v3  filter+next          | ~3–6× slower             |
| v4  bytes.find           | ~1.5–2× slower (copy overhead) |
| **v5  bytearray.find**   | **1.0× (baseline)**      |

I could also provide performance testing scripts (generate by AI) if you need.
