### PR TITLE
Fix Systec error message lookup

### DIFF
--- a/can/interfaces/systec/exceptions.py
+++ b/can/interfaces/systec/exceptions.py
@@ -13,10 +13,11 @@ class UcanException(CanError, ABC):
         self.func = func
         self.arguments = arguments
 
-        message = self._error_message_mapping.get(result, "unknown")
+        result_code = result.value
+        message = self._error_message_mapping.get(result_code, "unknown")
         super().__init__(
             message=f"Function {func.__name__} (called with {arguments}): {message}",
-            error_code=result.value,
+            error_code=result_code,
         )
 
     @property

--- a/doc/changelog.d/2077.fixed.rst
+++ b/doc/changelog.d/2077.fixed.rst
@@ -1,0 +1,1 @@
+Fixed Systec errors raising ``TypeError`` instead of reporting the underlying USB-CAN return code.

--- a/test/test_systec.py
+++ b/test/test_systec.py
@@ -5,6 +5,8 @@ from unittest.mock import Mock, patch
 
 import can
 from can.interfaces.systec import ucan, ucanbus
+from can.interfaces.systec.constants import ReturnCode
+from can.interfaces.systec.exceptions import UcanError
 from can.interfaces.systec.ucan import *
 
 
@@ -45,6 +47,15 @@ class SystecTest(unittest.TestCase):
         self.assertTrue(ucan.UcanInitCanEx2.called)
         self.assertTrue(ucan.UcanGetHardwareInfoEx2.called)
         self.assertTrue(ucan.UcanSetAcceptanceEx.called)
+
+    def test_error_preserves_ctypes_return_code_message(self):
+        def failing_function():
+            pass
+
+        error = UcanError(ReturnCode(ReturnCode.ERR_ILLPARAM), failing_function, ())
+
+        self.assertEqual(error.error_code, ReturnCode.ERR_ILLPARAM)
+        self.assertIn("wrong parameter handed over to the function", str(error))
 
     def test_bus_shutdown(self):
         self.bus.shutdown()


### PR DESCRIPTION
Fixes #2077.

The Systec backend passes a `ctypes` return-code object into its exception class. Looking up that object directly in the error-message table raises `TypeError` because it is not hashable, hiding the actual USB-CAN error.

The lookup now uses the numeric `.value`, while the original result object remains available on the exception. I also added a regression test and changelog entry.

Tests:

* `pytest test/test_systec.py -q` — 18 passed
* Ruff and Black checks passed
