### PR TITLE
Adding `flexible-serial` interface plugin

### DIFF
--- a/doc/changelog.d/2082.added.rst
+++ b/doc/changelog.d/2082.added.rst
@@ -1,0 +1,1 @@
+Added link to python-can-flexible-serial plugin in plugin interface documentation page

--- a/doc/plugin-interface.rst
+++ b/doc/plugin-interface.rst
@@ -62,29 +62,33 @@ The table below lists interface drivers that can be added by installing addition
 .. note::
    The packages listed below are maintained by other authors. Any issues should be reported in their corresponding repository and **not** in the python-can repository.
 
-+----------------------------+----------------------------------------------------------+
-| Name                       | Description                                              |
-+============================+==========================================================+
-| `python-can-canine`_       | CAN Driver for the CANine CAN interface                  |
-+----------------------------+----------------------------------------------------------+
-| `python-can-cvector`_      | Cython based version of the 'VectorBus'                  |
-+----------------------------+----------------------------------------------------------+
-| `python-can-remote`_       | CAN over network bridge                                  |
-+----------------------------+----------------------------------------------------------+
-| `python-can-sontheim`_     | CAN Driver for Sontheim CAN interfaces (e.g. CANfox)     |
-+----------------------------+----------------------------------------------------------+
-| `zlgcan`_                  | Python wrapper for zlgcan-driver-rs                      |
-+----------------------------+----------------------------------------------------------+
-| `python-can-cando`_        | Python wrapper for Netronics' CANdo and CANdoISO         |
-+----------------------------+----------------------------------------------------------+
-| `python-can-candle`_       | A full-featured driver for candleLight                   |
-+----------------------------+----------------------------------------------------------+
-| `python-can-coe`_          | A CAN-over-Ethernet interface for Technische Alternative |
-+----------------------------+----------------------------------------------------------+
-| `RP1210`_                  | CAN channels in RP1210 Vehicle Diagnostic Adapters       |
-+----------------------------+----------------------------------------------------------+
-| `python-can-damiao`_       | Interface for Damiao USB-CAN adapters                    |
-+----------------------------+----------------------------------------------------------+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Description
+   * - `python-can-canine`_
+     - CAN Driver for the CANine CAN interface
+   * - `python-can-cvector`_
+     - Cython based version of the 'VectorBus'
+   * - `python-can-remote`_
+     - CAN over network bridge
+   * - `python-can-sontheim`_
+     - CAN Driver for Sontheim CAN interfaces (e.g. CANfox)
+   * - `zlgcan`_
+     - Python wrapper for zlgcan-driver-rs
+   * - `python-can-cando`_
+     - Python wrapper for Netronics' CANdo and CANdoISO
+   * - `python-can-candle`_
+     - A full-featured driver for candleLight
+   * - `python-can-coe`_
+     - A CAN-over-Ethernet interface for Technische Alternative
+   * - `RP1210`_
+     - CAN channels in RP1210 Vehicle Diagnostic Adapters
+   * - `python-can-damiao`_
+     - Interface for Damiao USB-CAN adapters
+   * - `python-can-flexible-serial`_
+     - Expands the built in 'CAN over Serial' interface.
 
 .. _python-can-canine: https://github.com/tinymovr/python-can-canine
 .. _python-can-cvector: https://github.com/zariiii9003/python-can-cvector
@@ -96,4 +100,4 @@ The table below lists interface drivers that can be added by installing addition
 .. _python-can-coe: https://c0d3.sh/smarthome/python-can-coe
 .. _RP1210: https://github.com/dfieschko/RP1210
 .. _python-can-damiao: https://github.com/gaoyichuan/python-can-damiao
-
+.. _python-can-flexible-serial: https://github.com/mattbulow/python-can-flexible-serial

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ zlgcan = ["zlgcan"]
 candle = ["python-can-candle>=1.2.2"]
 rp1210 = ["rp1210>=1.0.1"]
 damiao = ["python-can-damiao"]
+flexible-serial = ["python-can-flexible-serial>=0.1.1"]
 viewer = [
     "windows-curses; platform_system == 'Windows' and platform_python_implementation=='CPython'"
 ]


### PR DESCRIPTION
## Summary of Changes

Adding to plugin interfaces documentation my `flexible-serial` plugin, which expands the built in 'CAN over Serial' interface. Introduces features to customize your message based serial frame and provide additional flags, CRC and CAN-FD support.

- 

## Related Issues / Pull Requests
None

- Closes #
- Related to #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [x] I have added or updated tests as appropriate.
- [x] I have added or updated documentation as appropriate.
- [x] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [x] All checks and tests pass (`tox`).

## Additional Notes

This plugin was built from the 'CAN over Serial' interface and is fully backwards compatible with it. Please let me know if it could be possible to get this to replace the current 'CAN over Serial' interface.
