### PR TITLE
fix: don't modify msg.data when padding frame for GsUsbFrame

### DIFF
--- a/can/interfaces/gs_usb.py
+++ b/can/interfaces/gs_usb.py
@@ -142,14 +142,14 @@ class GsUsbBus(can.BusABC):
         if msg.is_error_frame:
             can_id = can_id | CAN_ERR_FLAG
 
-        # Pad message data
-        msg.data.extend([0x00] * (CAN_MAX_DLC - len(msg.data)))
+        # Copy and pad message data without mutating msg.data
+        msg_data = msg.data + bytearray([0x00] * (CAN_MAX_DLC - len(msg.data)))
 
         frame = GsUsbFrame()
         frame.can_id = can_id
         frame.can_dlc = msg.dlc
         frame.timestamp_us = 0  # timestamp frame field is only useful on receive
-        frame.data = list(msg.data)
+        frame.data = list(msg_data)
 
         try:
             self.gs_usb.send(frame)

--- a/doc/changelog.d/2085.fixed.rst
+++ b/doc/changelog.d/2085.fixed.rst
@@ -1,0 +1,1 @@
+Fixed gs_usb.py modyfying the data member of the can.Message msg passed to GsUsbBus send method.

--- a/test/test_interface_gs_usb.py
+++ b/test/test_interface_gs_usb.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import can
 import pytest
 
 from can.interfaces.gs_usb import (
@@ -65,3 +66,22 @@ def test_find_devices_returns_empty_list_when_no_devices(mock_find):
     devices = _find_gs_usb_devices()
 
     assert devices == []
+
+
+@patch("can.interfaces.gs_usb.GsUsb")
+@patch("can.interfaces.gs_usb._find_gs_usb_devices")
+def test_send_dlc_zero_does_not_modify_message_data(mock_find_devices, mock_gs_usb_cls):
+    """Verify that send() does not mutate msg.data when DLC < CAN_MAX_DLC."""
+    mock_find_devices.return_value = [MagicMock()]
+    mock_gs_usb = MagicMock()
+    mock_gs_usb_cls.return_value = mock_gs_usb
+    mock_gs_usb.device_capability.fclk_can = 48_000_000
+
+    bus = GsUsbBus(channel=0, bitrate=500_000)
+    msg = can.Message(arbitration_id=0x123, data=bytearray(), dlc=0)
+    msg_data_copy = msg.data.copy()
+
+    bus.send(msg)
+
+    assert msg.data == msg_data_copy
+    mock_gs_usb.send.assert_called_once()


### PR DESCRIPTION
The current implementation of GsUsbBus send() modifies the msg.data bytearray in place, when padding it up to CAN_MAX_DLC for a GsUsbFrame. This is an issue as the can.Message equals method compares the data fields of messages, so if GsUsbBus send() modifies the data of a can.Message with dlc == 0, the padded data does not match the original message:

The passed can.Message should not be modified, only read. This commit creates a new padded bytearray from the msg.data bytearray, leaving the passed can.Message intact.

<!--
Thank you for contributing to python-can!
Please fill out the following template to help us review your pull request.
-->

## Summary of Changes

<!-- Briefly describe what your pull request does. -->

- Copy msg.data and pad the copy, rather than modifying the msg.data member in place

## Related Issues / Pull Requests

<!-- List any related issues, pull requests, or discussions. -->

- Closes #
- Related to #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [x] I have added or updated tests as appropriate.
- [x] I have added or updated documentation as appropriate.
- [x] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [ ] All checks and tests pass (`tox`).

Note that tox run showed 47 failed tests when run locally, unrelated to changes in this PR (mostly interfaces like pcan and kvaser). The added test passed.

## Additional Notes

Issue was discovered while running this zephyr-rtos test suite https://github.com/zephyrproject-rtos/zephyr/tree/main/tests/drivers/can/host using a [cannectivity ](https://cannectivity.org/index.html) based probe, which implements the gs_usb interface. The following error was observed:
```
2026-08-02 21:46:11,310 - twister - DEBUG - PYTEST: >       self.check_rx(msg, rx)
2026-08-02 21:46:11,310 - twister - DEBUG - PYTEST: E       Failed: rx message "Timestamp:        0.000000    ID:      010    S Rx                DL:  0                                Channel: scan@4200" not equal to tx message "Timestamp:        0.000000    ID:      010    S Rx                DL:  0"
2026-08-02 21:46:11,310 - twister - DEBUG - PYTEST: zephyr/tests/drivers/can/host/pytest/test_can.py:98: Failed
```
which was quite puzling given it "looks" identical because the data field is not printed if DLC == 0. debugging showed the mismatching data members, which failed the can.Message equals check, as this one checks data == data even when DLC == 0

There is no explicit documentation stating that the can.Message should not be modified, it can only be inferred from what I can see, maybe we should document this if it is indeed expected to not mutate the can.Message objects post creation? A small step in that direction could be to make the data a bytes object rather than bytearray, then gs_usb.py could not have called .extend() in the first place.