### PR TITLE
fix: do not assume BLF files only contain log containers

### DIFF
--- a/can/io/blf.py
+++ b/can/io/blf.py
@@ -202,6 +202,8 @@ class BLFReader(BinaryIOMessageReader):
                     LOG.warning("Unknown compression method (%d)", method)
                     continue
                 yield from self._parse_container(data)
+            else:
+                yield from self._parse_data(data + obj_data)
         self.stop()
 
     def _parse_container(self, data: bytes) -> Iterator[Message]:


### PR DESCRIPTION
<!--
Thank you for contributing to python-can!
Please fill out the following template to help us review your pull request.
-->

## Summary of Changes

<!-- Briefly describe what your pull request does. -->

The current BLFReader cannot load BLF files which do not make use of log containers but instead store object files at the top level. Vector tools accept these files, so I think this library should, too. This PR simply adds a second call that then parses the objects directly instead of going through the log container route.

## Related Issues / Pull Requests

<!-- List any related issues, pull requests, or discussions. -->

- Closes #
- Related to #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [ ] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [ ] I have added or updated tests as appropriate.
- [ ] I have added or updated documentation as appropriate.
- [ ] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [x] All checks and tests pass (`tox`).

## Additional Notes

<!-- Add any other information or context you want to share. -->
