### PR TITLE
Add python-can-hub to the plugin interface list

### DIFF
--- a/doc/plugin-interface.rst
+++ b/doc/plugin-interface.rst
@@ -85,6 +85,8 @@ The table below lists interface drivers that can be added by installing addition
 +----------------------------+----------------------------------------------------------+
 | `python-can-damiao`_       | Interface for Damiao USB-CAN adapters                    |
 +----------------------------+----------------------------------------------------------+
+| `python-can-hub`_          | Remote CAN interfaces over can-hub (QUIC/TLS/TCP/unix)   |
++----------------------------+----------------------------------------------------------+
 
 .. _python-can-canine: https://github.com/tinymovr/python-can-canine
 .. _python-can-cvector: https://github.com/zariiii9003/python-can-cvector
@@ -96,4 +98,5 @@ The table below lists interface drivers that can be added by installing addition
 .. _python-can-coe: https://c0d3.sh/smarthome/python-can-coe
 .. _RP1210: https://github.com/dfieschko/RP1210
 .. _python-can-damiao: https://github.com/gaoyichuan/python-can-damiao
+.. _python-can-hub: https://github.com/can-hub-io/can-hub/tree/main/python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ zlgcan = ["zlgcan"]
 candle = ["python-can-candle>=1.2.2"]
 rp1210 = ["rp1210>=1.0.1"]
 damiao = ["python-can-damiao"]
+canhub = ["python-can-hub"]
 viewer = [
     "windows-curses; platform_system == 'Windows' and platform_python_implementation=='CPython'"
 ]


### PR DESCRIPTION
## Summary of Changes

- Add `python-can-hub` to the list of plugin interfaces and as an optional dependency.

`python-can-hub` is a native backend for [can-hub](https://github.com/can-hub-io/can-hub), a hub that lets devices behind NAT export their SocketCAN interfaces over the network. The plugin speaks the binary protocol directly over QUIC, TLS, plain TCP or a unix socket, so no bridge process is needed:

```python
bus = can.Bus(interface="canhub", channel="agent/can0", url="quic://hub.example.com:7227")
```

Published on PyPI as [`python-can-hub`](https://pypi.org/project/python-can-hub/) and registered under the `can.interface` entry point as `canhub`.

One thing worth flagging: the package is AGPL-3.0. Declaring it as an optional dependency does not affect python-can's own licensing, but if you would rather not list an AGPL package under `[project.optional-dependencies]`, I am happy to drop that hunk and keep the documentation entry only.

## Related Issues / Pull Requests

None

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [ ] I have added or updated tests as appropriate.
- [x] I have added or updated documentation as appropriate.
