### PR TITLE
fix(socketcan): support file descriptors above 1023

### DIFF
--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -9,6 +9,7 @@ import ctypes
 import ctypes.util
 import errno
 import logging
+import math
 import select
 import socket
 import struct
@@ -815,9 +816,10 @@ class SocketcanBus(BusABC):  # pylint: disable=abstract-method
 
     def _recv_internal(self, timeout: float | None) -> tuple[Message | None, bool]:
         try:
-            # get all sockets that are ready (can be a list with a single value
-            # being self.socket or an empty list if self.socket is not ready)
-            ready_receive_sockets, _, _ = select.select([self.socket], [], [], timeout)
+            poller = select.poll()
+            poller.register(self.socket, select.POLLIN)
+            timeout_ms = None if timeout is None else math.ceil(timeout * 1000)
+            ready_receive_sockets = poller.poll(timeout_ms)
         except OSError as error:
             # something bad happened (e.g. the interface went down)
             raise can.CanOperationError(
@@ -856,10 +858,12 @@ class SocketcanBus(BusABC):  # pylint: disable=abstract-method
             timeout = 0
         time_left = timeout
         data = build_can_frame(msg)
+        poller = select.poll()
+        poller.register(self.socket, select.POLLOUT)
 
         while time_left >= 0:
             # Wait for write availability
-            ready = select.select([], [self.socket], [], time_left)[1]
+            ready = poller.poll(math.ceil(time_left * 1000))
             if not ready:
                 # Timeout
                 break

--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -47,6 +47,12 @@ RECEIVED_TIMESTAMP_STRUCT = struct.Struct("@ll")
 RECEIVED_ANCILLARY_BUFFER_SIZE = (
     CMSG_SPACE(RECEIVED_TIMESTAMP_STRUCT.size) if CMSG_SPACE_available else 0
 )
+MAX_POLL_TIMEOUT_MS = 2_147_483_647
+
+
+def _poll_timeout_ms(timeout: float) -> int:
+    """Convert seconds to a timeout accepted by ``poll()``."""
+    return min(math.ceil(timeout * 1000), MAX_POLL_TIMEOUT_MS)
 
 
 # Setup BCM struct
@@ -815,11 +821,19 @@ class SocketcanBus(BusABC):  # pylint: disable=abstract-method
         self.socket.close()
 
     def _recv_internal(self, timeout: float | None) -> tuple[Message | None, bool]:
+        if timeout is not None and timeout < 0:
+            raise ValueError("timeout must not be negative")
+
         try:
             poller = select.poll()
             poller.register(self.socket, select.POLLIN)
-            timeout_ms = None if timeout is None else math.ceil(timeout * 1000)
-            ready_receive_sockets = poller.poll(timeout_ms)
+            time_left = timeout
+            while True:
+                timeout_ms = None if time_left is None else _poll_timeout_ms(time_left)
+                ready_receive_sockets = poller.poll(timeout_ms)
+                if ready_receive_sockets or timeout_ms != MAX_POLL_TIMEOUT_MS:
+                    break
+                time_left -= MAX_POLL_TIMEOUT_MS / 1000
         except OSError as error:
             # something bad happened (e.g. the interface went down)
             raise can.CanOperationError(
@@ -852,7 +866,7 @@ class SocketcanBus(BusABC):  # pylint: disable=abstract-method
         logger_tx = log.getChild("tx")
         logger_tx.debug("sending: %s", msg)
 
-        started = time.time()
+        started = time.monotonic()
         # If no timeout is given, poll for availability
         if timeout is None:
             timeout = 0
@@ -863,17 +877,21 @@ class SocketcanBus(BusABC):  # pylint: disable=abstract-method
 
         while time_left >= 0:
             # Wait for write availability
-            ready = poller.poll(math.ceil(time_left * 1000))
+            timeout_ms = _poll_timeout_ms(time_left)
+            ready = poller.poll(timeout_ms)
             if not ready:
-                # Timeout
-                break
+                if timeout_ms != MAX_POLL_TIMEOUT_MS:
+                    # Timeout
+                    break
+                time_left = timeout - (time.monotonic() - started)
+                continue
             channel = str(msg.channel) if msg.channel else None
             sent = self._send_once(data, channel)
             if sent == len(data):
                 return
             # Not all data were sent, try again with remaining data
             data = data[sent:]
-            time_left = timeout - (time.time() - started)
+            time_left = timeout - (time.monotonic() - started)
 
         raise can.CanOperationError("Transmit buffer full")
 

--- a/doc/changelog.d/2053.fixed.rst
+++ b/doc/changelog.d/2053.fixed.rst
@@ -1,0 +1,1 @@
+Fix SocketCAN send and receive operations for socket file descriptors greater than 1023.

--- a/test/test_socketcan.py
+++ b/test/test_socketcan.py
@@ -13,6 +13,13 @@ import unittest
 import warnings
 from unittest.mock import MagicMock, patch
 
+try:
+    import fcntl
+    import resource
+except ImportError:
+    fcntl = None
+    resource = None
+
 import can
 from can.interfaces.socketcan.constants import (
     CAN_BCM_TX_DELETE,
@@ -397,7 +404,12 @@ class SocketCANTest(unittest.TestCase):
 @unittest.skipUnless(IS_LINUX, "socketcan is only available on Linux")
 class SocketCANHighFdTest(unittest.TestCase):
     def setUp(self):
-        import fcntl
+        assert fcntl is not None
+        assert resource is not None
+
+        soft_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+        if soft_limit != resource.RLIM_INFINITY and soft_limit <= 1024:
+            self.skipTest("RLIMIT_NOFILE does not permit file descriptor 1024")
 
         patcher_create = patch("can.interfaces.socketcan.socketcan.create_socket")
         patcher_bind = patch("can.interfaces.socketcan.socketcan.bind_socket")
@@ -447,6 +459,30 @@ class SocketCANHighFdTest(unittest.TestCase):
         self.assertEqual(msg.arbitration_id, 0x123)
         self.assertEqual(msg.data, bytearray(range(8)))
         mock_capture.assert_called_once_with(self.mock_socket, False)
+
+    @patch("can.interfaces.socketcan.socketcan.select.poll")
+    def test_recv_rejects_negative_timeout(self, mock_poll):
+        mock_poll.return_value.poll.return_value = []
+
+        with self.assertRaisesRegex(ValueError, "timeout must not be negative"):
+            self.bus.recv(timeout=-1.0)
+
+        mock_poll.return_value.poll.assert_not_called()
+
+    @patch("can.interfaces.socketcan.socketcan.select.poll")
+    def test_send_caps_large_finite_poll_timeout(self, mock_poll):
+        max_poll_timeout_ms = 2_147_483_647
+        mock_poll.return_value.poll.return_value = []
+        msg = can.Message(arbitration_id=0x123, data=range(8))
+
+        with patch(
+            "can.interfaces.socketcan.socketcan.time.monotonic",
+            side_effect=[0.0, max_poll_timeout_ms / 1000 + 2.0],
+        ):
+            with self.assertRaisesRegex(can.CanOperationError, "Transmit buffer full"):
+                self.bus.send(msg, timeout=max_poll_timeout_ms / 1000 + 1.0)
+
+        mock_poll.return_value.poll.assert_called_once_with(max_poll_timeout_ms)
 
 
 if __name__ == "__main__":

--- a/test/test_socketcan.py
+++ b/test/test_socketcan.py
@@ -5,11 +5,13 @@ Test functions in `can.interfaces.socketcan.socketcan`.
 """
 
 import ctypes
+import os
+import socket
 import struct
 import sys
 import unittest
 import warnings
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import can
 from can.interfaces.socketcan.constants import (
@@ -26,6 +28,7 @@ from can.interfaces.socketcan.socketcan import (
     build_bcm_transmit_header,
     build_bcm_tx_delete_header,
     build_bcm_update_header,
+    build_can_frame,
 )
 
 from .config import IS_LINUX, IS_PYPY, TEST_INTERFACE_SOCKETCAN
@@ -389,6 +392,61 @@ class SocketCANTest(unittest.TestCase):
                     "Please check if PyPy has implemented raw CAN socket support! "
                     "See: https://github.com/pypy/pypy/issues/3808"
                 )
+
+
+@unittest.skipUnless(IS_LINUX, "socketcan is only available on Linux")
+class SocketCANHighFdTest(unittest.TestCase):
+    def setUp(self):
+        import fcntl
+
+        patcher_create = patch("can.interfaces.socketcan.socketcan.create_socket")
+        patcher_bind = patch("can.interfaces.socketcan.socketcan.bind_socket")
+
+        self.mock_create_socket = patcher_create.start()
+        self.addCleanup(patcher_create.stop)
+        self.mock_bind_socket = patcher_bind.start()
+        self.addCleanup(patcher_bind.stop)
+
+        poll_socket, peer_socket = socket.socketpair()
+        self.addCleanup(poll_socket.close)
+        self.addCleanup(peer_socket.close)
+        self.peer_socket = peer_socket
+        self.high_fd = fcntl.fcntl(poll_socket.fileno(), fcntl.F_DUPFD_CLOEXEC, 1024)
+        self.addCleanup(os.close, self.high_fd)
+
+        self.mock_socket = MagicMock()
+        self.mock_socket.fileno.return_value = self.high_fd
+        self.mock_create_socket.return_value = self.mock_socket
+
+        self.bus = can.Bus(interface="socketcan", channel="can0")
+        self.addCleanup(self.bus.shutdown)
+
+    def test_send_high_fd(self):
+        msg = can.Message(arbitration_id=0x123, data=range(8))
+        frame_data = build_can_frame(msg)
+        self.mock_socket.send.return_value = len(frame_data)
+
+        self.bus.send(msg)
+
+        self.mock_socket.send.assert_called_once_with(frame_data)
+
+    @patch("can.interfaces.socketcan.socketcan.capture_message")
+    def test_recv_high_fd(self, mock_capture):
+        expected_msg = can.Message(
+            arbitration_id=0x123,
+            data=range(8),
+            channel="can0",
+            timestamp=1000.0,
+        )
+        mock_capture.return_value = expected_msg
+        self.peer_socket.send(b"x")
+
+        msg = self.bus.recv(timeout=1.0)
+
+        self.assertIsNotNone(msg)
+        self.assertEqual(msg.arbitration_id, 0x123)
+        self.assertEqual(msg.data, bytearray(range(8)))
+        mock_capture.assert_called_once_with(self.mock_socket, False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary of Changes

- Replace SocketCAN's `select.select()` readiness checks with `select.poll()` so valid socket file descriptors above `FD_SETSIZE` are supported.
- Preserve receive and send timeout behavior by converting seconds to millisecond poll timeouts with ceiling.
- Add Linux regression tests that duplicate a live socket descriptor to 1024 and exercise both receive and transmit paths.
- Add the required towncrier news fragment.

## Related Issues / Pull Requests

- Closes #2053

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [x] I have added or updated tests as appropriate.
- [x] I have added or updated documentation as appropriate.
- [x] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [ ] All checks and tests pass (`tox`).

## Additional Notes

Before this change, the send and receive regression tests both fail at descriptor 1024 with `ValueError: filedescriptor out of range in select()`.

After this change:

- `pytest -q test/test_socketcan.py --no-cov`: 10 passed, 3 skipped
- Full supported suite: 505 passed, 94 skipped, 32 deselected
- The deselected tests are the two UDP multicast classes, which cannot join a multicast group in the test sandbox.
- Black passes for the changed source and test files; Ruff and Pylint pass for the SocketCAN implementation.
