### PR TITLE
Fix SYSTEC error lookup for ctypes result codes

### DIFF
--- a/can/interfaces/systec/exceptions.py
+++ b/can/interfaces/systec/exceptions.py
@@ -13,7 +13,7 @@ class UcanException(CanError, ABC):
         self.func = func
         self.arguments = arguments
 
-        message = self._error_message_mapping.get(result, "unknown")
+        message = self._error_message_mapping.get(result.value, "unknown")
         super().__init__(
             message=f"Function {func.__name__} (called with {arguments}): {message}",
             error_code=result.value,

--- a/test/test_systec_exceptions.py
+++ b/test/test_systec_exceptions.py
@@ -1,0 +1,16 @@
+from ctypes import c_ubyte
+
+from can.interfaces.systec.constants import ReturnCode
+from can.interfaces.systec.exceptions import UcanError
+
+
+def test_ucan_error_accepts_ctypes_result_code() -> None:
+    def ucan_write_can_msg_ex() -> None:
+        pass
+
+    result = c_ubyte(ReturnCode.ERR_ILLPARAM)
+
+    error = UcanError(result, ucan_write_can_msg_ex, ("arg",))
+
+    assert error.error_code == ReturnCode.ERR_ILLPARAM
+    assert "wrong parameter handed over to the function" in str(error)


### PR DESCRIPTION
## Summary

Normalize SYSTEC `ctypes` return codes through `.value` before looking them up in the error-message mapping.

`UcanException` currently uses the `ctypes.c_ubyte` result object itself as a dictionary key. `ctypes` scalar values are unhashable, so error handling can raise `TypeError: unhashable type` and hide the original CAN error.

This change:
- looks up the message using `result.value`
- preserves the existing numeric `error_code`
- adds a regression test proving a `c_ubyte` SYSTEC return code produces the underlying diagnostic instead of a `TypeError`

Fixes #2077.