### PR TITLE
Fix Notifier async callback error handling

### DIFF
--- a/can/notifier.py
+++ b/can/notifier.py
@@ -74,7 +74,7 @@ class _NotifierRegistry:
         with self.lock:
             registered_pairs_to_remove: list[_BusNotifierPair] = []
             for pair in self.pairs:
-                if pair.bus is bus and pair.notifier is notifier:
+                if bus is pair.bus and pair.notifier is notifier:
                     registered_pairs_to_remove.append(pair)
             for pair in registered_pairs_to_remove:
                 self.pairs.remove(pair)
@@ -223,7 +223,7 @@ class Notifier(AbstractContextManager["Notifier"]):
         if self._loop:
             handle_message: Callable[[Message], Any] = functools.partial(
                 self._loop.call_soon_threadsafe,
-                self._on_message_received,  # type: ignore[arg-type]
+                self._on_message_received_with_error_handling,  # type: ignore[arg-type]
             )
         else:
             handle_message = self._on_message_received
@@ -248,7 +248,16 @@ class Notifier(AbstractContextManager["Notifier"]):
 
     def _on_message_available(self, bus: BusABC) -> None:
         if msg := bus.recv(0):
+            self._on_message_received_with_error_handling(msg)
+
+    def _on_message_received_with_error_handling(self, msg: Message) -> None:
+        try:
             self._on_message_received(msg)
+        except Exception as exc:  # pylint: disable=broad-except
+            self.exception = exc
+            if not self._on_error(exc):
+                raise
+            logger.debug("suppressed exception: %s", exc)
 
     def _on_message_received(self, msg: Message) -> None:
         for callback in self.listeners:
@@ -257,7 +266,24 @@ class Notifier(AbstractContextManager["Notifier"]):
                 # Schedule coroutine and keep a reference to the task
                 task = self._loop.create_task(res)
                 self._tasks.add(task)
-                task.add_done_callback(self._tasks.discard)
+                task.add_done_callback(self._on_task_done)
+
+    def _on_task_done(self, task: asyncio.Task) -> None:
+        self._tasks.discard(task)
+        if task.cancelled():
+            return
+
+        exc = task.exception()
+        if exc is None:
+            return
+
+        self.exception = exc
+        if isinstance(exc, Exception):
+            if not self._on_error(exc):
+                raise exc
+            logger.debug("suppressed exception: %s", exc)
+        else:
+            raise exc
 
     def _on_error(self, exc: Exception) -> bool:
         """Calls ``on_error()`` for all listeners if they implement it.
@@ -278,7 +304,7 @@ class Notifier(AbstractContextManager["Notifier"]):
         return was_handled
 
     def add_listener(self, listener: MessageRecipient) -> None:
-        """Add new Listener to the notification set.
+        """Add new Listener for notification.
 
         :param listener: Listener to be added to the list to be notified
         """
@@ -289,8 +315,8 @@ class Notifier(AbstractContextManager["Notifier"]):
         throws an exception if the given listener is not part of the
         stored listeners.
 
-        :param listener: Listener to be removed from the set to be notified
-        :raises ValueError: if `listener` was never added to this notifier
+        :param listener: Listener to be removed from the set
+        :raises ValueError: if `listener` was never added to the notifier
         """
         self.listeners.remove(listener)
 
@@ -301,7 +327,7 @@ class Notifier(AbstractContextManager["Notifier"]):
 
     @staticmethod
     def find_instances(bus: BusABC) -> tuple["Notifier", ...]:
-        """Find :class:`~can.Notifier` instances associated with a given CAN bus.
+        """Find :class:`~can.Notifier` instances associated with a given bus.
 
         This method searches the registry for the :class:`~can.Notifier`
         that is linked to the specified bus. If the bus is found, the

--- a/can/notifier.py
+++ b/can/notifier.py
@@ -74,7 +74,7 @@ class _NotifierRegistry:
         with self.lock:
             registered_pairs_to_remove: list[_BusNotifierPair] = []
             for pair in self.pairs:
-                if bus is pair.bus and pair.notifier is notifier:
+                if pair.bus is bus and pair.notifier is notifier:
                     registered_pairs_to_remove.append(pair)
             for pair in registered_pairs_to_remove:
                 self.pairs.remove(pair)
@@ -165,21 +165,16 @@ class Notifier(AbstractContextManager["Notifier"]):
         :raises ValueError:
             If the *bus* is already assigned to an active :class:`~can.Notifier`.
         """
-        # add bus to notifier registry
         Notifier._registry.register(bus, self)
-
-        # add bus to internal bus list
         self._bus_list.append(bus)
 
         file_descriptor: int = -1
         try:
             file_descriptor = bus.fileno()
         except NotImplementedError:
-            # Bus doesn't support fileno, we fall back to thread based reader
             pass
 
         if self._loop is not None and file_descriptor >= 0:
-            # Use bus file descriptor to watch for messages
             self._loop.add_reader(file_descriptor, self._on_message_available, bus)
             self._readers.append(file_descriptor)
         else:
@@ -208,18 +203,15 @@ class Notifier(AbstractContextManager["Notifier"]):
                 if now < end_time:
                     reader.join(end_time - now)
             elif self._loop:
-                # reader is a file descriptor
                 self._loop.remove_reader(reader)
         for listener in self.listeners:
             if hasattr(listener, "stop"):
                 listener.stop()
 
-        # remove bus from registry
         for bus in self._bus_list:
             Notifier._registry.unregister(bus, self)
 
     def _rx_thread(self, bus: BusABC) -> None:
-        # determine message handling callable early, not inside while loop
         if self._loop:
             handle_message: Callable[[Message], Any] = functools.partial(
                 self._loop.call_soon_threadsafe,
@@ -237,13 +229,10 @@ class Notifier(AbstractContextManager["Notifier"]):
                 self.exception = exc
                 if self._loop is not None:
                     self._loop.call_soon_threadsafe(self._on_error, exc)
-                    # Raise anyway
                     raise
                 elif not self._on_error(exc):
-                    # If it was not handled, raise the exception here
                     raise
                 else:
-                    # It was handled, so only log it
                     logger.debug("suppressed exception: %s", exc)
 
     def _on_message_available(self, bus: BusABC) -> None:
@@ -263,7 +252,6 @@ class Notifier(AbstractContextManager["Notifier"]):
         for callback in self.listeners:
             res = callback(msg)
             if res and self._loop and asyncio.iscoroutine(res):
-                # Schedule coroutine and keep a reference to the task
                 task = self._loop.create_task(res)
                 self._tasks.add(task)
                 task.add_done_callback(self._on_task_done)
@@ -272,11 +260,9 @@ class Notifier(AbstractContextManager["Notifier"]):
         self._tasks.discard(task)
         if task.cancelled():
             return
-
         exc = task.exception()
         if exc is None:
             return
-
         self.exception = exc
         if isinstance(exc, Exception):
             if not self._on_error(exc):
@@ -304,7 +290,7 @@ class Notifier(AbstractContextManager["Notifier"]):
         return was_handled
 
     def add_listener(self, listener: MessageRecipient) -> None:
-        """Add new Listener for notification.
+        """Add new Listener to the notification set.
 
         :param listener: Listener to be added to the list to be notified
         """
@@ -315,8 +301,8 @@ class Notifier(AbstractContextManager["Notifier"]):
         throws an exception if the given listener is not part of the
         stored listeners.
 
-        :param listener: Listener to be removed from the set
-        :raises ValueError: if `listener` was never added to the notifier
+        :param listener: Listener to be removed from the set to be notified
+        :raises ValueError: if `listener` was never added to this notifier
         """
         self.listeners.remove(listener)
 
@@ -327,7 +313,7 @@ class Notifier(AbstractContextManager["Notifier"]):
 
     @staticmethod
     def find_instances(bus: BusABC) -> tuple["Notifier", ...]:
-        """Find :class:`~can.Notifier` instances associated with a given bus.
+        """Find :class:`~can.Notifier` instances associated with a given CAN bus.
 
         This method searches the registry for the :class:`~can.Notifier`
         that is linked to the specified bus. If the bus is found, the

--- a/can/notifier.py
+++ b/can/notifier.py
@@ -165,16 +165,21 @@ class Notifier(AbstractContextManager["Notifier"]):
         :raises ValueError:
             If the *bus* is already assigned to an active :class:`~can.Notifier`.
         """
+        # add bus to notifier registry
         Notifier._registry.register(bus, self)
+
+        # add bus to internal bus list
         self._bus_list.append(bus)
 
         file_descriptor: int = -1
         try:
             file_descriptor = bus.fileno()
         except NotImplementedError:
+            # Bus doesn't support fileno, we fall back to thread based reader
             pass
 
         if self._loop is not None and file_descriptor >= 0:
+            # Use bus file descriptor to watch for messages
             self._loop.add_reader(file_descriptor, self._on_message_available, bus)
             self._readers.append(file_descriptor)
         else:
@@ -203,15 +208,18 @@ class Notifier(AbstractContextManager["Notifier"]):
                 if now < end_time:
                     reader.join(end_time - now)
             elif self._loop:
+                # reader is a file descriptor
                 self._loop.remove_reader(reader)
         for listener in self.listeners:
             if hasattr(listener, "stop"):
                 listener.stop()
 
+        # remove bus from registry
         for bus in self._bus_list:
             Notifier._registry.unregister(bus, self)
 
     def _rx_thread(self, bus: BusABC) -> None:
+        # determine message handling callable early, not inside while loop
         if self._loop:
             handle_message: Callable[[Message], Any] = functools.partial(
                 self._loop.call_soon_threadsafe,
@@ -229,10 +237,13 @@ class Notifier(AbstractContextManager["Notifier"]):
                 self.exception = exc
                 if self._loop is not None:
                     self._loop.call_soon_threadsafe(self._on_error, exc)
+                    # Raise anyway
                     raise
                 elif not self._on_error(exc):
+                    # If it was not handled, raise the exception here
                     raise
                 else:
+                    # It was handled, so only log it
                     logger.debug("suppressed exception: %s", exc)
 
     def _on_message_available(self, bus: BusABC) -> None:
@@ -252,6 +263,7 @@ class Notifier(AbstractContextManager["Notifier"]):
         for callback in self.listeners:
             res = callback(msg)
             if res and self._loop and asyncio.iscoroutine(res):
+                # Schedule coroutine and keep a reference to the task
                 task = self._loop.create_task(res)
                 self._tasks.add(task)
                 task.add_done_callback(self._on_task_done)
@@ -260,9 +272,11 @@ class Notifier(AbstractContextManager["Notifier"]):
         self._tasks.discard(task)
         if task.cancelled():
             return
+
         exc = task.exception()
         if exc is None:
             return
+
         self.exception = exc
         if isinstance(exc, Exception):
             if not self._on_error(exc):

--- a/can/notifier.py
+++ b/can/notifier.py
@@ -276,14 +276,13 @@ class Notifier(AbstractContextManager["Notifier"]):
         exc = task.exception()
         if exc is None:
             return
+        if not isinstance(exc, Exception):
+            raise exc
 
         self.exception = exc
-        if isinstance(exc, Exception):
-            if not self._on_error(exc):
-                raise exc
-            logger.debug("suppressed exception: %s", exc)
-        else:
+        if not self._on_error(exc):
             raise exc
+        logger.debug("suppressed exception: %s", exc)
 
     def _on_error(self, exc: Exception) -> bool:
         """Calls ``on_error()`` for all listeners if they implement it.

--- a/test/notifier_test.py
+++ b/test/notifier_test.py
@@ -7,6 +7,24 @@ import unittest
 import can
 
 
+class RaisingListener(can.Listener):
+    def on_message_received(self, msg: can.Message) -> None:
+        raise ValueError("listener failed")
+
+
+class ErrorCollector(can.Listener):
+    def __init__(self, event: asyncio.Event) -> None:
+        self.event = event
+        self.errors: list[Exception] = []
+
+    def on_message_received(self, msg: can.Message) -> None:
+        pass
+
+    def on_error(self, exc: Exception) -> None:
+        self.errors.append(exc)
+        self.event.set()
+
+
 class NotifierTest(unittest.TestCase):
     def test_single_bus(self):
         with can.Bus("test", interface="virtual", receive_own_messages=True) as bus:
@@ -85,6 +103,58 @@ class AsyncNotifierTest(unittest.TestCase):
                 recv_msg = await asyncio.wait_for(reader.get_message(), 0.5)
                 self.assertIsNotNone(recv_msg)
                 notifier.stop()
+
+        asyncio.run(run_it())
+
+    def test_sync_listener_error_calls_on_error_with_loop(self):
+        async def run_it():
+            event = asyncio.Event()
+            collector = ErrorCollector(event)
+            with can.Bus(
+                "sync-listener-error", interface="virtual", receive_own_messages=True
+            ) as bus:
+                notifier = can.Notifier(
+                    bus,
+                    [RaisingListener(), collector],
+                    0.1,
+                    loop=asyncio.get_running_loop(),
+                )
+                try:
+                    bus.send(can.Message())
+                    await asyncio.wait_for(event.wait(), 0.5)
+                    self.assertEqual(len(collector.errors), 1)
+                    self.assertIsInstance(collector.errors[0], ValueError)
+                    self.assertIs(notifier.exception, collector.errors[0])
+                finally:
+                    notifier.stop()
+
+        asyncio.run(run_it())
+
+    def test_async_listener_error_calls_on_error(self):
+        async def run_it():
+            event = asyncio.Event()
+            collector = ErrorCollector(event)
+
+            async def raising_callback(msg: can.Message) -> None:
+                raise RuntimeError("async listener failed")
+
+            with can.Bus(
+                "async-listener-error", interface="virtual", receive_own_messages=True
+            ) as bus:
+                notifier = can.Notifier(
+                    bus,
+                    [raising_callback, collector],
+                    0.1,
+                    loop=asyncio.get_running_loop(),
+                )
+                try:
+                    bus.send(can.Message())
+                    await asyncio.wait_for(event.wait(), 0.5)
+                    self.assertEqual(len(collector.errors), 1)
+                    self.assertIsInstance(collector.errors[0], RuntimeError)
+                    self.assertIs(notifier.exception, collector.errors[0])
+                finally:
+                    notifier.stop()
 
         asyncio.run(run_it())
 


### PR DESCRIPTION
## Summary

Route listener exceptions through `Notifier._on_error()` when a Notifier is using an asyncio event loop.

With a loop configured, thread-backed receivers currently schedule `_on_message_received()` using `call_soon_threadsafe()`. Exceptions raised by synchronous listeners therefore occur later on the event-loop thread and bypass `_rx_thread()`'s exception handler. Coroutine listeners have the same problem because their tasks are only discarded on completion, so task exceptions are never passed to `_on_error()`.

This change:
- wraps event-loop message dispatch so synchronous listener exceptions populate `Notifier.exception` and call `_on_error()`
- applies the same guarded dispatch to file-descriptor based loop readers
- inspects completed coroutine tasks, routes their exceptions through `_on_error()`, and keeps cancelled tasks quiet
- adds regression tests for both synchronous and asynchronous listener failures while an asyncio loop is configured

The existing no-loop receive-thread behavior is unchanged.

Fixes #1912.