### PR TITLE
Speed up socketcan capture_message by ~32%

### DIFF
--- a/can/interfaces/socketcan/socketcan.py
+++ b/can/interfaces/socketcan/socketcan.py
@@ -47,6 +47,8 @@ RECEIVED_ANCILLARY_BUFFER_SIZE = (
     CMSG_SPACE(RECEIVED_TIMESTAMP_STRUCT.size) if CMSG_SPACE_available else 0
 )
 
+MSG_DONTROUTE = int(socket.MSG_DONTROUTE)
+
 
 # Setup BCM struct
 def bcm_header_factory(
@@ -656,7 +658,7 @@ def capture_message(sock: socket.socket, get_channel: bool = False) -> Message |
     error_state_indicator = bool(flags & constants.CANFD_ESI)
 
     # Section 4.7.1: MSG_DONTROUTE: set when the received frame was created on the local host.
-    is_rx = not bool(msg_flags & socket.MSG_DONTROUTE)
+    is_rx = not msg_flags & MSG_DONTROUTE
 
     if is_extended_frame_format:
         # log.debug("CAN: Extended")
@@ -666,22 +668,21 @@ def capture_message(sock: socket.socket, get_channel: bool = False) -> Message |
         # log.debug("CAN: Standard")
         arbitration_id = can_id & 0x000007FF
 
-    msg = Message(
-        timestamp=timestamp,
-        channel=channel,
-        arbitration_id=arbitration_id,
-        is_extended_id=is_extended_frame_format,
-        is_remote_frame=is_remote_transmission_request,
-        is_error_frame=is_error_frame,
-        is_fd=is_fd,
-        is_rx=is_rx,
-        bitrate_switch=bitrate_switch,
-        error_state_indicator=error_state_indicator,
-        dlc=can_dlc,
-        data=data,
+    # Built positionally: binding twelve keyword arguments is slower.
+    return Message(
+        timestamp,
+        arbitration_id,
+        is_extended_frame_format,
+        is_remote_transmission_request,
+        is_error_frame,
+        channel,
+        can_dlc,
+        data,
+        is_fd,
+        is_rx,
+        bitrate_switch,
+        error_state_indicator,
     )
-
-    return msg
 
 
 class SocketcanBus(BusABC):  # pylint: disable=abstract-method

--- a/doc/changelog.d/2097.changed.rst
+++ b/doc/changelog.d/2097.changed.rst
@@ -1,0 +1,1 @@
+Improved performance of the ``socketcan`` receive path: ``capture_message`` now uses roughly a third less CPU per frame.

--- a/test/test_socketcan.py
+++ b/test/test_socketcan.py
@@ -5,6 +5,8 @@ Test functions in `can.interfaces.socketcan.socketcan`.
 """
 
 import ctypes
+import inspect
+import socket
 import struct
 import sys
 import unittest
@@ -20,6 +22,7 @@ from can.interfaces.socketcan.constants import (
     TX_COUNTEVT,
 )
 from can.interfaces.socketcan.socketcan import (
+    MSG_DONTROUTE,
     BcmMsgHead,
     bcm_header_factory,
     build_bcm_header,
@@ -389,6 +392,44 @@ class SocketCANTest(unittest.TestCase):
                     "Please check if PyPy has implemented raw CAN socket support! "
                     "See: https://github.com/pypy/pypy/issues/3808"
                 )
+
+
+class SocketCANHotPathTest(unittest.TestCase):
+    """Guard the per-frame optimisations in :func:`capture_message`."""
+
+    def test_msg_dontroute_is_plain_int(self):
+        """``socket.MSG_DONTROUTE`` is an ``enum.IntFlag`` member on CPython, and
+        evaluating ``msg_flags & <IntFlag>`` once per received frame constructs a new
+        flag instance each time. ``capture_message`` therefore tests against a plain
+        int, which must still carry the same value.
+        """
+        self.assertEqual(MSG_DONTROUTE, socket.MSG_DONTROUTE)
+        self.assertIs(type(MSG_DONTROUTE), int)
+
+    def test_capture_message_message_args(self):
+        """``capture_message`` builds its :class:`~can.Message` positionally to avoid
+        per-frame keyword binding, so a reordering of ``Message.__init__`` would
+        silently corrupt every received frame. Pin the expected order.
+        """
+        params = list(inspect.signature(can.Message.__init__).parameters)
+        self.assertEqual(
+            params[:13],
+            [
+                "self",
+                "timestamp",
+                "arbitration_id",
+                "is_extended_id",
+                "is_remote_frame",
+                "is_error_frame",
+                "channel",
+                "dlc",
+                "data",
+                "is_fd",
+                "is_rx",
+                "bitrate_switch",
+                "error_state_indicator",
+            ],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thank you for contributing to python-can!
Please fill out the following template to help us review your pull request.
-->

## Summary of Changes

`capture_message` runs once per received frame, and two lines in it cost more than
the rest of the decode combined. This removes both. No API or behaviour change.

- **Hoist `socket.MSG_DONTROUTE` to a module-level plain `int`.** It is an
  `enum.IntFlag` member, so `msg_flags & socket.MSG_DONTROUTE` constructed a
  `MsgFlag` instance on every frame.
- **Build `Message` positionally** instead of with twelve keyword arguments;
  binding them per frame is measurable.
- **Add `SocketCANHotPathTest`** to `test/test_socketcan.py`, pinning the
  `Message.__init__` argument order so a future reordering cannot silently corrupt
  received frames, and asserting the hoisted constant still carries the same value.

Net effect on a live 500 kbit/s bus: **107.8 -> 73.3 us of CPU per frame**, a ~32%
reduction. Full A/B and correctness evidence under Additional Notes.

## Related Issues / Pull Requests

Related to #1135

At the ~10k f/s of a busy 1 Mbit bus, stock `capture_message` needs 1057 ms of CPU
per second of bus time — more than a whole core just to decode, before any user code
runs. That is a concrete mechanism behind the "python can't keep up" reports in
#1135. This brings it to 733 ms/s. It does not close that issue, but it is a real
part of it.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] Other (please describe): **Performance optimisation** of the socketcan receive
      hot path. Behaviour-preserving; verified field-for-field against the previous
      implementation (see below).

## Checklist

- [x] I have followed the [contribution guide](https://python-can.readthedocs.io/en/main/development.html).
- [x] I have added or updated tests as appropriate.
- [x] I have added or updated documentation as appropriate.
- [x] I have added a [news fragment](doc/changelog.d/) for towncrier.
- [x] All checks and tests pass (`tox`).

## Additional Notes

<!-- Add any other information or context you want to share. -->
### Measurements

Live 500 kbit/s bus at 1444 frames/s, aarch64 (Cortex-A53) / CPython 3.13.15 /
python-can 4.6.1. CPU time via `time.process_time` so blocking `recvmsg` waits are
excluded. 2500 frames x 3 rounds, median. Each row changes exactly one thing against
a verbatim copy of the current implementation:

| variant | us/frame | saves |
|---|---|---|
| stock `capture_message` | 105.7 | — |
| `MSG_DONTROUTE` hoisted to int | 79.4 | **26.3 (25%)** |
| positional `Message()` | 95.5 | **10.2 (10%)** |
| both | 70.6 | **35.1 (33%)** |

End to end with this branch applied, same bus: **107.8 -> 73.3 us/frame**.

For scale, the bare `recvmsg` syscall is 31 us/frame, so this removes ~45% of the
Python-side work above the syscall. At 1444 f/s `capture_message` drops from 15.3%
to 10.4% of one core.

A tight-loop microbenchmark of the `&` alone reports only 12.8 us
(`13.2 us` IntFlag vs `0.5 us` int), i.e. it *understates* the in-situ saving of
26.3 us. A cache-thrash variant widens the microbenchmark gap (13.2 -> 15.8 us),
so the enum machinery's cold per-frame working set appears to be part of it. I could
not fully account for the remainder; the in-situ A/B is the number I would trust.

### Correctness

Compared against the current implementation on identical inputs, all twelve `Message`
fields plus their types:

- 3000 frames captured from a live bus, replayed through both, with
  `get_channel` both `False` and `True` — 0 mismatches.
- 1995 synthetic frames covering `MSG_DONTROUTE` set (798 cases, i.e. `is_rx=False`)
  and clear, standard and extended IDs, remote and error frames, classic and FD MTU,
  BRS/ESI, every valid DLC and the `len8_dlc` 9..15 range — 0 mismatches.

The live bus only produces standard non-FD `is_rx=True` frames, so the synthetic set
is what actually exercises the changed line.

### Things I measured and deliberately did not include

- **`CAN_FD_DLC` as a `frozenset`** for the `data_len not in can.util.CAN_FD_DLC`
  test in `dissect_can_frame`. Looks like a 0.68 us win in isolation (1.03 -> 0.35 us)
  but measured **-0.41 us, i.e. nothing**, in situ: classic-CAN `data_len` is 0..8 and
  hits within the first nine list entries.
- **Dropping the two per-frame `assert`s** on the ancillary data: worth only 1.0 us,
  not enough to justify the behaviour discussion.
- **`recvmsg_into` with a preallocated buffer**: 2.9 us/frame *slower*.
- **memoryview-based payload slice** to avoid the `bytes` -> `bytearray` copy:
  4.6 us/frame *slower*.