### PR TITLE
fix: resolve TypeError when handling Systec CAN error codes

### DIFF
--- a/can/interfaces/systec/exceptions.py
+++ b/can/interfaces/systec/exceptions.py
@@ -13,7 +13,7 @@ class UcanException(CanError, ABC):
         self.func = func
         self.arguments = arguments
 
-        message = self._error_message_mapping.get(result, "unknown")
+        message = self._error_message_mapping.get(result.value, "unknown")
         super().__init__(
             message=f"Function {func.__name__} (called with {arguments}): {message}",
             error_code=result.value,


### PR DESCRIPTION
## Summary of Changes
- `UcanException.__init__` looked up the error message using `self._error_message_mapping.get(result, "unknown")`, but `result` is a `ReturnCode` type which is unhashable. This line raised `TypeError: unhashable type` instead of raising the intended error, masking the real hardware issue.

- Fixed by using `result.value` (a plain int) for the lookup.

## Related Issues / Pull Requests
- Closes #2077

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist
- [x] I have followed the contribution guide.
- [x] I have added or updated tests as appropriate.
- [x] I have added or updated documentation as appropriate.
- [x] I have added a news fragment for towncrier.
- [x] All checks and tests pass (`tox`).